### PR TITLE
Update for LLVM 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,32 +4,32 @@ os: linux
 addons:
   apt:
     sources:
-      - llvm-toolchain-trusty-4.0
+      - llvm-toolchain-trusty-6.0
     packages:
-      - llvm-4.0
-      - llvm-4.0-dev
-      - clang-4.0
+      - llvm-6.0
+      - llvm-6.0-dev
+      - clang-6.0
 matrix:
   include:
     - os: osx
       env:
-        - CXX=clang++ PATH=/usr/local/opt/llvm@4/bin:$PATH LLVM_DIR=/usr/local/opt/llvm@4 LDFLAGS:=-L/usr/local/opt/llvm@4/lib CPPFLAGS=-I/usr/local/opt/llvm@4/include
+        - CXX=clang++ PATH=/usr/local/opt/llvm@6/bin:$PATH LLVM_DIR=/usr/local/opt/llvm@6 LDFLAGS:=-L/usr/local/opt/llvm@6/lib CPPFLAGS=-I/usr/local/opt/llvm@6/include
         - CONFIG_ARGS="-DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
-      install: brew install llvm@4
+      install: brew install llvm@6
       cache:
         directories: ~/Library/Caches/Homebrew/
     - os: osx
       env:
-        - CXX=clang++ PATH=/usr/local/opt/llvm@4/bin:$PATH LLVM_DIR=/usr/local/opt/llvm@4 LDFLAGS:=-L/usr/local/opt/llvm@4/lib CPPFLAGS=-I/usr/local/opt/llvm@4/include
+        - CXX=clang++ PATH=/usr/local/opt/llvm@6/bin:$PATH LLVM_DIR=/usr/local/opt/llvm@6 LDFLAGS:=-L/usr/local/opt/llvm@6/lib CPPFLAGS=-I/usr/local/opt/llvm@6/include
         - CONFIG_ARGS="-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
-      install: brew install llvm@4  
+      install: brew install llvm@6  
       cache:
         directories: ~/Library/Caches/Homebrew/
 env:
   global:
-    - CC=clang-4.0 CXX=clang++-4.0
+    - CC=clang-6.0 CXX=clang++-6.0
     - PATH=$TRAVIS_BUILD_DIR/cmake-3.8.1-Linux-x86_64/bin:$PATH
-    - LLVM_DIR=/usr/lib/llvm-4.0
+    - LLVM_DIR=/usr/lib/llvm-6.0
   matrix:
     - CONFIG_ARGS="-DCMAKE_BUILD_TYPE:STRING=Debug"
     - CONFIG_ARGS=

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@
 #########
 # Please change the following home directories of your LLVM builds
 ########
-LLVMRELEASE=/home/ysui/llvm-4.0.0/llvm-4.0.0.obj
-LLVMDEBUG=/home/ysui/llvm-4.0.0/llvm-4.0.0.dbg
+LLVMRELEASE=/home/ysui/llvm-6.0.0/llvm-6.0.0.obj
+LLVMDEBUG=/home/ysui/llvm-6.0.0/llvm-6.0.0.dbg
 
 if [[ $1 == 'debug' ]]
 then

--- a/include/MemoryModel/PointsToDFDS.h
+++ b/include/MemoryModel/PointsToDFDS.h
@@ -200,7 +200,7 @@ public:
         PTData<Key,Data>::dumpPts(this->ptsMap);
         /// dump points-to of address-taken variables
         std::error_code ErrInfo;
