### PR TITLE
Return conservative getModRefInfo result for external calls

### DIFF
--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -378,6 +378,10 @@ protected:
     inline bool hasModSideEffectOfCallSite(const CallBlockNode* cs) {
         return csToModsMap.find(cs) != csToModsMap.end();
     }
+    /// Has indirect refs or mods of a callsite
+    inline bool hasSideEffectOfCallSite(const CallBlockNode* cs) {
+        return (hasRefSideEffectOfCallSite(cs) || hasModSideEffectOfCallSite(cs));
+    }
     //@}
 
 public:


### PR DESCRIPTION
The current getModRefInfo APIs returns `NoModRef` for external function calls, which is not correct (my bad). This commit fixes the issue and returns the conservative `ModRef` results.

External calls to `malloc`, `realloc`, etc. are not affected and will still return a more accurate `Mod` result as they are specially treated as [HeapAllocExtCall](https://github.com/SVF-tools/SVF/blob/master/lib/MSSA/MemRegion.cpp#L512).

Example:
```C
int main() {
  char* str = "Hello World";

  printf("%s\n", str);
  printf("%s\n", str);

  return 0;
}
```

The mod-ref result between the first and second `printf` external calls returns `ModRef`.