### PR TITLE
Stop indirect call resolution when limit is hit

### DIFF
--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -625,7 +625,7 @@ void PointerAnalysis::resolveIndCalls(CallSite cs, const PointsTo& target, CallE
     for (PointsTo::iterator ii = target.begin(), ie = target.end();
             ii != ie; ii++) {
 
-        if(getNumOfResolvedIndCallEdge() > IndirectCallLimit) {
+        if(getNumOfResolvedIndCallEdge() >= IndirectCallLimit) {
             errMsg("Resolved Indirect Call Edges are Out-Of-Budget, please increase the limit");
             return;
         }


### PR DESCRIPTION
Previously, a fencepost error; one extra call can be resolved because it would stop when the limit is exceeded, not when it is reached.

E.g. if the limit is 0, the check would pass since !(0 > 0), which allows an indirect call to be resolved before the check begins to fail (since 1 > 0). 