### PR TITLE
delay inclusion of mod to ref to preserve useful mod-ref analysis result

### DIFF
--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -325,11 +325,11 @@ protected:
         addRefSideEffectOfFunction(fun,cpts);
     }
     inline void addCPtsToCallSiteRefs(PointsTo& cpts, CallSite cs) {
-        callsiteToRefPointsToMap[cs] = cpts;
+        callsiteToRefPointsToMap[cs] |= cpts;
         funToPointsToMap[cs.getCaller()].insert(cpts);
     }
     inline void addCPtsToCallSiteMods(PointsTo& cpts, CallSite cs) {
-        callsiteToModPointsToMap[cs] = cpts;
+        callsiteToModPointsToMap[cs] |= cpts;
         funToPointsToMap[cs.getCaller()].insert(cpts);
     }
     inline bool hasCPtsList(const Function* fun) const {

--- a/lib/MSSA/MemRegion.cpp
+++ b/lib/MSSA/MemRegion.cpp
@@ -218,7 +218,9 @@ void MRGenerator::collectModRefForCall() {
         }
         if(hasModSideEffectOfCallSite(*it)) {
             NodeBS mods = getModSideEffectOfCallSite(*it);
+            /// mods are treated as both def and use of memory objects
             addCPtsToCallSiteMods(mods,*it);
+            addCPtsToCallSiteRefs(mods,*it);
         }
     }
 }
@@ -515,9 +517,6 @@ bool MRGenerator::handleCallsiteModRef(NodeBS& mod, NodeBS& ref, CallSite cs, co
     else{
         mod = getModSideEffectOfFunction(callee);
         ref = getRefSideEffectOfFunction(callee);
-
-        /// ref set include all mods
-        ref |= mod;
     }
     // add ref set
     bool refchanged = addRefSideEffectOfCallSite(cs, ref);


### PR DESCRIPTION
As raised in [issue 176](https://github.com/SVF-tools/SVF/issues/176). An early stage of inclusion of mod to ref in [MRGenerator::handleCallsiteModRef](https://github.com/SVF-tools/SVF/blob/master/lib/MSSA/MemRegion.cpp#L520) limits the accuracy of mod-ref analysis and makes two intermediate maps `csToRefsMap` and `csToModsMap` unuseable. Since `funToPointsToMap`, `callsiteToRefPointsToMap` and `callsiteToModPointsToMap` are the three maps that contain def-use information of memory objects and get propagated to generate the correct MSSA, a delay of inclusion of mod to ref to a later stage in [MRGenerator::collectModRefForCall()](https://github.com/SVF-tools/SVF/blob/master/lib/MSSA/MemRegion.cpp#L219) can both preserve the useful information of mod-ref analysis and maintain the correctness of MSSA.