### PR TITLE
Add missing dependant library

### DIFF
--- a/tools/SABER/CMakeLists.txt
+++ b/tools/SABER/CMakeLists.txt
@@ -3,7 +3,7 @@ if(DEFINED IN_SOURCE_BUILD)
     set(LLVM_LINK_COMPONENTS BitWriter Core IPO IrReader InstCombine Instrumentation Target Linker Analysis ScalarOpts Support Svf Cudd)
     add_llvm_tool( saber saber.cpp )
 else()
-    llvm_map_components_to_libnames(llvm_libs BitWriter Core IPO IrReader InstCombine Instrumentation Target Linker Analysis ScalarOpts Support )
+    llvm_map_components_to_libnames(llvm_libs BitWriter Core IPO IrReader InstCombine Instrumentation Target Linker Analysis ScalarOpts Support TransformUtils)
     add_executable( saber saber.cpp )
 
     target_link_libraries( saber LLVMSvf LLVMCudd ${llvm_libs} )

--- a/tools/WPA/CMakeLists.txt
+++ b/tools/WPA/CMakeLists.txt
@@ -3,7 +3,7 @@ if(DEFINED IN_SOURCE_BUILD)
     set(LLVM_LINK_COMPONENTS BitWriter Core IPO IrReader InstCombine Instrumentation Target Linker Analysis ScalarOpts Support Svf Cudd)
     add_llvm_tool( wpa wpa.cpp )
 else()
-    llvm_map_components_to_libnames(llvm_libs bitwriter core ipo irreader instcombine instrumentation target linker analysis scalaropts support )
+    llvm_map_components_to_libnames(llvm_libs bitwriter core ipo irreader instcombine instrumentation target linker analysis scalaropts support transformutils)
     add_executable( wpa wpa.cpp )
 
     target_link_libraries( wpa LLVMSvf LLVMCudd ${llvm_libs} )


### PR DESCRIPTION
This PR adds some missing dependencies to `wpa` and `saber`

The problem occurs when building SVF with llvm that is built as a shared library (`-DBUILD_SHARED_LIBS=ON`), with this error message:

``` Linking CXX executable ../../bin/saber
/usr/bin/ld: ../../lib/libLLVMSvf.a(MemModel.cpp.o): undefined reference to symbol '_ZTVN4llvm22UnifyFunc
tionExitNodesE'
/src/llvm_build/lib/libLLVMTransformUtils.so.7: error adding symbols: DSO missing from command line
```

This change fixes the issue for me.