### PR TITLE
Corrected Method Spelling (vefityCallGraph -> verifyCallGraph)

### DIFF
--- a/include/Util/AnalysisUtil.h
+++ b/include/Util/AnalysisUtil.h
@@ -344,7 +344,7 @@ inline const llvm::Value* getForkedFun(const llvm::Instruction *inst) {
 }
 //@}
 
-/// Return sole argument of the thread rountine
+/// Return sole argument of the thread routine
 //@{
 inline const llvm::Value* getActualParmAtForkSite(const llvm::CallSite cs) {
     return ThreadAPI::getThreadAPI()->getActualParmAtForkSite(cs);
@@ -354,7 +354,7 @@ inline const llvm::Value* getActualParmAtForkSite(const llvm::Instruction *inst)
 }
 //@}
 
-/// Return the task function of the parallel_for rountine
+/// Return the task function of the parallel_for routine
 //@{
 inline const llvm::Value* getTaskFuncAtHareParForSite(const llvm::CallSite cs) {
     return ThreadAPI::getThreadAPI()->getTaskFuncAtHareParForSite(cs);

--- a/include/Util/PTACallGraph.h
+++ b/include/Util/PTACallGraph.h
@@ -259,7 +259,7 @@ public:
     }
 
     /// Issue a warning if the function which has indirect call sites can not be reached from program entry.
-    void vefityCallGraph();
+    void verifyCallGraph();
 
     /// Get call graph node
     //@{

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -247,7 +247,7 @@ void PointerAnalysis::finalize() {
     if (FuncPointerPrint)
         printIndCSTargets();
 
-    getPTACallGraph()->vefityCallGraph();
+    getPTACallGraph()->verifyCallGraph();
 
     getPTACallGraph()->dump("callgraph_final");
 

--- a/lib/Util/PTACallGraph.cpp
+++ b/lib/Util/PTACallGraph.cpp
@@ -248,7 +248,7 @@ void PTACallGraph::getIndCallSitesInvokingCallee(const llvm::Function* callee, P
 /*!
  * Issue a warning if the function which has indirect call sites can not be reached from program entry.
  */
-void PTACallGraph::vefityCallGraph()
+void PTACallGraph::verifyCallGraph()
 {
     CallEdgeMap::const_iterator it = indirectCallMap.begin();
     CallEdgeMap::const_iterator eit = indirectCallMap.end();


### PR DESCRIPTION
As suggested by https://github.com/nix7965 in https://github.com/SVF-tools/SVF/issues/133