### PR TITLE
add getModRefInfo APIs support for SVF

### DIFF
--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -436,6 +436,13 @@ public:
 		else
 			return pta->getPAG()->getInstPAGEdgeList(inst);
     }
+    
+    /// getModRefInfo APIs
+    //@{
+    ModRefInfo getModRefInfo(CallSite cs);
+    ModRefInfo getModRefInfo(CallSite cs, const Value* V);
+    ModRefInfo getModRefInfo(CallSite cs1, CallSite cs2);
+    //@}
 
 };
 

--- a/include/Util/BasicTypes.h
+++ b/include/Util/BasicTypes.h
@@ -186,6 +186,7 @@ typedef llvm::ConstantPointerNull ConstantPointerNull;
 typedef llvm::ConstantArray ConstantArray;
 typedef llvm::GlobalAlias GlobalAlias;
 typedef llvm::AliasResult AliasResult;
+typedef llvm::ModRefInfo ModRefInfo;
 typedef llvm::AnalysisID AnalysisID;
 typedef llvm::ConstantDataArray ConstantDataArray;
 

--- a/include/WPA/WPAPass.h
+++ b/include/WPA/WPAPass.h
@@ -40,6 +40,7 @@
 #include "MemoryModel/PointerAnalysis.h"
 
 class SVFModule;
+class SVFG;
 
 /*!
  * Whole program pointer analysis.
@@ -91,6 +92,20 @@ public:
     /// Print all alias pairs
     virtual void PrintAliasPairs(PointerAnalysis* pta);
 
+    /// Interface of mod-ref analysis to determine whether a CallSite instruction can mod or ref any memory location
+    virtual ModRefInfo getModRefInfo(const CallInst* callInst);
+
+    /// Interface of mod-ref analysis to determine whether a CallSite instruction can mod or ref a specific memory location, given Location infos
+    virtual inline ModRefInfo getModRefInfo(const CallInst* callInst, const MemoryLocation& Loc) {
+        return getModRefInfo(callInst, Loc.Ptr);
+    }
+
+    /// Interface of mod-ref analysis to determine whether a CallSite instruction can mod or ref a specific memory location, given Value infos
+    virtual ModRefInfo getModRefInfo(const CallInst* callInst, const Value* V);
+
+    /// Interface of mod-ref analysis between two CallSite instructions
+    virtual ModRefInfo getModRefInfo(const CallInst* callInst1, const CallInst* callInst2);
+
     /// We start from here
     virtual bool runOnModule(llvm::Module& module) {
         SVFModule svfModule(module);
@@ -112,6 +127,7 @@ private:
 
     PTAVector ptaVector;	///< all pointer analysis to be executed.
     PointerAnalysis* _pta;	///<  pointer analysis to be executed.
+    SVFG* _svfg;  ///< svfg generated through -ander pointer analysis
 };
 
 

--- a/lib/MSSA/MemRegion.cpp
+++ b/lib/MSSA/MemRegion.cpp
@@ -557,3 +557,83 @@ void MRGenerator::modRefAnalysis(PTACallGraphNode* callGraphNode, WorkList& work
         }
     }
 }
+
+/*!
+ * Determine whether a CallSite instruction can mod or ref
+ * any memory location
+ */
+ModRefInfo MRGenerator::getModRefInfo(CallSite cs) {
+    bool ref = hasRefSideEffectOfCallSite(cs);
+    bool mod = hasModSideEffectOfCallSite(cs);
+
+    if (mod && ref)
+        return ModRefInfo::ModRef;
+    else if (ref)
+        return ModRefInfo::Ref;
+    else if (mod)
+        return ModRefInfo::Mod;
+    else
+        return ModRefInfo::NoModRef;
+}
+
+/*!
+ * Determine whether a CallSite instruction can mod or ref
+ * a specific memory location pointed by V
+ */
+ModRefInfo MRGenerator::getModRefInfo(CallSite cs, const Value* V) {
+    bool ref = false;
+    bool mod = false;
+
+    if (pta->getPAG()->hasValueNode(V)) {
+        const PointsTo& pts(pta->getPts(pta->getPAG()->getValueNode(V)));
+        if (hasRefSideEffectOfCallSite(cs) && getRefSideEffectOfCallSite(cs).intersects(pts))
+            ref = true;
+        if (hasModSideEffectOfCallSite(cs) && getModSideEffectOfCallSite(cs).intersects(pts))
+            mod = true;
+    }
+
+    if (mod && ref)
+        return ModRefInfo::ModRef;
+    else if (ref)
+        return ModRefInfo::Ref;
+    else if (mod)
+        return ModRefInfo::Mod;
+    else
+        return ModRefInfo::NoModRef;
+}
+
+/*!
+ * Determine mod-ref relations between two CallSite instructions
+ */
+ModRefInfo MRGenerator::getModRefInfo(CallSite cs1, CallSite cs2) {
+    bool ref = false;
+    bool mod = false;
+
+    /// return NoModRef neither two callsites ref or mod any memory
+    if (getModRefInfo(cs1) == ModRefInfo::NoModRef || getModRefInfo(cs2) == ModRefInfo::NoModRef)
+        return ModRefInfo::NoModRef;
+
+    const PointsTo& cs1Ref = getRefSideEffectOfCallSite(cs1);
+    const PointsTo& cs1Mod = getModSideEffectOfCallSite(cs1);
+    const PointsTo& cs2Ref = getRefSideEffectOfCallSite(cs2);
+    const PointsTo& cs2Mod = getModSideEffectOfCallSite(cs2);
+
+    /// Ref: cs1 ref memory mod by cs2
+    if (cs1Ref.intersects(cs2Mod))
+        ref = true;
+    /// Mod: cs1 mod memory ref or mod by cs2
+    if (cs1Mod.intersects(cs2Ref) || cs1Mod.intersects(cs2Mod))
+        mod = true;
+    /// ModRef: cs1 ref and mod memory mod by cs2
+    if (cs1Ref.intersects(cs2Mod) && cs1Mod.intersects(cs2Mod))
+        ref = mod = true;
+
+    if (ref && mod)
+        return ModRefInfo::ModRef;
+    else if (ref)
+        return ModRefInfo::Ref;
+    else if (mod)
+        return ModRefInfo::Mod;
+    else
+        return ModRefInfo::NoModRef;
+}

