### PR TITLE
Modeling I/O Buffer within SVF and add necessary methods

### DIFF
--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -522,6 +522,25 @@ public:
     }
     //@}
 
+    /// Get I/O buffer
+    //@{
+    inline NodeID getIOBufferNode() const {
+        return symInfo->IOBufferSymID();
+    }
+    inline NodeID getIOBufferPtr() const {
+        return symInfo->IOBufferPtrSymID();
+    }
+    inline bool isIOBufferObj(NodeID id) const {
+        return (SymbolTableInfo::isIOBufferObj(id));
+    }
+    inline bool isIOBufferPtr(NodeID id) const {
+        return (SymbolTableInfo::isIOBufferPtr(id));
+    }
+    inline const MemObj* getIOBufferObj() const {
+        return symInfo->getIOBufferObj();
+    }
+    //@}
+
     inline u32_t getNodeNumAfterPAGBuild() const {
         return nodeNumAfterPAGBuild;
     }
@@ -615,6 +634,12 @@ public:
     }
     inline NodeID addBlackholePtrNode() {
         return addDummyValNode(getBlkPtr());
+    }
+    inline NodeID addIOBufferObjNode() {
+        return addObjNode(NULL, new DummyObjPN(getIOBufferNode(),getIOBufferObj()), getIOBufferNode());
+    }
+    inline NodeID addIOBufferPtrNode() {
+        return addDummyValNode(getIOBufferPtr());
     }
     //@}
 