-        llvm::tool_output_file F("svfg_pts.data", ErrInfo, llvm::sys::fs::F_None);
+        llvm::ToolOutputFile F("svfg_pts.data", ErrInfo, llvm::sys::fs::F_None);
         if (!ErrInfo) {
             llvm::raw_fd_ostream & osm = F.os();
             NodeBS locs;

--- a/include/Util/DataFlowUtil.h
+++ b/include/Util/DataFlowUtil.h
@@ -207,7 +207,7 @@ private:
 /*!
  * Iterated dominance frontier
  */
-class IteratedDominanceFrontier: public llvm::DominanceFrontierBase<llvm::BasicBlock> {
+class IteratedDominanceFrontier: public llvm::DominanceFrontierBase<llvm::BasicBlock, false> {
 
 private:
     const llvm::DominanceFrontier *DF;
@@ -218,7 +218,7 @@ public:
     static char ID;
 
     IteratedDominanceFrontier() :
-        llvm::DominanceFrontierBase<llvm::BasicBlock>(false), DF(NULL) {
+        llvm::DominanceFrontierBase<llvm::BasicBlock, false>(), DF(NULL) {
     }
 
     virtual ~IteratedDominanceFrontier() {

--- a/include/Util/GraphUtil.h
+++ b/include/Util/GraphUtil.h
@@ -58,7 +58,7 @@ public:
         std::string Filename = GraphName + ".dot";
         O << "Writing '" << Filename << "'...";
         std::error_code ErrInfo;
-        tool_output_file F(Filename.c_str(), ErrInfo, sys::fs::F_None);
+        ToolOutputFile F(Filename.c_str(), ErrInfo, sys::fs::F_None);
 
         if (!ErrInfo) {
             // dump the ValueFlowGraph here

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -236,13 +236,13 @@ void MemSSA::insertPHI(const Function& fun) {
         while (!bbs.empty()) {
             const BasicBlock* bb = bbs.back();
             bbs.pop_back();
-            DominanceFrontierBase<BasicBlock>::const_iterator it = df->find(const_cast<BasicBlock*>(bb));
+            DominanceFrontierBase<BasicBlock, false>::const_iterator it = df->find(const_cast<BasicBlock*>(bb));
             if(it == df->end()) {
                 wrnMsg("bb not in the dominance frontier map??");
                 continue;
             }
-            const DominanceFrontierBase<BasicBlock>::DomSetType& domSet = it->second;
-            for (DominanceFrontierBase<BasicBlock>::DomSetType::const_iterator bit =
+            const DominanceFrontierBase<BasicBlock, false>::DomSetType& domSet = it->second;
+            for (DominanceFrontierBase<BasicBlock, false>::DomSetType::const_iterator bit =
                         domSet.begin(); bit != domSet.end(); ++bit) {
                 const BasicBlock* pbb = *bit;
                 // if we never insert this phi node before

--- a/lib/MemoryModel/PAGBuilder.cpp
+++ b/lib/MemoryModel/PAGBuilder.cpp
@@ -985,7 +985,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const Function *callee) {
                 /// apr_thread_create has 2 arg.
                 assert((forkedFun->arg_size() <= 2) && "Size of formal parameter of start routine should be one");
                 if(forkedFun->arg_size() <= 2 && forkedFun->arg_size() >= 1) {
-                    const Argument* formalParm = &(forkedFun->getArgumentList().front());
+                    const Argument* formalParm = &(*forkedFun->arg_begin());
                     /// Connect actual parameter to formal parameter of the start routine
                     if(isa<PointerType>(actualParm->getType()) && isa<PointerType>(formalParm->getType()) )
                         pag->addThreadForkEdge(pag->getValueNode(actualParm), pag->getValueNode(formalParm),inst);
@@ -1008,7 +1008,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const Function *callee) {
                 /// The task function of hare_parallel_for has 3 args.
                 assert((taskFunc->arg_size() == 3) && "Size of formal parameter of hare_parallel_for's task routine should be 3");
                 const Value* actualParm = getTaskDataAtHareParForSite(inst);
-                const Argument* formalParm = &(taskFunc->getArgumentList().front());
+                const Argument* formalParm = &(*taskFunc->arg_begin());
                 /// Connect actual parameter to formal parameter of the start routine
                 if(isa<PointerType>(actualParm->getType()) && isa<PointerType>(formalParm->getType()) )
                     pag->addThreadForkEdge(pag->getValueNode(actualParm), pag->getValueNode(formalParm),inst);

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -341,7 +341,7 @@ void BVDataPTAImpl::writeToFile(const string& filename) {
     outs() << "Storing pointer analysis results to '" << filename << "'...";
 
     error_code err;
-    tool_output_file F(filename.c_str(), err, sys::fs::F_None);
+    ToolOutputFile F(filename.c_str(), err, sys::fs::F_None);
     if (err) {
         outs() << "  error opening file for writing!\n";
         F.os().clear_error();

--- a/lib/Util/DataFlowUtil.cpp
+++ b/lib/Util/DataFlowUtil.cpp
@@ -40,7 +40,7 @@ void IteratedDominanceFrontier::calculate(llvm::BasicBlock * bb,
 
     DomSetType worklist;
 
-    DominanceFrontierBase<llvm::BasicBlock>::const_iterator it = DF.find(bb);
+    DominanceFrontierBase<llvm::BasicBlock, false>::const_iterator it = DF.find(bb);
     assert(it != DF.end());
 
     worklist.insert(it->second.begin(), it->second.end());

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -9,7 +9,7 @@
 ################################################
 
 ##remember to run ./setup script before running testings
-CLANGFLAG='-g -c -emit-llvm -I.'
+CLANGFLAG='-Xclang -disable-O0-optnone -g -c -emit-llvm -I.'
 LLVMOPTFLAG='-mem2reg -mergereturn'
 
 TESTWITHOPT=$1


### PR DESCRIPTION
Relevant LLVM changes for updating to v6.0.0 from v4.0.0:

- The `IsPostDominators` member of `llvm::DominanceFrontierBase` has become a template parameter (https://reviews.llvm.org/D35315).
- The method `llvm::Function::getArgumentList` has been dropped in favour of `llvm::Function::arg_begin`, `llvm::Function::arg_end` and `llvm::Function::args` (https://reviews.llvm.org/rL298010).
- `tool_output_file` has been renamed `ToolOutputFile`.
- `FindAllocaDbgDeclare` has been replaced with `FindDbgAddrUses`, which returns a list of zero or one `llvm.dbg.declare` intrinsics plus zero or more `llvm.dbg.addr` intrinsics (upcast as `DbgInfoIntrinsic` objects) (https://reviews.llvm.org/D37768).

I've run the test script for the `mem_leak` directory and it all looks fine – could you advise any further testing that needs to be done?

Many thanks!
Jack