### PR TITLE
Add no Pointer Analysis is specified assertion

### DIFF
--- a/lib/WPA/WPAPass.cpp
+++ b/lib/WPA/WPAPass.cpp
@@ -99,6 +99,7 @@ void WPAPass::runOnModule(SVFModule svfModule) {
         if (PASelected.isSet(i))
             runPointerAnalysis(svfModule, i);
     }
+    assert(!ptaVector.empty() && "No pointer analysis is specified.\n");
 }
 
 


### PR DESCRIPTION
WPAPass is able to run different pointer analysis on the bitcode but no default pointer analysis is used. This leads to the segmentation fault mention in issue #156 when querying the alias result.

In order to fix this issue, it would be safe to check if any pointer analysis is chosen before doing any further work.

This commit adds an assertion to make sure that lacking pointer analysis is not allowed. It runs `wpa` as a command-line tool or invokes `WPAPass` through a shared library. In both cases, the program will abort if no pointer analysis is specified.