### PR TITLE
Fix C++ Analysis Error due to LLVM-6.0 changes of Attribute argument No.

### DIFF
--- a/lib/MemoryModel/CHA.cpp
+++ b/lib/MemoryModel/CHA.cpp
@@ -164,7 +164,7 @@ void CHGraph::buildCHGOnBasicBlock(const BasicBlock *B,
                 continue;
             if ((relationType == CONSTRUCTOR && isConstructor(callee)) ||
                     (relationType == DESTRUCTOR && isDestructor(callee))) {
-                if (cs.arg_size() < 1 || (cs.paramHasAttr(1, Attribute::StructRet) && cs.arg_size() < 2))
+                if (cs.arg_size() < 1 || (cs.arg_size() < 2 && cs.paramHasAttr(0, Attribute::StructRet)))
                     continue;
                 const Value *thisPtr = getVCallThisPtr(cs);
                 if (thisPtr != NULL) {

--- a/lib/Util/CPPUtil.cpp
+++ b/lib/Util/CPPUtil.cpp
@@ -224,7 +224,7 @@ bool cppUtil::isVirtualCallSite(CallSite cs) {
 }
 
 const Value *cppUtil::getVCallThisPtr(CallSite cs) {
-    if (cs.paramHasAttr(1, Attribute::StructRet)) {
+    if (cs.paramHasAttr(0, Attribute::StructRet)) {
         return cs.getArgument(1);
     } else {
         return cs.getArgument(0);


### PR DESCRIPTION
An error occurs due to the Argument number is changed in LLVM-6.0. 
```
cs.paramHasAttr(0, ...) 
```
"0" is the first argument now.
Previously, in LLVM-4.0, "1" is the first argument.

This needs to be confirmed if someone knows.
