### PR TITLE
Make getRevPts to part of PointerAnalysis class

### DIFF
--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -353,6 +353,10 @@ public:
 
     /// Get points-to targets of a pointer. It needs to be implemented in child class
     virtual PointsTo& getPts(NodeID ptr) = 0;
+    
+    /// Given an object, get all the nodes having whose pointsto contains the object. 
+    /// Similar to getPts, this also needs to be implemented in child classes.
+    virtual PointsTo& getRevPts(NodeID nodeId) = 0;
 
     /// Clear points-to data
     virtual void clearPts() {


### PR DESCRIPTION
Make `getRevPts` part of PointerAnalysis base class, this just makes it easy to access the method from base-class pointer, else we need cast to child class before accessing this method.