--- a/lib/WPA/WPAPass.cpp
+++ b/lib/WPA/WPAPass.cpp
@@ -33,6 +33,7 @@
  */
 
 
+#include "Util/SVFUtil.h"
 #include "Util/SVFModule.h"
 #include "MemoryModel/PointerAnalysis.h"
 #include "WPA/WPAPass.h"
@@ -151,6 +152,9 @@ void WPAPass::runPointerAnalysis(SVFModule svfModule, u32_t kind)
         SVFGBuilder memSSA(true);
         assert(SVFUtil::isa<Andersen>(_pta) && "supports only andersen for pre-computed SVFG");
         SVFG *svfg = memSSA.buildFullSVFG((BVDataPTAImpl*)_pta);
+        /// support mod-ref queries only for -ander
+        if (PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA))
+            _svfg = svfg;
         svfg->dump("ander_svfg");
     }
 
@@ -219,4 +223,28 @@ AliasResult WPAPass::alias(const Value* V1, const Value* V2) {
     }
 
     return result;
+}
+
+/*!
+ * Return mod-ref result of a CallInst
+ */
+ModRefInfo WPAPass::getModRefInfo(const CallInst* callInst) {
+    assert(PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA) && anderSVFG && "mod-ref query is only support with -ander and -svfg turned on");
+    return _svfg->getMSSA()->getMRGenerator()->getModRefInfo(SVFUtil::getLLVMCallSite(callInst));
+}
+
+/*!
+ * Return mod-ref results of a CallInst to a specific memory location
+ */
+ModRefInfo WPAPass::getModRefInfo(const CallInst* callInst, const Value* V) {
+    assert(PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA) && anderSVFG && "mod-ref query is only support with -ander and -svfg turned on");
+    return _svfg->getMSSA()->getMRGenerator()->getModRefInfo(SVFUtil::getLLVMCallSite(callInst), V);
+}
+
+/*!
+ * Return mod-ref result between two CallInsts
+ */
+ModRefInfo WPAPass::getModRefInfo(const CallInst* callInst1, const CallInst* callInst2) {
+    assert(PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA) && anderSVFG && "mod-ref query is only support with -ander and -svfg turned on");
+    return _svfg->getMSSA()->getMRGenerator()->getModRefInfo(SVFUtil::getLLVMCallSite(callInst1), SVFUtil::getLLVMCallSite(callInst2));
 }


