### PR TITLE
expose getCallInstToCallGraphEdgesMap for analysis

### DIFF
--- a/include/Util/PTACallGraph.h
+++ b/include/Util/PTACallGraph.h
@@ -244,7 +244,7 @@ public:
         return numOfResolvedIndCallEdge;
     }
 
-    inline CallInstToCallGraphEdgesMap const& getCallInstToCallGraphEdgesMap() const {
+    inline const CallInstToCallGraphEdgesMap& getCallInstToCallGraphEdgesMap() const {
         return callinstToCallGraphEdgesMap;
     }
 

--- a/include/Util/PTACallGraph.h
+++ b/include/Util/PTACallGraph.h
@@ -244,7 +244,7 @@ public:
         return numOfResolvedIndCallEdge;
     }
 
-    inline CallInstToCallGraphEdgesMap& getCallInstToCallGraphEdgesMap() {
+    inline CallInstToCallGraphEdgesMap const& getCallInstToCallGraphEdgesMap() const {
         return callinstToCallGraphEdgesMap;
     }
 

--- a/include/Util/PTACallGraph.h
+++ b/include/Util/PTACallGraph.h
@@ -244,6 +244,10 @@ public:
         return numOfResolvedIndCallEdge;
     }
 
+    inline CallInstToCallGraphEdgesMap& getCallInstToCallGraphEdgesMap() {
+        return callinstToCallGraphEdgesMap;
+    }
+
     /// Issue a warning if the function which has indirect call sites can not be reached from program entry.
     void vefityCallGraph();
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,7 +62,6 @@ if ( CMAKE_SYSTEM_NAME MATCHES "Darwin")
 else()
     target_link_libraries(Svf ${llvm_libs})
 endif()
-set_property(TARGET LLVMSvf PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if(DEFINED IN_SOURCE_BUILD)
     add_dependencies(Svf intrinsics_gen)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,6 +62,7 @@ if ( CMAKE_SYSTEM_NAME MATCHES "Darwin")
 else()
     target_link_libraries(Svf ${llvm_libs})
 endif()
+set_property(TARGET LLVMSvf PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if(DEFINED IN_SOURCE_BUILD)
     add_dependencies(Svf intrinsics_gen)


### PR DESCRIPTION
Sometimes we need `callinstToCallGraphEdgesMap` information to get calling relations between callers and callees; therefore it may be worthy to expose this analysis result.