### PR TITLE
Runtime exception on clean up

### DIFF
--- a/include/SVF-FE/DataFlowUtil.h
+++ b/include/SVF-FE/DataFlowUtil.h
@@ -142,13 +142,19 @@ public:
     /// Destructor
     ~PTACFInfoBuilder() {
         for(FunToLoopInfoMap::iterator it = funToLoopInfoMap.begin(), eit = funToLoopInfoMap.end(); it!=eit; ++it) {
-            delete it->second;
+            if(it->second != nullptr) {
+                delete it->second;
+            }
         }
         for(FunToDTMap::iterator it = funToDTMap.begin(), eit = funToDTMap.end(); it!=eit; ++it) {
-            delete it->second;
+            if(it->second != nullptr) {
+                delete it->second;
+            }
         }
         for(FunToPostDTMap::iterator it = funToPDTMap.begin(), eit = funToPDTMap.end(); it!=eit; ++it) {
-            delete it->second;
+            if(it->second != nullptr) {
+                delete it->second;
+            }
         }
     }
 


### PR DESCRIPTION
I'm not sure what caused this exception to occur in some cases, but it always occurs during the cleanup of SVF for me now. I think it's related to the nodes in the SVFG that I consider "sources" during a source-sink analysis. I haven't dug that deep into it but this is a fix regardless.

![image](https://user-images.githubusercontent.com/62764299/83222125-871f1d00-a145-11ea-851e-38f161943209.png)
