### PR TITLE
Set mod ref sets for external callsite

### DIFF
--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -306,6 +306,9 @@ protected:
         aliasMRs.insert(mr);
     }
 
+    /// Collect mod ref for external callsite other than heap alloc external call
+    virtual void collectModRefForExtCallSiteOtherThanHeapAlloc(const CallBlockNode* cs);
+
     /// Mod-Ref analysis for callsite invoking this callGraphNode
     virtual void modRefAnalysis(PTACallGraphNode* callGraphNode, WorkList& worklist);
 


### PR DESCRIPTION
Though SVF handles external functions' def-use behavior by defining a customized `extf_t`, it misses to include the results into the mod-ref analysis other than `HeapAllocExtCall`.

The reason is that in
https://github.com/SVF-tools/SVF/blob/f7b3d0e3b51b25e3894d5645a0f5172284645f29/lib/MSSA/MemRegion.cpp#L510
the `getModSideEffectOfFunction(callee)` and `getRefSideEffectOfFunction(callee)` returns nothing for callee functions who don't have definitions. To set it's mod ref sets, we have to retrieve it from the PAG edges constructed from
https://github.com/SVF-tools/SVF/blob/f7b3d0e3b51b25e3894d5645a0f5172284645f29/lib/SVF-FE/PAGBuilder.cpp#L760


An example like below
```C
int main(int argc, char **argv) {
  char* s1 = (char *)malloc(sizeof(argc));    // src
  char* s2 = (char *)malloc(sizeof(argc));    // dst
  memcpy(s2, s1, argc);

  return 0;
}
```
The mod ref behavior of external call `memcpy(s2, s1, argc)` is now returning the sound and correct `ModRef` result.