### PR TITLE
Update for LLVM 5.0.0

### DIFF
--- a/include/Util/DataFlowUtil.h
+++ b/include/Util/DataFlowUtil.h
@@ -207,7 +207,7 @@ private:
 /*!
  * Iterated dominance frontier
  */
-class IteratedDominanceFrontier: public llvm::DominanceFrontierBase<llvm::BasicBlock> {
+class IteratedDominanceFrontier: public llvm::DominanceFrontierBase<llvm::BasicBlock, false> {
 
 private:
     const llvm::DominanceFrontier *DF;
@@ -218,7 +218,7 @@ public:
     static char ID;
 
     IteratedDominanceFrontier() :
-        llvm::DominanceFrontierBase<llvm::BasicBlock>(false), DF(NULL) {
+        llvm::DominanceFrontierBase<llvm::BasicBlock, false>(), DF(NULL) {
     }
 
     virtual ~IteratedDominanceFrontier() {

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -236,13 +236,13 @@ void MemSSA::insertPHI(const Function& fun) {
         while (!bbs.empty()) {
             const BasicBlock* bb = bbs.back();
             bbs.pop_back();
-            DominanceFrontierBase<BasicBlock>::const_iterator it = df->find(const_cast<BasicBlock*>(bb));
+            DominanceFrontierBase<BasicBlock, false>::const_iterator it = df->find(const_cast<BasicBlock*>(bb));
             if(it == df->end()) {
                 wrnMsg("bb not in the dominance frontier map??");
                 continue;
             }
-            const DominanceFrontierBase<BasicBlock>::DomSetType& domSet = it->second;
-            for (DominanceFrontierBase<BasicBlock>::DomSetType::const_iterator bit =
+            const DominanceFrontierBase<BasicBlock, false>::DomSetType& domSet = it->second;
+            for (DominanceFrontierBase<BasicBlock, false>::DomSetType::const_iterator bit =
                         domSet.begin(); bit != domSet.end(); ++bit) {
                 const BasicBlock* pbb = *bit;
                 // if we never insert this phi node before

--- a/lib/MemoryModel/PAGBuilder.cpp
+++ b/lib/MemoryModel/PAGBuilder.cpp
@@ -962,7 +962,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const Function *callee) {
                 /// apr_thread_create has 2 arg.
                 assert((forkedFun->arg_size() <= 2) && "Size of formal parameter of start routine should be one");
                 if(forkedFun->arg_size() <= 2 && forkedFun->arg_size() >= 1) {
-                    const Argument* formalParm = &(forkedFun->getArgumentList().front());
+                    const Argument* formalParm = &(*forkedFun->arg_begin());
                     /// Connect actual parameter to formal parameter of the start routine
                     if(isa<PointerType>(actualParm->getType()) && isa<PointerType>(formalParm->getType()) )
                         pag->addThreadForkEdge(pag->getValueNode(actualParm), pag->getValueNode(formalParm),inst);
@@ -985,7 +985,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const Function *callee) {
                 /// The task function of hare_parallel_for has 3 args.
                 assert((taskFunc->arg_size() == 3) && "Size of formal parameter of hare_parallel_for's task routine should be 3");
                 const Value* actualParm = getTaskDataAtHareParForSite(inst);
-                const Argument* formalParm = &(taskFunc->getArgumentList().front());
+                const Argument* formalParm = &(*taskFunc->arg_begin());
                 /// Connect actual parameter to formal parameter of the start routine
                 if(isa<PointerType>(actualParm->getType()) && isa<PointerType>(formalParm->getType()) )
                     pag->addThreadForkEdge(pag->getValueNode(actualParm), pag->getValueNode(formalParm),inst);

--- a/lib/Util/DataFlowUtil.cpp
+++ b/lib/Util/DataFlowUtil.cpp
@@ -40,7 +40,7 @@ void IteratedDominanceFrontier::calculate(llvm::BasicBlock * bb,
 
     DomSetType worklist;
 
-    DominanceFrontierBase<llvm::BasicBlock>::const_iterator it = DF.find(bb);
+    DominanceFrontierBase<llvm::BasicBlock, false>::const_iterator it = DF.find(bb);
     assert(it != DF.end());
 
     worklist.insert(it->second.begin(), it->second.end());


### PR DESCRIPTION
Many thanks for this excellent codebase! I'm new to SVF but I have updated it for LLVM 5.0.0 for a project of mine – only a couple of changes, namely:

- The `IsPostDominators` member of `llvm::DominanceFrontierBase` has become a template parameter (https://reviews.llvm.org/D35315).
- The method `llvm::Function::getArgumentList` has been dropped in favour of `llvm::Function::arg_begin`, `llvm::Function::arg_end` and `llvm::Function::args` (https://reviews.llvm.org/rL298010).

Note that the `swap.c` example on the Wiki has changed behaviour since LLVM 4: the `-mem2reg` option to `opt` doesn't do anything as written because clang now adds the attribute `optnone` to functions when compiling under `-O0` (https://reviews.llvm.org/D28404).

To replicate the old behaviour, we can pass the flag `-disable-O0-optnone` to `cc1`, e.g.:
```
clang -Xclang -disable-O0-optnone -c -emit-llvm swap.c -o swap.bc
```

The tests pass with the caveat that the `-Xclang -disable-O0-optnone` flags need to be passed to clang (I haven't included this change in the PR).

LLVM 5 features its own `MemorySSA` analysis (https://llvm.org/docs/MemorySSA.html) – I don't know if has some utility for SVF.

Let me know if any issues!