### PR TITLE
Refine getModRefInfo APIs to accomodate with field-sensitivity of SVF

### DIFF
--- a/lib/MSSA/MemRegion.cpp
+++ b/lib/MSSA/MemRegion.cpp
@@ -585,10 +585,17 @@ ModRefInfo MRGenerator::getModRefInfo(CallSite cs, const Value* V) {
     bool mod = false;
 
     if (pta->getPAG()->hasValueNode(V)) {
-        const PointsTo& pts(pta->getPts(pta->getPAG()->getValueNode(V)));
-        if (hasRefSideEffectOfCallSite(cs) && getRefSideEffectOfCallSite(cs).intersects(pts))
+        const PointsTo& pts(pta->getPts(pta->getPAG()->getValueNode(V))); 
+        const PointsTo& csRef = getRefSideEffectOfCallSite(cs);
+        const PointsTo& csMod = getModSideEffectOfCallSite(cs);
+        PointsTo ptsExpanded, csRefExpanded, csModExpanded;
+        pta->expandFIObjs(pts, ptsExpanded);
+        pta->expandFIObjs(csRef, csRefExpanded);
+        pta->expandFIObjs(csMod, csModExpanded);
+        
+        if (csRefExpanded.intersects(ptsExpanded))
             ref = true;
-        if (hasModSideEffectOfCallSite(cs) && getModSideEffectOfCallSite(cs).intersects(pts))
+        if (csModExpanded.intersects(ptsExpanded))
             mod = true;
     }
 
@@ -617,15 +624,20 @@ ModRefInfo MRGenerator::getModRefInfo(CallSite cs1, CallSite cs2) {
     const PointsTo& cs1Mod = getModSideEffectOfCallSite(cs1);
     const PointsTo& cs2Ref = getRefSideEffectOfCallSite(cs2);
     const PointsTo& cs2Mod = getModSideEffectOfCallSite(cs2);
+    PointsTo cs1RefExpanded, cs1ModExpanded, cs2RefExpanded, cs2ModExpanded;
+    pta->expandFIObjs(cs1Ref, cs1RefExpanded);
+    pta->expandFIObjs(cs1Mod, cs1ModExpanded);
+    pta->expandFIObjs(cs2Ref, cs2RefExpanded);
+    pta->expandFIObjs(cs2Mod, cs2ModExpanded);
 
     /// Ref: cs1 ref memory mod by cs2
-    if (cs1Ref.intersects(cs2Mod))
+    if (cs1RefExpanded.intersects(cs2ModExpanded))
         ref = true;
     /// Mod: cs1 mod memory ref or mod by cs2
-    if (cs1Mod.intersects(cs2Ref) || cs1Mod.intersects(cs2Mod))
+    if (cs1ModExpanded.intersects(cs2RefExpanded) || cs1ModExpanded.intersects(cs2ModExpanded))
         mod = true;
     /// ModRef: cs1 ref and mod memory mod by cs2
-    if (cs1Ref.intersects(cs2Mod) && cs1Mod.intersects(cs2Mod))
+    if (cs1RefExpanded.intersects(cs2ModExpanded) && cs1ModExpanded.intersects(cs2ModExpanded))
         ref = mod = true;
 
     if (ref && mod)


### PR DESCRIPTION
SVF is field-sensitive when treating with class/struct objects. This causes the current getModRefInfo APIs to return NoModRef if a callisite modified/referred all fields except the base field of an object, as raised in issue #188.

The solution is to expand the mod/ref PointsTo set of callsite or the base pointer to include all fields of an object if the PointsTo set contains the base pointer.

Example
```C++
struct S {
  int v1;
  int v2;
  int v3;
};

void setV1(S *s, int v) {
  s->v1 = v;
}

void setV2(S *s, int v) {
  s->v2 = v;
}

void setV3(S *s, int v) {
  s->v3 = v;
}

int main(int argc, char **argv) {
  S *s = (S *)malloc(sizeof(S));
  s->v1 = argc;

  setV1(s, argc);
  setV2(s, argc);
  setV3(s, argc);

  return 0;
}
```

The mod-ref result between pointer `s` and callsite `setV2(s, argc)` or `setV3(s, argc)` now returns Mod. The mod-ref result between callsite `setV2(s, argc)` and `setV3(s, argc)` still returns NoModRef since they are not modifying the base field but modifying two different fields of the object.