### PR TITLE
Adding support for vector operands.

### DIFF
--- a/lib/Util/BreakConstantExpr.cpp
+++ b/lib/Util/BreakConstantExpr.cpp
@@ -272,6 +272,17 @@ BreakConstantGEPs::runOnModule (Module & module) {
                 for (unsigned index = 0; index < I->getNumOperands(); ++index) {
                     if (hasConstantGEP (I->getOperand(index))) {
                         Worklist.push_back (I);
+                        break;
+                    } else {
+                        ConstantVector *CVOper = dyn_cast<ConstantVector>(I->getOperand(index));
+                        if (CVOper != nullptr) {
+                            for (unsigned vindex = 0; vindex < CVOper->getNumOperands(); ++vindex) {
+                                if (hasConstantGEP(CVOper->getOperand(vindex))) {
+                                    Worklist.push_back(I);
+                                    break;
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -328,6 +339,17 @@ BreakConstantGEPs::runOnModule (Module & module) {
                         Instruction * NewInst = convertExpression (CE, I);
                         I->replaceUsesOfWith (CE, NewInst);
                         Worklist.push_back (NewInst);
+                    } else {
+                        ConstantVector *CVOper = dyn_cast<ConstantVector>(I->getOperand(index));
+                        if (CVOper != nullptr) {
+                            for (unsigned vindex = 0; vindex < CVOper->getNumOperands(); ++vindex) {
+                                if (ConstantExpr *CE = hasConstantGEP(CVOper->getOperand(vindex))) {
+                                    Instruction *NewInst = convertExpression(CE, I);
+                                    I->replaceUsesOfWith(CE, NewInst);
+                                    Worklist.push_back(NewInst);
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Adding support for vector operands in BreakConstantExpr.

Note that, I have added the additional break as an optimization.
Reason: It is enough to add instruction once if there is an operand that hasConstantGEP, instead of adding the same instruction once for each operand.