### PR TITLE
Set moduleIdentifier of svfModule built from LLVM Module

### DIFF
--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -60,7 +60,7 @@ LLVMModuleSet *LLVMModuleSet::llvmModuleSet = NULL;
 std::string SVFModule::pagReadFromTxt = "";
 
 SVFModule* LLVMModuleSet::buildSVFModule(Module &mod) {
-  svfModule = new SVFModule();
+  svfModule = new SVFModule(mod.getModuleIdentifier());
   moduleNum = 1;
   cxts = &(mod.getContext());
   modules = new unique_ptr<Module>[moduleNum];


### PR DESCRIPTION
A simple fix to pass the assertion
https://github.com/SVF-tools/SVF/blob/f7b3d0e3b51b25e3894d5645a0f5172284645f29/include/Util/SVFModule.h#L134