### PR TITLE
Add the ability to construct an SVFModule through an LLVM Module

### DIFF
--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -71,6 +71,7 @@ public:
         llvmModuleSet = NULL;
     }
 
+    SVFModule* buildSVFModule(Module &mod);
     SVFModule* buildSVFModule(const std::vector<std::string> &moduleNameVec);
 
     void build(const std::vector<std::string> &moduleNameVec);

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -59,6 +59,20 @@ static llvm::cl::opt<bool> SVFMain("svfmain", llvm::cl::init(false), llvm::cl::d
 LLVMModuleSet *LLVMModuleSet::llvmModuleSet = NULL;
 std::string SVFModule::pagReadFromTxt = "";
 
+SVFModule* LLVMModuleSet::buildSVFModule(Module &mod) {
+  svfModule = new SVFModule();
+  moduleNum = 1;
+  cxts = &(mod.getContext());
+  modules = new unique_ptr<Module>[moduleNum];
+  modules[0] = std::unique_ptr<Module>(&mod);
+
+  initialize();
+  buildFunToFunMap();
+  buildGlobalDefToRepMap();
+
+  return svfModule;
+}
+
 SVFModule* LLVMModuleSet::buildSVFModule(const std::vector<std::string> &moduleNameVec) {
 	assert(llvmModuleSet && "LLVM Module set needs to be created!");
 


### PR DESCRIPTION
WPAPass is no longer a module pass, which provides the flexibility to create a WPAPass object inside any LLVM pass and it would be helpful to generate an SVFModule through an LLVM Module.