### PR TITLE
Call buildCHGNodes with SVFFunction as parameter

### DIFF
--- a/lib/SVF-FE/CHA.cpp
+++ b/lib/SVF-FE/CHA.cpp
@@ -91,7 +91,7 @@ void CHGraph::buildCHG() {
 		for (Module::const_global_iterator I = M->global_begin(), E = M->global_end(); I != E; ++I)
 			buildCHGNodes(&(*I));
 		for (Module::const_iterator F = M->begin(), E = M->end(); F != E; ++F)
-			buildCHGNodes(&(*F));
+			buildCHGNodes(LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(&(*F)));
 		for (Module::const_iterator F = M->begin(), E = M->end(); F != E; ++F)
 			buildCHGEdges(LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(&(*F)));
 


### PR DESCRIPTION
https://github.com/SVF-tools/SVF/blob/e3d5175d50ee9219a607685b39d0b86014329dd8/lib/SVF-FE/CHA.cpp#L136
never gets called since an LLVM Function is passed instead of an SVFFunction, but I assume an SVFFunction is expected.