### PR TITLE
Fix the arguments to WriteBitcodeToFile function

### DIFF
--- a/lib/Util/SVFModule.cpp
+++ b/lib/Util/SVFModule.cpp
@@ -368,7 +368,7 @@ void LLVMModuleSet::dumpModulesToFile(const std::string suffix) {
 
         std::error_code EC;
         llvm::raw_fd_ostream OS(OutputFilename.c_str(), EC, llvm::sys::fs::F_None);
-        WriteBitcodeToFile(*mod, OS);
+        WriteBitcodeToFile(mod, OS);
         OS.flush();
     }
 }


### PR DESCRIPTION
WriteBitcodeToFile expectes reference to the Module object: https://llvm.org/doxygen/BitcodeWriter_8cpp_source.html#l04360

Error details:
razzer/tools/SVF/lib/Util/SVFModule.cpp:371:36: error: cannot convert 'llvm::Module' to 'const llvm::Module*' for argument '1' to 'void llvm::WriteBitcodeToFile(const llvm::Module*, llvm::raw_ostream&, bool, const llvm::ModuleSummaryIndex*, bool, llvm::ModuleHash*)'
         WriteBitcodeToFile(*mod, OS);