### PR TITLE
cmake: allow LLVM_DIR configuring with cmake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required(VERSION 3.4.3)
 # we check for the presence of the add_llvm_loadable_module command.
 # - if this command is not present, we are building out-of-source
 if(NOT COMMAND add_llvm_library)
+    if (DEFINED LLVM_DIR)
+        set(ENV{LLVM_DIR} "${LLVM_DIR}")
+    endif()
     if (DEFINED ENV{LLVM_DIR})
         # We need to match the build environment for LLVM:
         # In particular, we need C++11 and the -fno-rtti flag


### PR DESCRIPTION
This enables usage of
```
cmake ... -D LLVM_DIR=...
```
I need this for a [meson subproject](https://mesonbuild.com/CMake-module.html). Meson supports to specify arbitrary cmake argument for the actual call of cmake but does not allow to specify environment variables.