### PR DESCRIPTION
As in pr #177, SVF now naturally support interprocedural mod-ref queries by leveraging two maps `csToRefsMap` and `csToModsMap`. This commit adds three types of mod-ref query APIs to SVF.
* mod-ref query of whether a callInst instruction can mod or ref any memory location
* mod-ref query of whether a callInst instruction can mod or ref a specific memory location
* mod-ref info between two callInst instructions, which is in line with [LLVM getModRefInfo between two calls](https://llvm.org/docs/AliasAnalysis.html#the-getmodrefinfo-methods)

In order to make queries to those two maps above, a `std::vector<SVFG*> svfgVector` is added in `class WPA` to store all the svfg constructed based on Andersen's Pointer Analysis. BitVector stores the union of all query results. The query result rule is bold (less conservative), that is, `NoModRef` is favored the most than `Ref`, then `Mod` and finally `ModRef`. If `Ref` and `Mod` result appear at the same time, then `NoModRef` result gets returned.

Example 1: One ref and one mod
```C
int get_value(int* p, int* q, int a) {
  *p = a;
  return *q;
}

int main(int argc, const char* argv[]) {
  int a = argc;
  int b = argc;
  int* p = &a;
  int* q = &b;

  int value = get_value(p, q, a);

  printf("%d", value);
  return 0;
}
```
Memory pointed by `p` is modified and memory pointered by pointer `q` is referenced in get_value().
The mod-ref result of pointer `p` is **Mod** and of pointer `q` is **Ref**.
The mod-ref result of callInst `int value = get_value(p, q, a)` is **ModRef**.

Example 2: Mod inside another call
```C
int get_value2(int* p, int a) {
  *p = a;
  return a;
}

int get_value(int* p, int a) {
  return get_value2(p, a);
}

int main(int argc, const char* argv[]) {
  int a = argc;
  int* p = &a;

  int value = get_value(p, a);

  printf("%d", value);
  return 0;
}
```
The memory pointed by `p` is modified through another callInst inside `get_value()`.
The mod-ref result of callInst `int value = get_value(p, a)` and `p` is **Mod**.

Example 3: ModRef through indirect calls
```C
int get_value2(int* p, int a) {
  *p = a;
  return a;
}

int get_value1(int* p, int a) {
  return *p;
}

int main(int argc, const char* argv[]) {
  int a = argc;
  int* p = &a;

  int (*f)(int*, int*, int);
  if (a > 10)
    f = &get_value;
  else
    f = &get_value2;

  int value = f(p, a);

  printf("%d", value);
  return 0;
}
```
The memory pointed by `p` can either be referred through a function pointer that refers it or another function pointer that modifies it. The mod-ref result of pointer `p` is **ModRef**.

Example 4: ModRef between two calls
```C
int get_value1(int* p, int a) {
  *p = *p + 1;
  return a;
}

int get_value2(int* p, int a) {
  *p = a;
  return a;
}

int main(int argc, const char* argv[]) {
  int a = argc;
  int* p = &a;

  int value1 = get_value1(p, a);
  int value2 = get_value2(p, a);

  printf("%d %d", value1, value2);
  return 0;
}
```
The first call referred and modified the memory modified by the second call. The mod-ref result of `int value1 = get_value1(p, a)` and ` int value2 = get_value2(p, a)` is **ModRef**, and the result between ` int value2 = get_value2(p, a)` and ` int value1 = get_value1(p, a)` is only **Mod** since the second call mod the memory ref or mod by the first call.

Since its an extension by leveraging internal data of SVF. Please let me know are there anything wrong or suggestions. Thanks!