### PR TITLE
Flush some streams.

### DIFF
--- a/include/Graphs/ICFGStat.h
+++ b/include/Graphs/ICFGStat.h
@@ -151,6 +151,7 @@ public:
             std::cout << std::setw(field_width) << it->first << it->second << "\n";
         }
         PTNumStatMap.clear();
+        std::cout.flush();
     }
 };
 

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -497,6 +497,8 @@ public:
                 }
             }
         }
+
+        SVFUtil::outs().flush();
     }
 };
 

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -227,6 +227,8 @@ void BVDataPTAImpl::dumpTopLevelPtsTo()
             }
         }
     }
+
+    outs().flush();
 }
 
 

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -294,6 +294,7 @@ void PTAStat::printStat(string statname)
     }
 
     std::cout << "#######################################################" << std::endl;
+    std::cout.flush();
     generalNumMap.clear();
     PTNumStatMap.clear();
     timeStatMap.clear();

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -753,5 +753,7 @@ void Andersen::dumpTopLevelPtsTo()
             }
         }
     }
+
+    outs().flush();
 }
 


### PR DESCRIPTION
Since two streams are used (`std::cout` and `llvm::outs()`) sometimes things get printed on top of each other, which makes things a bit hard to read.

A more robust solution would probably be to remove `std::cout` or `llvm::outs()` but I'm not sure it's quite as simple.

* `std::cout` has features that `llvm::outs()` doesn't which are used by SVF. This is to the best of my knowledge but I couldn't find an equivalent to `set_width` after taking a quick look, for example.
* `llvm::outs()` is built to be faster.