--- a/include/MemoryModel/MemModel.h
+++ b/include/MemoryModel/MemModel.h
@@ -40,6 +40,8 @@ enum SYMTYPE {
     ConstantObj,
     BlkPtr,
     NullPtr,
+    IOBufferObj,
+    IOBufferPtr,
     ValSym,
     ObjSym,
     RetSym,
@@ -259,7 +261,7 @@ public:
     /// Constructor
     MemObj(const Value *val, SymID id);
 
-    /// Constructor for black hole and constant obj
+    /// Constructor for black hole, constant obj and I/O buffer obj
     MemObj(SymID id, const Type* type = NULL);
 
     /// Destructor
@@ -270,7 +272,7 @@ public:
     /// Initialize the object
     void init(const Value *val);
 
-    /// Initialize black hole and constant object
+    /// Initialize black hole, constant object and I/O buffer obj
     void init(const Type* type);
 
     /// Get obj type
@@ -306,6 +308,9 @@ public:
 
     /// Whether it is a black hole object
     bool isBlackHoleObj() const;
+
+    /// Whether it is an IO buffer object
+    bool isIOBufferObj() const;
 
     /// object attributes methods
     //@{

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -179,6 +179,9 @@ public:
     static inline bool isNullPtr(NodeID id) {
         return (id == NullPtr);
     }
+    static inline bool isIOBufferPtr(NodeID id) {
+        return (id == IOBufferPtr);
+    }
     static inline bool isBlkObj(NodeID id) {
         return (id == BlackHole);
     }
@@ -188,6 +191,9 @@ public:
     static inline bool isBlkObjOrConstantObj(NodeID id) {
         return (isBlkObj(id) || isConstantObj(id));
     }
+    static inline bool isIOBufferObj(NodeID id) {
+        return (id == IOBufferObj);
+    }
 
     inline void createBlkOrConstantObj(SymID symId) {
         assert(isBlkObjOrConstantObj(symId));
@@ -195,11 +201,20 @@ public:
         objMap[symId] = new MemObj(symId);;
     }
 
+    inline void createIOBufferObj(SymID symId) {
+        assert(isIOBufferObj(symId));
+        assert(objMap.find(symId)==objMap.end());
+        objMap[symId] = new MemObj(symId, Type::getInt8Ty(LLVMModuleSet::getLLVMModuleSet()->getContext()));
+    }
+
     inline MemObj* getBlkObj() const {
         return getObj(blackholeSymID());
     }
     inline MemObj* getConstantObj() const {
         return getObj(constantSymID());
+    }
+    inline MemObj* getIOBufferObj() const {
+        return getObj(IOBufferSymID());
     }
 
     inline SymID blkPtrSymID() const {
@@ -210,12 +225,20 @@ public:
         return NullPtr;
     }
 
+    inline SymID IOBufferPtrSymID() const {
+        return IOBufferPtr;
+    }
+
     inline SymID constantSymID() const {
         return ConstantObj;
     }
 
     inline SymID blackholeSymID() const {
         return BlackHole;
+    }
+
+    inline SymID IOBufferSymID() const {
+        return IOBufferObj;
     }
 
     /// Can only be invoked by PAG::addDummyNode() when creaing PAG from file.

--- a/lib/MemoryModel/MemModel.cpp
+++ b/lib/MemoryModel/MemModel.cpp
@@ -216,8 +216,12 @@ void MemObj::setFieldSensitive() {
  */
 void MemObj::init(const Type* type) {
     typeInfo = new ObjTypeInfo(StInfo::getMaxFieldLimit(),type);
-    typeInfo->setFlag(ObjTypeInfo::HEAP_OBJ);
-    typeInfo->setFlag(ObjTypeInfo::HASPTR_OBJ);
+    if (isIOBufferObj())
+        typeInfo->setFlag(ObjTypeInfo::STATIC_OBJ);
+    else {
+        typeInfo->setFlag(ObjTypeInfo::HEAP_OBJ);
+        typeInfo->setFlag(ObjTypeInfo::HASPTR_OBJ);
+    }
 }
 
 /*!
@@ -241,6 +245,13 @@ MemObj::MemObj(SymID id, const Type* type) :
  */
 bool MemObj::isBlackHoleObj() const {
     return SymbolTableInfo::isBlkObj(GSymID);
+}
+
+/*!
+ * Whether it is an I/O buffer object
+ */
+bool MemObj::isIOBufferObj() const {
+    return SymbolTableInfo::isIOBufferObj(GSymID);
 }
 
 

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -118,6 +118,8 @@ void PAGBuilder::initalNode() {
     pag->addConstantObjNode();
     pag->addBlackholePtrNode();
     addNullPtrNode();
+    pag->addIOBufferObjNode();
+    pag->addIOBufferPtrNode();
 
     for (SymbolTableInfo::ValueToIDMapTy::iterator iter =
                 symTable->valSyms().begin(); iter != symTable->valSyms().end();
@@ -164,6 +166,12 @@ void PAGBuilder::initalNode() {
 			}
 		}
     }
+
+    /// add address edge for IO buffer node
+    DBOUT(DPAGBuild, outs() << "add address edge for I/O buffer node\n");
+    NodeID ptr = pag->getIOBufferPtr();
+    NodeID obj = pag->getIOBufferNode();
+    addAddrEdge(obj, ptr);
 
     assert(pag->getTotalNodeNum() >= symTable->getTotalSymNum()
            && "not all node been inititalize!!!");

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -429,7 +429,16 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule) {
 
     // Pointer #3 always represents the null pointer.
     assert(totalSymNum == NullPtr && "Something changed!");
-    symTyMap.insert(std::make_pair(totalSymNum, NullPtr));
+    symTyMap.insert(std::make_pair(totalSymNum++, NullPtr));
+
+    // Object #4 always represents the I/O buffer
+    assert(totalSymNum == IOBufferObj && "Something changed!");
+    symTyMap.insert(std::make_pair(totalSymNum++, IOBufferObj));
+    createIOBufferObj(IOBufferObj);
+
+    // Pointer #5 always represents the pointer points-to I/O buffer
+    assert(totalSymNum == IOBufferPtr && "Something changed!");
+    symTyMap.insert(std::make_pair(totalSymNum, IOBufferPtr));
 
     // Add symbols for all the globals .
     for (SVFModule::global_iterator I = svfModule->global_begin(), E =


### PR DESCRIPTION
Link to issue #199, the data flow of any function who performs I/O operation can be more accurately modeled with an I/O buffer object.

This commit adds `IOBufferObj`(NodeID = 4) and `IOBufferPtr`(NodeID = 5) to the SymbolTable of SVF  combined with necessary methods.

I assume this wouldn't break any other assertion checks in SVF since this new object is only for modeling purpose and no pointer can point to it.

Please feel free to let me know if anything needs to be changed. Thanks!