### PR TITLE
Move some std::map/set to DenseMap/Set.

### DIFF
--- a/include/DDA/DDAPass.h
+++ b/include/DDA/DDAPass.h
@@ -25,7 +25,7 @@ public:
     /// Pass ID
     static char ID;
     typedef SCCDetection<SVFG*> SVFGSCC;
-    typedef std::set<const SVFGEdge*> SVFGEdgeSet;
+    typedef DenseSet<const SVFGEdge*> SVFGEdgeSet;
     typedef std::vector<PointerAnalysis*> PTAVector;
 
     DDAPass() : ModulePass(ID), _pta(NULL), _client(NULL) {}

--- a/include/DDA/DDAVFSolver.h
+++ b/include/DDA/DDAVFSolver.h
@@ -31,7 +31,7 @@ public:
     typedef std::map<DPIm,CVar> DPMToCVarMap;
     typedef std::map<DPIm,DPIm> DPMToDPMMap;
     typedef DenseMap<NodeID, DPTItemSet> LocToDPMVecMap;
-    typedef std::set<const SVFGEdge* > ConstSVFGEdgeSet;
+    typedef DenseSet<const SVFGEdge* > ConstSVFGEdgeSet;
     typedef SVFGEdge::SVFGEdgeSetTy SVFGEdgeSet;
     typedef std::map<const SVFGNode*, DPTItemSet> StoreToPMSetMap;
 

--- a/include/Graphs/ExternalPAG.h
+++ b/include/Graphs/ExternalPAG.h
@@ -21,19 +21,19 @@ class ExternalPAG
 private:
     /// Maps function names to the entry nodes of the extpag which implements
     /// it. This is to connect arguments and callsites.
-    static std::map<const SVFFunction*, std::map<int, PAGNode *>>
+    static DenseMap<const SVFFunction*, DenseMap<int, PAGNode *>>
             functionToExternalPAGEntries;
-    static std::map<const SVFFunction*, PAGNode *> functionToExternalPAGReturns;
+    static DenseMap<const SVFFunction*, PAGNode *> functionToExternalPAGReturns;
 
     /// Name of the function this external PAG represents.
     std::string functionName;
 
     /// Value nodes in this external PAG, represented by NodeIDs
     /// because we will rebuild these nodes in the main PAG.
-    std::set<NodeID> valueNodes;
+    DenseSet<NodeID> valueNodes;
     /// Object nodes in this external PAG, represented by NodeIDs
     /// because we will rebuild these nodes in the main PAG.
-    std::set<NodeID> objectNodes;
+    DenseSet<NodeID> objectNodes;
     /// Edges in this external PAG, represented by the parts of an Edge because
     /// we will rebuild these edges in the main PAG.
     std::set<std::tuple<NodeID, NodeID, std::string, int>>edges;
@@ -42,7 +42,7 @@ private:
 
     /// Nodes in the ExternalPAG which call edges should connect to.
     /// argNodes[0] is arg 0, argNodes[1] is arg 1, ...
-    std::map<int, NodeID> argNodes;
+    DenseMap<int, NodeID> argNodes;
     /// Node from which return edges connect.
     NodeID returnNode;
 
@@ -98,11 +98,11 @@ public:
         return functionName;
     }
 
-    std::set<NodeID> &getValueNodes()
+    DenseSet<NodeID> &getValueNodes()
     {
         return valueNodes;
     }
-    std::set<NodeID> &getObjectNodes()
+    DenseSet<NodeID> &getObjectNodes()
     {
         return objectNodes;
     }
@@ -111,7 +111,7 @@ public:
         return edges;
     }
 
-    std::map<int, NodeID> &getArgNodes()
+    DenseMap<int, NodeID> &getArgNodes()
     {
         return argNodes;
     }

--- a/include/Graphs/ICFG.h
+++ b/include/Graphs/ICFG.h
@@ -48,11 +48,11 @@ public:
     typedef ICFGNodeIDToNodeMapTy::iterator iterator;
     typedef ICFGNodeIDToNodeMapTy::const_iterator const_iterator;
 
-    typedef std::map<const SVFFunction*, FunEntryBlockNode *> FunToFunEntryNodeMapTy;
-    typedef std::map<const SVFFunction*, FunExitBlockNode *> FunToFunExitNodeMapTy;
-    typedef std::map<const Instruction*, CallBlockNode *> CSToCallNodeMapTy;
-    typedef std::map<const Instruction*, RetBlockNode *> CSToRetNodeMapTy;
-    typedef std::map<const Instruction*, IntraBlockNode *> InstToBlockNodeMapTy;
+    typedef DenseMap<const SVFFunction*, FunEntryBlockNode *> FunToFunEntryNodeMapTy;
+    typedef DenseMap<const SVFFunction*, FunExitBlockNode *> FunToFunExitNodeMapTy;
+    typedef DenseMap<const Instruction*, CallBlockNode *> CSToCallNodeMapTy;
+    typedef DenseMap<const Instruction*, RetBlockNode *> CSToRetNodeMapTy;
+    typedef DenseMap<const Instruction*, IntraBlockNode *> InstToBlockNodeMapTy;
 
     NodeID totalICFGNode;
 

--- a/include/Graphs/ICFGNode.h
+++ b/include/Graphs/ICFGNode.h
@@ -60,8 +60,8 @@ public:
 
     typedef ICFGEdge::ICFGEdgeSetTy::iterator iterator;
     typedef ICFGEdge::ICFGEdgeSetTy::const_iterator const_iterator;
-    typedef std::set<const CallPE *> CallPESet;
-    typedef std::set<const RetPE *> RetPESet;
+    typedef DenseSet<const CallPE *> CallPESet;
+    typedef DenseSet<const RetPE *> RetPESet;
     typedef std::list<const VFGNode*> VFGNodeList;
 
 public:

--- a/include/Graphs/ICFGStat.h
+++ b/include/Graphs/ICFGStat.h
@@ -51,7 +51,7 @@ private:
     int numOfIntraEdges;
 
 public:
-    typedef std::set<const ICFGNode *> ICFGNodeSet;
+    typedef DenseSet<const ICFGNode *> ICFGNodeSet;
 
     ICFGStat(ICFG *cfg) : PTAStat(NULL), icfg(cfg)
     {

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -44,31 +44,31 @@ class PAG : public GenericGraph<PAGNode,PAGEdge>
 {
 
 public:
-    typedef std::set<const CallBlockNode*> CallSiteSet;
-    typedef std::map<const CallBlockNode*,NodeID> CallSiteToFunPtrMap;
-    typedef std::map<NodeID,CallSiteSet> FunPtrToCallSitesMap;
+    typedef DenseSet<const CallBlockNode*> CallSiteSet;
+    typedef DenseMap<const CallBlockNode*,NodeID> CallSiteToFunPtrMap;
+    typedef DenseMap<NodeID,CallSiteSet> FunPtrToCallSitesMap;
     typedef DenseMap<NodeID,NodeBS> MemObjToFieldsMap;
-    typedef std::set<const PAGEdge*> PAGEdgeSet;
+    typedef DenseSet<const PAGEdge*> PAGEdgeSet;
     typedef std::list<const PAGEdge*> PAGEdgeList;
     typedef std::list<const PAGNode*> PAGNodeList;
     typedef std::list<const CopyPE*> CopyPEList;
     typedef std::list<const BinaryOPPE*> BinaryOPList;
     typedef std::list<const CmpPE*> CmpPEList;
-    typedef std::map<const PAGNode*,CopyPEList> PHINodeMap;
-    typedef std::map<const PAGNode*,BinaryOPList> BinaryNodeMap;
-    typedef std::map<const PAGNode*,CmpPEList> CmpNodeMap;
+    typedef DenseMap<const PAGNode*,CopyPEList> PHINodeMap;
+    typedef DenseMap<const PAGNode*,BinaryOPList> BinaryNodeMap;
+    typedef DenseMap<const PAGNode*,CmpPEList> CmpNodeMap;
     typedef DenseMap<const SVFFunction*,PAGNodeList> FunToArgsListMap;
-    typedef std::map<const CallBlockNode*,PAGNodeList> CSToArgsListMap;
-    typedef std::map<const RetBlockNode*,const PAGNode*> CSToRetMap;
+    typedef DenseMap<const CallBlockNode*,PAGNodeList> CSToArgsListMap;
+    typedef DenseMap<const RetBlockNode*,const PAGNode*> CSToRetMap;
     typedef DenseMap<const SVFFunction*,const PAGNode*> FunToRetMap;
     typedef DenseMap<const SVFFunction*,PAGEdgeSet> FunToPAGEdgeSetMap;
     typedef DenseMap<const ICFGNode*,PAGEdgeList> Inst2PAGEdgesMap;
-    typedef std::map<NodeID, NodeID> NodeToNodeMap;
+    typedef DenseMap<NodeID, NodeID> NodeToNodeMap;
     typedef std::pair<NodeID, Size_t> NodeOffset;
     typedef std::pair<NodeID, LocationSet> NodeLocationSet;
     typedef DenseMap<NodeOffset,NodeID,DenseMapInfo<std::pair<NodeID,Size_t> > > NodeOffsetMap;
     typedef std::map<NodeLocationSet,NodeID> NodeLocationSetMap;
-    typedef std::map<NodePair,NodeID> NodePairSetMap;
+    typedef DenseMap<NodePair,NodeID> NodePairSetMap;
 
 private:
     SymbolTableInfo* symInfo;

--- a/include/Graphs/PTACallGraph.h
+++ b/include/Graphs/PTACallGraph.h
@@ -197,10 +197,10 @@ public:
     typedef DenseMap<const SVFFunction*, PTACallGraphNode *> FunToCallGraphNodeMap;
     typedef DenseMap<const CallBlockNode*, CallGraphEdgeSet> CallInstToCallGraphEdgesMap;
     typedef std::pair<const CallBlockNode*, const SVFFunction*> CallSitePair;
-    typedef std::map<CallSitePair, CallSiteID> CallSiteToIdMap;
-    typedef std::map<CallSiteID, CallSitePair> IdToCallSiteMap;
-    typedef	std::set<const SVFFunction*> FunctionSet;
-    typedef std::map<const CallBlockNode*, FunctionSet> CallEdgeMap;
+    typedef DenseMap<CallSitePair, CallSiteID> CallSiteToIdMap;
+    typedef DenseMap<CallSiteID, CallSitePair> IdToCallSiteMap;
+    typedef DenseSet<const SVFFunction*> FunctionSet;
+    typedef DenseMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
     typedef CallGraphEdgeSet::iterator CallGraphEdgeIter;
     typedef CallGraphEdgeSet::const_iterator CallGraphEdgeConstIter;
 

--- a/include/Graphs/SVFG.h
+++ b/include/Graphs/SVFG.h
@@ -75,8 +75,8 @@ public:
     typedef NodeBS ActualOUTSVFGNodeSet;
     typedef NodeBS FormalINSVFGNodeSet;
     typedef NodeBS FormalOUTSVFGNodeSet;
-    typedef std::map<const CallBlockNode*, ActualINSVFGNodeSet>  CallSiteToActualINsMapTy;
-    typedef std::map<const CallBlockNode*, ActualOUTSVFGNodeSet>  CallSiteToActualOUTsMapTy;
+    typedef DenseMap<const CallBlockNode*, ActualINSVFGNodeSet>  CallSiteToActualINsMapTy;
+    typedef DenseMap<const CallBlockNode*, ActualOUTSVFGNodeSet>  CallSiteToActualOUTsMapTy;
     typedef DenseMap<const SVFFunction*, FormalINSVFGNodeSet>  FunctionToFormalINsMapTy;
     typedef DenseMap<const SVFFunction*, FormalOUTSVFGNodeSet>  FunctionToFormalOUTsMapTy;
     typedef MemSSA::MUSet MUSet;

--- a/include/Graphs/SVFGEdge.h
+++ b/include/Graphs/SVFGEdge.h
@@ -40,7 +40,7 @@ class IndirectSVFGEdge : public VFGEdge
 {
 
 public:
-    typedef std::set<const MRVer*> MRVerSet;
+    typedef DenseSet<const MRVer*> MRVerSet;
 private:
     MRVerSet mrs;
     PointsTo cpts;

--- a/include/Graphs/SVFGOPT.h
+++ b/include/Graphs/SVFGOPT.h
@@ -52,8 +52,8 @@
  */
 class SVFGOPT : public SVFG
 {
-    typedef std::set<SVFGNode*> SVFGNodeSet;
-    typedef std::map<NodeID, NodeID> NodeIDToNodeIDMap;
+    typedef DenseSet<SVFGNode*> SVFGNodeSet;
+    typedef DenseMap<NodeID, NodeID> NodeIDToNodeIDMap;
     typedef FIFOWorkList<const MSSAPHISVFGNode*> WorkList;
 
 public:

--- a/include/Graphs/SVFGStat.h
+++ b/include/Graphs/SVFGStat.h
@@ -89,8 +89,8 @@ private:
 class SVFGStat : public PTAStat
 {
 public:
-    typedef std::set<const SVFGNode*> SVFGNodeSet;
-    typedef std::set<const SVFGEdge*> SVFGEdgeSet;
+    typedef DenseSet<const SVFGNode*> SVFGNodeSet;
+    typedef DenseSet<const SVFGEdge*> SVFGEdgeSet;
     typedef SCCDetection<SVFG*> SVFGSCC;
 
     SVFGStat(SVFG* g);

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -54,14 +54,14 @@ public:
 
     typedef DenseMap<NodeID, VFGNode *> VFGNodeIDToNodeMapTy;
     typedef DenseMap<const PAGNode*, NodeID> PAGNodeToDefMapTy;
-    typedef std::map<std::pair<NodeID,const CallBlockNode*>, ActualParmVFGNode *> PAGNodeToActualParmMapTy;
+    typedef DenseMap<std::pair<NodeID,const CallBlockNode*>, ActualParmVFGNode *> PAGNodeToActualParmMapTy;
     typedef DenseMap<const PAGNode*, ActualRetVFGNode *> PAGNodeToActualRetMapTy;
     typedef DenseMap<const PAGNode*, FormalParmVFGNode *> PAGNodeToFormalParmMapTy;
     typedef DenseMap<const PAGNode*, FormalRetVFGNode *> PAGNodeToFormalRetMapTy;
-    typedef std::map<const PAGEdge*, StmtVFGNode*> PAGEdgeToStmtVFGNodeMapTy;
-    typedef std::map<const PAGNode*, IntraPHIVFGNode*> PAGNodeToPHIVFGNodeMapTy;
-    typedef std::map<const PAGNode*, BinaryOPVFGNode*> PAGNodeToBinaryOPVFGNodeMapTy;
-    typedef std::map<const PAGNode*, CmpVFGNode*> PAGNodeToCmpVFGNodeMapTy;
+    typedef DenseMap<const PAGEdge*, StmtVFGNode*> PAGEdgeToStmtVFGNodeMapTy;
+    typedef DenseMap<const PAGNode*, IntraPHIVFGNode*> PAGNodeToPHIVFGNodeMapTy;
+    typedef DenseMap<const PAGNode*, BinaryOPVFGNode*> PAGNodeToBinaryOPVFGNodeMapTy;
+    typedef DenseMap<const PAGNode*, CmpVFGNode*> PAGNodeToCmpVFGNodeMapTy;
 
     typedef FormalParmVFGNode::CallPESet CallPESet;
     typedef FormalRetVFGNode::RetPESet RetPESet;
@@ -71,8 +71,8 @@ public:
     typedef VFGNodeIDToNodeMapTy::iterator iterator;
     typedef VFGNodeIDToNodeMapTy::const_iterator const_iterator;
     typedef PAG::PAGEdgeSet PAGEdgeSet;
-    typedef std::set<const VFGNode*> GlobalVFGNodeSet;
-    typedef std::set<const PAGNode*> PAGNodeSet;
+    typedef DenseSet<const VFGNode*> GlobalVFGNodeSet;
+    typedef DenseSet<const PAGNode*> PAGNodeSet;
 
 
 protected:

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -57,8 +57,8 @@ public:
 
     typedef VFGEdge::VFGEdgeSetTy::iterator iterator;
     typedef VFGEdge::VFGEdgeSetTy::const_iterator const_iterator;
-    typedef std::set<const CallPE*> CallPESet;
-    typedef std::set<const RetPE*> RetPESet;
+    typedef DenseSet<const CallPE*> CallPESet;
+    typedef DenseSet<const RetPE*> RetPESet;
 
 public:
     /// Constructor
@@ -306,7 +306,7 @@ public:
 class CmpVFGNode: public VFGNode
 {
 public:
-    typedef std::map<u32_t,const PAGNode*> OPVers;
+    typedef DenseMap<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -377,7 +377,7 @@ public:
 class BinaryOPVFGNode: public VFGNode
 {
 public:
-    typedef std::map<u32_t,const PAGNode*> OPVers;
+    typedef DenseMap<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -485,7 +485,7 @@ class PHIVFGNode : public VFGNode
 {
 
 public:
-    typedef std::map<u32_t,const PAGNode*> OPVers;
+    typedef DenseMap<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;

--- a/include/MSSA/MemPartition.h
+++ b/include/MSSA/MemPartition.h
@@ -71,8 +71,8 @@ class IntraDisjointMRG : public MRGenerator
 {
 public:
     typedef std::map<PointsTo, PointsToList> PtsToSubPtsMap;
-    typedef std::map<const SVFFunction*, PtsToSubPtsMap> FunToPtsMap;
-    typedef std::map<const SVFFunction*, PointsToList> FunToInterMap;
+    typedef DenseMap<const SVFFunction*, PtsToSubPtsMap> FunToPtsMap;
+    typedef DenseMap<const SVFFunction*, PointsToList> FunToInterMap;
 
     IntraDisjointMRG(BVDataPTAImpl* p, bool ptrOnly) : MRGenerator(p, ptrOnly)
     {}

--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -137,7 +137,7 @@ public:
     //@}
     ///Define mem region set
     typedef std::set<const MemRegion*, MemRegion::equalMemRegion> MRSet;
-    typedef std::map<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
+    typedef DenseMap<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
     typedef std::set<PointsTo, MemRegion::equalPointsTo> PointsToList;
     typedef std::map<const SVFFunction*, PointsToList > FunToPointsToMap;
     typedef std::map<PointsTo, PointsTo, MemRegion::equalPointsTo > PtsToRepPtsSetMap;
@@ -156,7 +156,7 @@ public:
     //@{
     typedef DenseMap<const LoadPE*, PointsTo> LoadsToPointsToMap;
     typedef DenseMap<const StorePE*, PointsTo> StoresToPointsToMap;
-    typedef std::map<const CallBlockNode*, PointsTo> CallSiteToPointsToMap;
+    typedef DenseMap<const CallBlockNode*, PointsTo> CallSiteToPointsToMap;
     //@}
 
     /// Maps Mod-Ref analysis
@@ -164,7 +164,7 @@ public:
     /// Map a function to its indirect refs/mods of memory objects
     typedef DenseMap<const SVFFunction*, NodeBS> FunToNodeBSMap;
     /// Map a callsite to its indirect refs/mods of memory objects
-    typedef std::map<const CallBlockNode*, NodeBS> CallSiteToNodeBSMap;
+    typedef DenseMap<const CallBlockNode*, NodeBS> CallSiteToNodeBSMap;
     //@}
 
     typedef std::map<NodeID, NodeBS> NodeToPTSSMap;

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -70,8 +70,8 @@ public:
     //@{
     typedef DenseMap<const LoadPE*, MUSet> LoadToMUSetMap;
     typedef DenseMap<const StorePE*, CHISet> StoreToChiSetMap;
-    typedef std::map<const CallBlockNode*, MUSet> CallSiteToMUSetMap;
-    typedef std::map<const CallBlockNode*, CHISet> CallSiteToCHISetMap;
+    typedef DenseMap<const CallBlockNode*, MUSet> CallSiteToMUSetMap;
+    typedef DenseMap<const CallBlockNode*, CHISet> CallSiteToCHISetMap;
     typedef DenseMap<const BasicBlock*, PHISet> BBToPhiSetMap;
     //@}
 

--- a/include/MemoryModel/MemModel.h
+++ b/include/MemoryModel/MemModel.h
@@ -59,9 +59,9 @@ private:
     /// flattened field offsets of of a struct
     std::vector<u32_t> foffset;
     /// Types of all fields of a struct
-    std::map<u32_t, const llvm::Type*> fldIdx2TypeMap;
+    DenseMap<u32_t, const llvm::Type*> fldIdx2TypeMap;
     /// Types of all fields of a struct
-    std::map<u32_t, const llvm::Type*> offset2TypeMap;
+    DenseMap<u32_t, const llvm::Type*> offset2TypeMap;
     /// All field infos after flattening a struct
     std::vector<FieldInfo> finfo;
 

--- a/include/MemoryModel/PTAStat.h
+++ b/include/MemoryModel/PTAStat.h
@@ -114,9 +114,9 @@ public:
 
     static const char* NumOfNullPointer;	///< Number of pointers points-to null
 
-    typedef std::map<const char*,u32_t> NUMStatMap;
+    typedef DenseMap<const char*,u32_t> NUMStatMap;
 
-    typedef std::map<const char*,double> TIMEStatMap;
+    typedef DenseMap<const char*,double> TIMEStatMap;
 
     PTAStat(PointerAnalysis* p);
     virtual ~PTAStat() {}

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -95,13 +95,13 @@ public:
     /// Indirect call edges type, map a callsite to a set of callees
     //@{
     typedef llvm::AliasAnalysis AliasAnalysis;
-    typedef std::set<const CallBlockNode*> CallSiteSet;
+    typedef DenseSet<const CallBlockNode*> CallSiteSet;
     typedef PAG::CallSiteToFunPtrMap CallSiteToFunPtrMap;
-    typedef	std::set<const SVFFunction*> FunctionSet;
-    typedef std::map<const CallBlockNode*, FunctionSet> CallEdgeMap;
+    typedef DenseSet<const SVFFunction*> FunctionSet;
+    typedef DenseMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
     typedef SCCDetection<PTACallGraph*> CallGraphSCC;
-    typedef std::set<const GlobalValue*> VTableSet;
-    typedef std::set<const SVFFunction*> VFunSet;
+    typedef DenseSet<const GlobalValue*> VTableSet;
+    typedef DenseSet<const SVFFunction*> VFunSet;
     //@}
 
     static const std::string aliasTestMayAlias;

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -178,8 +178,8 @@ public:
     typedef CondVar<Cond> CVar;
     typedef CondStdSet<CVar>  CPtSet;
     typedef PTData<CVar,CPtSet> PTDataTy;	         /// Points-to data structure type
-    typedef std::map<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
-    typedef std::map<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
+    typedef DenseMap<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
+    typedef DenseMap<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
 
     /// Constructor
     CondPTAImpl(PointerAnalysis::PTATY type) : PointerAnalysis(type), normalized(false)

--- a/include/MemoryModel/PointsToDFDS.h
+++ b/include/MemoryModel/PointsToDFDS.h
@@ -45,7 +45,7 @@ public:
     typedef NodeID LocID;
     typedef typename PTData<Key,Data>::PtsMap PtsMap;
     typedef typename PTData<Key,Data>::PtsMapConstIter PtsMapConstIter;
-    typedef std::map<LocID, PtsMap> DFPtsMap;	///< Data-flow point-to map
+    typedef DenseMap<LocID, PtsMap> DFPtsMap;	///< Data-flow point-to map
     typedef typename DFPtsMap::iterator DFPtsMapIter;
     typedef typename DFPtsMap::const_iterator DFPtsMapconstIter;
     typedef typename PTData<Key,Data>::PTDataTY PTDataTy;
@@ -294,7 +294,7 @@ class IncDFPTData : public DFPTData<Key,Data>
 {
 public:
     typedef typename DFPTData<Key,Data>::LocID LocID;
-    typedef std::map<LocID, Data> UpdatedVarMap;	///< for propagating only newly added variable in IN/OUT set
+    typedef DenseMap<LocID, Data> UpdatedVarMap;	///< for propagating only newly added variable in IN/OUT set
     typedef typename UpdatedVarMap::iterator UpdatedVarMapIter;
     typedef typename UpdatedVarMap::const_iterator UpdatedVarconstIter;
     typedef typename PTData<Key,Data>::PTDataTY PTDataTy;

--- a/include/SVF-FE/CHG.h
+++ b/include/SVF-FE/CHG.h
@@ -173,12 +173,12 @@ typedef GenericGraph<CHNode,CHEdge> GenericCHGraphTy;
 class CHGraph: public CommonCHGraph, public GenericCHGraphTy
 {
 public:
-    typedef std::set<const CHNode*> CHNodeSetTy;
+    typedef DenseSet<const CHNode*> CHNodeSetTy;
     typedef FIFOWorkList<const CHNode*> WorkList;
     typedef std::map<std::string, CHNodeSetTy> NameToCHNodesMap;
-    typedef std::map<CallSite, CHNodeSetTy> CallSiteToCHNodesMap;
-    typedef std::map<CallSite, VTableSet> CallSiteToVTableSetMap;
-    typedef std::map<CallSite, VFunSet> CallSiteToVFunSetMap;
+    typedef DenseMap<CallSite, CHNodeSetTy> CallSiteToCHNodesMap;
+    typedef DenseMap<CallSite, VTableSet> CallSiteToVTableSetMap;
+    typedef DenseMap<CallSite, VFunSet> CallSiteToVFunSetMap;
 
     typedef enum
     {
@@ -217,7 +217,7 @@ public:
 
     inline s32_t getVirtualFunctionID(const SVFFunction* vfn) const
     {
-        std::map<const SVFFunction*, s32_t>::const_iterator it =
+        DenseMap<const SVFFunction*, s32_t>::const_iterator it =
             virtualFunctionToIDMap.find(vfn);
         if (it != virtualFunctionToIDMap.end())
             return it->second;
@@ -226,7 +226,7 @@ public:
     }
     inline const SVFFunction* getVirtualFunctionBasedonID(s32_t id) const
     {
-        std::map<const SVFFunction*, s32_t>::const_iterator it, eit;
+        DenseMap<const SVFFunction*, s32_t>::const_iterator it, eit;
         for (it = virtualFunctionToIDMap.begin(), eit =
                     virtualFunctionToIDMap.end(); it != eit; ++it)
         {
@@ -294,7 +294,7 @@ private:
     NameToCHNodesMap templateNameToInstancesMap;
     CallSiteToCHNodesMap csToClassesMap;
 
-    std::map<const SVFFunction*, s32_t> virtualFunctionToIDMap;
+    DenseMap<const SVFFunction*, s32_t> virtualFunctionToIDMap;
     CallSiteToVTableSetMap csToCHAVtblsMap;
     CallSiteToVFunSetMap csToCHAVFnsMap;
 };

--- a/include/SVF-FE/CommonCHG.h
+++ b/include/SVF-FE/CommonCHG.h
@@ -11,8 +11,8 @@
 #ifndef COMMONCHG_H_
 #define COMMONCHG_H_
 
-typedef std::set<const GlobalValue*> VTableSet;
-typedef std::set<const SVFFunction*> VFunSet;
+typedef DenseSet<const GlobalValue*> VTableSet;
+typedef DenseSet<const SVFFunction*> VFunSet;
 
 /// Common base for class hierarchy graph. Only implements what PointerAnalysis needs.
 class CommonCHGraph

--- a/include/SVF-FE/DataFlowUtil.h
+++ b/include/SVF-FE/DataFlowUtil.h
@@ -144,9 +144,9 @@ class PTACFInfoBuilder
 {
 
 public:
-    typedef std::map<const Function*, DominatorTree*> FunToDTMap;  ///< map a function to its dominator tree
-    typedef std::map<const Function*, PostDominatorTree*> FunToPostDTMap;  ///< map a function to its post dominator tree
-    typedef std::map<const Function*, PTALoopInfo*> FunToLoopInfoMap;  ///< map a function to its loop info
+    typedef DenseMap<const Function*, DominatorTree*> FunToDTMap;  ///< map a function to its dominator tree
+    typedef DenseMap<const Function*, PostDominatorTree*> FunToPostDTMap;  ///< map a function to its post dominator tree
+    typedef DenseMap<const Function*, PTALoopInfo*> FunToLoopInfoMap;  ///< map a function to its loop info
 
     /// Constructor
     PTACFInfoBuilder()

--- a/include/SVF-FE/ICFGBuilder.h
+++ b/include/SVF-FE/ICFGBuilder.h
@@ -39,7 +39,7 @@ class ICFGBuilder
 public:
 
     typedef std::vector<const Instruction*> InstVec;
-    typedef std::set<const Instruction*> BBSet;
+    typedef DenseSet<const Instruction*> BBSet;
 
 private:
     ICFG* icfg;

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -39,9 +39,9 @@ class LLVMModuleSet
 public:
 
     typedef std::vector<const SVFFunction*> FunctionSetType;
-    typedef std::map<const SVFFunction*, const SVFFunction*> FunDeclToDefMapTy;
-    typedef std::map<const SVFFunction*, FunctionSetType> FunDefToDeclsMapTy;
-    typedef std::map<const GlobalVariable*, GlobalVariable*> GlobalDefToRepMapTy;
+    typedef DenseMap<const SVFFunction*, const SVFFunction*> FunDeclToDefMapTy;
+    typedef DenseMap<const SVFFunction*, FunctionSetType> FunDefToDeclsMapTy;
+    typedef DenseMap<const GlobalVariable*, GlobalVariable*> GlobalDefToRepMapTy;
 
 private:
     static LLVMModuleSet *llvmModuleSet;

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -53,7 +53,7 @@ public:
     typedef DenseMap<SymID,SYMTYPE> IDToSymTyMapTy;
     /// struct type to struct info map
     typedef DenseMap<const Type*, StInfo*> TypeToFieldInfoMap;
-    typedef std::set<CallSite> CallSiteSet;
+    typedef DenseSet<CallSite> CallSiteSet;
     typedef DenseMap<const Instruction*,CallSiteID> CallSiteToIDMapTy;
     typedef DenseMap<CallSiteID,const Instruction*> IDToCallSiteMapTy;
 

--- a/include/Util/BasicTypes.h
+++ b/include/Util/BasicTypes.h
@@ -217,7 +217,6 @@ using DenseMap = llvm::DenseMap<KeyT, ValueT, KeyInfoT, BucketT>;
 template <typename ValueT, typename ValueInfoT = DenseMapInfo<ValueT>>
 using DenseSet = llvm::DenseSet<ValueT, ValueInfoT>;
 
-
 class SVFFunction : public SVFValue
 {
 private:

--- a/include/Util/ExtAPI.h
+++ b/include/Util/ExtAPI.h
@@ -90,7 +90,7 @@ private:
     //  (hash_map and map are much slower).
     llvm::StringMap<extf_t> info;
     //A cache of is_ext results for all SVFFunction*'s (hash_map is fastest).
-    std::map<const SVFFunction*, bool> isext_cache;
+    DenseMap<const SVFFunction*, bool> isext_cache;
 
     void init();                          //fill in the map (see ExtAPI.cpp)
 
@@ -204,7 +204,7 @@ public:
     {
         assert(F);
         //Check the cache first; everything below is slower.
-        std::map<const SVFFunction*, bool>::iterator i_iec= isext_cache.find(F);
+        DenseMap<const SVFFunction*, bool>::iterator i_iec= isext_cache.find(F);
         if(i_iec != isext_cache.end())
             return i_iec->second;
 

--- a/include/Util/SCC.h
+++ b/include/Util/SCC.h
@@ -111,8 +111,8 @@ public:
         NodeBS _subNodes; /// nodes in the scc represented by this node
     };
 
-    typedef std::map<NodeID,GNodeSCCInfo > GNODESCCInfoMap;
-    typedef std::map<NodeID,NodeID > NodeToNodeMap;
+    typedef DenseMap<NodeID,GNodeSCCInfo > GNODESCCInfoMap;
+    typedef DenseMap<NodeID, NodeID> NodeToNodeMap;
 
     SCCDetection(const GraphType &GT)
         : _graph(GT),

--- a/include/Util/SVFModule.h
+++ b/include/Util/SVFModule.h
@@ -39,7 +39,7 @@ public:
     typedef std::vector<Function*> LLVMFunctionSetType;
     typedef std::vector<GlobalVariable*> GlobalSetType;
     typedef std::vector<GlobalAlias*> AliasSetType;
-    typedef std::map<const Function*,const SVFFunction*> LLVMFun2SVFFunMap;
+    typedef DenseMap<const Function*,const SVFFunction*> LLVMFun2SVFFunMap;
 
     /// Iterators type def
     typedef FunctionSetType::iterator iterator;

--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -50,7 +50,7 @@ class Andersen:  public WPAConstraintSolver, public BVDataPTAImpl
 
 public:
     typedef SCCDetection<ConstraintGraph*> CGSCC;
-    typedef std::map<CallSite, NodeID> CallSite2DummyValPN;
+    typedef DenseMap<CallSite, NodeID> CallSite2DummyValPN;
 
     /// Pass ID
     static char ID;
@@ -422,7 +422,7 @@ class AndersenWaveDiffWithType : public AndersenWaveDiff
 
 private:
 
-    typedef std::map<NodeID, std::set<const GepCGEdge*>> TypeMismatchedObjToEdgeTy;
+    typedef DenseMap<NodeID, DenseSet<const GepCGEdge*>> TypeMismatchedObjToEdgeTy;
 
     TypeMismatchedObjToEdgeTy typeMismatchedObjToEdges;
 
@@ -431,12 +431,12 @@ private:
         TypeMismatchedObjToEdgeTy::iterator it = typeMismatchedObjToEdges.find(obj);
         if (it != typeMismatchedObjToEdges.end())
         {
-            std::set<const GepCGEdge*> &edges = it->second;
+            DenseSet<const GepCGEdge*> &edges = it->second;
             edges.insert(gepEdge);
         }
         else
         {
-            std::set<const GepCGEdge*> edges;
+            DenseSet<const GepCGEdge*> edges;
             edges.insert(gepEdge);
             typeMismatchedObjToEdges[obj] = edges;
         }

--- a/include/WPA/FlowSensitive.h
+++ b/include/WPA/FlowSensitive.h
@@ -238,7 +238,7 @@ protected:
     virtual void printCTirAliasStats(void);
 
     /// Fills may/noAliases for the location/pointer pairs in cmp.
-    virtual void countAliases(std::set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases);
+    virtual void countAliases(DenseSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases);
 
     SVFG* svfg;
     ///Get points-to set for a node from data flow IN/OUT set at a statement.

--- a/include/WPA/FlowSensitiveTBHC.h
+++ b/include/WPA/FlowSensitiveTBHC.h
@@ -86,7 +86,7 @@ public:
 protected:
     virtual void backPropagate(NodeID clone) override;
 
-    virtual void countAliases(std::set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases) override;
+    virtual void countAliases(DenseSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases) override;
 
 private:
     /// Determines whether each GEP is for a load or not. Builds gepIsLoad map.

--- a/lib/DDA/DDAClient.cpp
+++ b/lib/DDA/DDAClient.cpp
@@ -140,8 +140,8 @@ void FunptrDDAClient::performStat(PointerAnalysis* pta)
         if(ddaPts.count() >= anderPts.count() || ddaPts.empty())
             continue;
 
-        std::set<const SVFFunction*> ander_vfns;
-        std::set<const SVFFunction*> dda_vfns;
+        DenseSet<const SVFFunction*> ander_vfns;
+        DenseSet<const SVFFunction*> dda_vfns;
         ander->getVFnsFromPts(cbn,anderPts, ander_vfns);
         pta->getVFnsFromPts(cbn,ddaPts, dda_vfns);
 

--- a/lib/Graphs/ExternalPAG.cpp
+++ b/lib/Graphs/ExternalPAG.cpp
@@ -27,9 +27,9 @@ llvm::cl::list<std::string> DumpPAGFunctions("dump-function-pags",
         llvm::cl::CommaSeparated);
 
 
-std::map<const SVFFunction*, std::map<int, PAGNode *>>
+DenseMap<const SVFFunction*, DenseMap<int, PAGNode *>>
         ExternalPAG::functionToExternalPAGEntries;
-std::map<const SVFFunction*, PAGNode *> ExternalPAG::functionToExternalPAGReturns;
+DenseMap<const SVFFunction*, PAGNode *> ExternalPAG::functionToExternalPAGReturns;
 
 std::vector<std::pair<std::string, std::string>>
         ExternalPAG::parseExternalPAGs(llvm::cl::list<std::string> &extpagsArgs)
@@ -79,7 +79,7 @@ bool ExternalPAG::connectCallsiteToExternalPAG(CallSite *cs)
     const SVFFunction* svfFun = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(function);
     if (!hasExternalPAG(svfFun)) return false;
 
-    std::map<int, PAGNode*> argNodes =
+    DenseMap<int, PAGNode*> argNodes =
         functionToExternalPAGEntries[svfFun];
     PAGNode *retNode = functionToExternalPAGReturns[svfFun];
 
@@ -254,9 +254,9 @@ void ExternalPAG::dumpFunctions(std::vector<std::string> functions)
     PAG *pag = PAG::getPAG();
 
     // Naive: first map functions to entries in PAG, then dump them.
-    std::map<const SVFFunction*, std::vector<PAGNode *>> functionToPAGNodes;
+    DenseMap<const SVFFunction*, std::vector<PAGNode *>> functionToPAGNodes;
 
-    std::set<PAGNode *> callDsts;
+    DenseSet<PAGNode *> callDsts;
     for (PAG::iterator it = pag->begin(); it != pag->end(); ++it)
     {
         PAGNode *currNode = it->second;
@@ -300,8 +300,8 @@ void ExternalPAG::dumpFunctions(std::vector<std::string> functions)
         std::string functionName = it->first->getName();
 
         // The final nodes and edges we will print.
-        std::set<PAGNode *> nodes;
-        std::set<PAGEdge *> edges;
+        DenseSet<PAGNode *> nodes;
+        DenseSet<PAGEdge *> edges;
         // The search stack.
         std::stack<PAGNode *> todoNodes;
         // The arguments to the function.
@@ -391,7 +391,7 @@ bool ExternalPAG::addExternalPAG(const SVFFunction* function)
     //        : to map function names to the return node.
 
     // To create the new edges.
-    std::map<NodeID, PAGNode *> extToNewNodes;
+    DenseMap<NodeID, PAGNode *> extToNewNodes;
 
     // Add the value nodes.
     for (auto extNodeIt = this->getValueNodes().begin();
@@ -471,7 +471,7 @@ bool ExternalPAG::addExternalPAG(const SVFFunction* function)
     }
 
     // Record the arg nodes.
-    std::map<int, PAGNode *> argNodes;
+    DenseMap<int, PAGNode *> argNodes;
     for (auto argNodeIt = this->getArgNodes().begin();
             argNodeIt != this->getArgNodes().end(); ++argNodeIt)
     {

--- a/lib/Graphs/SVFGStat.cpp
+++ b/lib/Graphs/SVFGStat.cpp
@@ -390,7 +390,7 @@ void SVFGStat::performSCCStat(SVFGEdgeSet insensitiveCalRetEdges)
     SVFGSCC* svfgSCC = new SVFGSCC(graph);
     svfgSCC->find();
 
-    std::set<NodeID> sccRepNodeSet;
+    DenseSet<NodeID> sccRepNodeSet;
     SVFG::SVFGNodeIDToNodeMapTy::iterator it = graph->begin();
     SVFG::SVFGNodeIDToNodeMapTy::iterator eit = graph->end();
     for (; it != eit; ++it)

--- a/lib/MSSA/MemRegion.cpp
+++ b/lib/MSSA/MemRegion.cpp
@@ -233,10 +233,9 @@ void MRGenerator::collectModRefForCall()
 
     DBOUT(DGENERAL, outs() << pasMsg("\t\tAdd PointsTo to Callsites \n"));
 
-    for(std::set<CallSite>::const_iterator it =  SymbolTableInfo::Symbolnfo()->getCallSiteSet().begin(),
-            eit = SymbolTableInfo::Symbolnfo()->getCallSiteSet().end(); it!=eit; ++it)
+    for (CallSite cs : SymbolTableInfo::Symbolnfo()->getCallSiteSet())
     {
-        const CallBlockNode* callBlockNode = pta->getPAG()->getICFG()->getCallBlockNode((*it).getInstruction());
+        const CallBlockNode* callBlockNode = pta->getPAG()->getICFG()->getCallBlockNode(cs.getInstruction());
         if(hasRefSideEffectOfCallSite(callBlockNode))
         {
             NodeBS refs = getRefSideEffectOfCallSite(callBlockNode);

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -568,7 +568,7 @@ void PointerAnalysis::getVFnsFromPts(const CallBlockNode* cs, const PointsTo &ta
 
     if (chgraph->csHasVtblsBasedonCHA(SVFUtil::getLLVMCallSite(cs->getCallSite())))
     {
-        std::set<const GlobalValue*> vtbls;
+        DenseSet<const GlobalValue*> vtbls;
         const VTableSet &chaVtbls = chgraph->getCSVtblsBasedonCHA(SVFUtil::getLLVMCallSite(cs->getCallSite()));
         for (PointsTo::iterator it = target.begin(), eit = target.end(); it != eit; ++it)
         {

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -237,7 +237,7 @@ void BVDataPTAImpl::dumpTopLevelPtsTo()
  */
 void BVDataPTAImpl::dumpAllPts()
 {
-    std::set<NodeID> pagNodes;
+    DenseSet<NodeID> pagNodes;
     for(PAG::iterator it = pag->begin(), eit = pag->end(); it!=eit; it++)
     {
         pagNodes.insert(it->first);

--- a/lib/SVF-FE/CHG.cpp
+++ b/lib/SVF-FE/CHG.cpp
@@ -718,9 +718,9 @@ void CHGraph::getVFnsFromVtbls(CallSite cs, const VTableSet &vtbls, VFunSet &vir
     size_t idx = getVCallIdx(cs);
     /// get the function name of the virtual callsite
     string funName = getFunNameOfVCallSite(cs);
-    for (VTableSet::iterator it = vtbls.begin(), eit = vtbls.end(); it != eit; ++it)
+    for (const GlobalValue *vt : vtbls)
     {
-        const CHNode *child = getNode(getClassNameFromVtblObj(*it));
+        const CHNode *child = getNode(getClassNameFromVtblObj(vt));
         if (child == NULL)
             continue;
         CHNode::FuncVector vfns;

--- a/lib/SVF-FE/DCHG.cpp
+++ b/lib/SVF-FE/DCHG.cpp
@@ -1134,7 +1134,7 @@ void DCHGraph::print(void)
     SVFUtil::outs() << thickLine;
     unsigned numStructs = 0;
     unsigned largestStruct = 0;
-    std::set<NodeID> nodes;
+    DenseSet<NodeID> nodes;
     for (DCHGraph::const_iterator it = begin(); it != end(); ++it)
     {
         nodes.insert(it->first);

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -249,10 +249,10 @@ void LLVMModuleSet::addSVFMain()
 
 void LLVMModuleSet::buildFunToFunMap()
 {
-    std::set<Function*> funDecls, funDefs;
+    DenseSet<Function*> funDecls, funDefs;
     std::set<string> declNames, defNames, intersectNames;
     typedef std::map<string, Function*> NameToFunDefMapTy;
-    typedef std::map<string, std::set<Function*>> NameToFunDeclsMapTy;
+    typedef std::map<string, DenseSet<Function*>> NameToFunDeclsMapTy;
 
     for (SVFModule::LLVMFunctionSetType::iterator it = svfModule->llvmFunBegin(),
             eit = svfModule->llvmFunEnd(); it != eit; ++it)
@@ -292,7 +292,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
     ///// name to def map
     NameToFunDefMapTy nameToFunDefMap;
-    for (std::set<Function*>::iterator it = funDefs.begin(),
+    for (DenseSet<Function*>::iterator it = funDefs.begin(),
             eit = funDefs.end(); it != eit; ++it)
     {
         Function *fdef = *it;
@@ -304,7 +304,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
     ///// name to decls map
     NameToFunDeclsMapTy nameToFunDeclsMap;
-    for (std::set<Function*>::iterator it = funDecls.begin(),
+    for (DenseSet<Function*>::iterator it = funDecls.begin(),
             eit = funDecls.end(); it != eit; ++it)
     {
         Function *fdecl = *it;
@@ -314,19 +314,19 @@ void LLVMModuleSet::buildFunToFunMap()
         NameToFunDeclsMapTy::iterator mit = nameToFunDeclsMap.find(funName);
         if (mit == nameToFunDeclsMap.end())
         {
-            std::set<Function*> decls;
+            DenseSet<Function*> decls;
             decls.insert(fdecl);
             nameToFunDeclsMap[funName] = decls;
         }
         else
         {
-            std::set<Function*> &decls = mit->second;
+            DenseSet<Function*> &decls = mit->second;
             decls.insert(fdecl);
         }
     }
 
     /// Fun decl --> def
-    for (std::set<Function*>::iterator it = funDecls.begin(),
+    for (DenseSet<Function*>::iterator it = funDecls.begin(),
             eit = funDecls.end(); it != eit; ++it)
     {
         const Function *fdecl = *it;
@@ -340,7 +340,7 @@ void LLVMModuleSet::buildFunToFunMap()
     }
 
     /// Fun def --> decls
-    for (std::set<Function*>::iterator it = funDefs.begin(),
+    for (DenseSet<Function*>::iterator it = funDefs.begin(),
             eit = funDefs.end(); it != eit; ++it)
     {
         const Function *fdef = *it;
@@ -351,7 +351,7 @@ void LLVMModuleSet::buildFunToFunMap()
         if (mit == nameToFunDeclsMap.end())
             continue;
         std::vector<const SVFFunction*>& decls = FunDefToDeclsMap[svfModule->getSVFFunction(fdef)];
-        for (std::set<Function*>::iterator sit = mit->second.begin(),
+        for (DenseSet<Function*>::iterator sit = mit->second.begin(),
                 seit = mit->second.end(); sit != seit; ++sit)
         {
             decls.push_back(svfModule->getSVFFunction(*sit));
@@ -361,7 +361,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
 void LLVMModuleSet::buildGlobalDefToRepMap()
 {
-    typedef std::map<string, std::set<GlobalVariable*>> NameToGlobalsMapTy;
+    typedef std::map<string, DenseSet<GlobalVariable*>> NameToGlobalsMapTy;
     NameToGlobalsMapTy nameToGlobalsMap;
     for (SVFModule::global_iterator it = svfModule->global_begin(),
             eit = svfModule->global_end(); it != eit; ++it)
@@ -373,13 +373,13 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
         NameToGlobalsMapTy::iterator mit = nameToGlobalsMap.find(name);
         if (mit == nameToGlobalsMap.end())
         {
-            std::set<GlobalVariable*> globals;
+            DenseSet<GlobalVariable*> globals;
             globals.insert(global);
             nameToGlobalsMap[name] = globals;
         }
         else
         {
-            std::set<GlobalVariable*> &globals = mit->second;
+            DenseSet<GlobalVariable*> &globals = mit->second;
             globals.insert(global);
         }
     }
@@ -387,9 +387,9 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
     for (NameToGlobalsMapTy::iterator it = nameToGlobalsMap.begin(),
             eit = nameToGlobalsMap.end(); it != eit; ++it)
     {
-        std::set<GlobalVariable*> &globals = it->second;
+        DenseSet<GlobalVariable*> &globals = it->second;
         GlobalVariable *rep = *(globals.begin());
-        std::set<GlobalVariable*>::iterator repit = globals.begin();
+        DenseSet<GlobalVariable*>::iterator repit = globals.begin();
         while (repit != globals.end())
         {
             GlobalVariable *cur = *repit;
@@ -400,7 +400,7 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
             }
             repit++;
         }
-        for (std::set<GlobalVariable*>::iterator sit = globals.begin(),
+        for (DenseSet<GlobalVariable*>::iterator sit = globals.begin(),
                 seit = globals.end(); sit != seit; ++sit)
         {
             GlobalVariable *cur = *sit;

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -125,7 +125,7 @@ void PTAStat::performStat()
     u32_t numOfConstant = 0;
     u32_t fiObjNumber = 0;
     u32_t fsObjNumber = 0;
-    std::set<SymID> memObjSet;
+    DenseSet<SymID> memObjSet;
     for(PAG::iterator it = pag->begin(), eit = pag->end(); it!=eit; ++it)
     {
         PAGNode* node = it->second;
@@ -223,7 +223,7 @@ void PTAStat::callgraphStat()
     unsigned totalEdge = 0;
     unsigned edgeInCycle = 0;
 
-    std::set<NodeID> sccRepNodeSet;
+    DenseSet<NodeID> sccRepNodeSet;
     PTACallGraph::iterator it = graph->begin();
     PTACallGraph::iterator eit = graph->end();
     for (; it != eit; ++it)

--- a/lib/WPA/AndersenStat.cpp
+++ b/lib/WPA/AndersenStat.cpp
@@ -60,7 +60,7 @@ void AndersenStat::collectCycleInfo(ConstraintGraph* consCG)
     _NumOfCycles = 0;
     _NumOfPWCCycles = 0;
     _NumOfNodesInCycles = 0;
-    std::set<NodeID> repNodes;
+    DenseSet<NodeID> repNodes;
     repNodes.clear();
     for(ConstraintGraph::iterator it = consCG->begin(), eit = consCG->end(); it!=eit; ++it)
     {

--- a/lib/WPA/AndersenWaveDiffWithType.cpp
+++ b/lib/WPA/AndersenWaveDiffWithType.cpp
@@ -50,13 +50,13 @@ void AndersenWaveDiffWithType::processTypeMismatchedGep(NodeID obj, const Type *
     TypeMismatchedObjToEdgeTy::iterator it = typeMismatchedObjToEdges.find(obj);
     if (it == typeMismatchedObjToEdges.end())
         return;
-    std::set<const GepCGEdge*> &edges = it->second;
-    std::set<const GepCGEdge*> processed;
+    DenseSet<const GepCGEdge*> &edges = it->second;
+    DenseSet<const GepCGEdge*> processed;
 
     PTAType ptaTy(type);
     NodeBS &nodesOfType = typeSystem->getVarsForType(ptaTy);
 
-    for (std::set<const GepCGEdge*>::iterator nit = edges.begin(), neit = edges.end(); nit != neit; ++nit)
+    for (DenseSet<const GepCGEdge*>::iterator nit = edges.begin(), neit = edges.end(); nit != neit; ++nit)
     {
         if (const NormalGepCGEdge *normalGepEdge = SVFUtil::dyn_cast<NormalGepCGEdge>(*nit))
         {
@@ -69,7 +69,7 @@ void AndersenWaveDiffWithType::processTypeMismatchedGep(NodeID obj, const Type *
         }
     }
 
-    for (std::set<const GepCGEdge*>::iterator nit = processed.begin(), neit = processed.end(); nit != neit; ++nit)
+    for (DenseSet<const GepCGEdge*>::iterator nit = processed.begin(), neit = processed.end(); nit != neit; ++nit)
         edges.erase(*nit);
 }
 

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -700,7 +700,7 @@ void FlowSensitive::printCTirAliasStats(void)
     assert(dchg && "eval-ctir-aliases needs DCHG.");
 
     // < SVFG node ID (loc), PAG node of interest (top-level pointer) >.
-    std::set<std::pair<NodeID, NodeID>> cmpLocs;
+    DenseSet<std::pair<NodeID, NodeID>> cmpLocs;
     for (SVFG::iterator npair = svfg->begin(); npair != svfg->end(); ++npair)
     {
         NodeID loc = npair->first;
@@ -759,7 +759,7 @@ void FlowSensitive::printCTirAliasStats(void)
                  << "  " << "NO  % : " << 100 * ((double)noAliases/(double)(total)) << "\n";
 }
 
-void FlowSensitive::countAliases(std::set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
+void FlowSensitive::countAliases(DenseSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
 {
     for (std::pair<NodeID, NodeID> locPA : cmp)
     {

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -97,7 +97,7 @@ void FlowSensitiveStat::performStat()
 
     u32_t fiObjNumber = 0;
     u32_t fsObjNumber = 0;
-    std::set<SymID> nodeSet;
+    DenseSet<SymID> nodeSet;
     for (PAG::const_iterator nodeIt = pag->begin(), nodeEit = pag->end(); nodeIt != nodeEit; nodeIt++)
     {
         NodeID nodeId = nodeIt->first;

--- a/lib/WPA/FlowSensitiveTBHC.cpp
+++ b/lib/WPA/FlowSensitiveTBHC.cpp
@@ -656,9 +656,9 @@ void FlowSensitiveTBHC::expandFIObjs(const PointsTo& pts, PointsTo& expandedPts)
     }
 }
 
-void FlowSensitiveTBHC::countAliases(std::set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
+void FlowSensitiveTBHC::countAliases(DenseSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
 {
-    std::map<std::pair<NodeID, NodeID>, PointsTo> filteredPts;
+    DenseMap<std::pair<NodeID, NodeID>, PointsTo> filteredPts;
     for (std::pair<NodeID, NodeID> locP : cmp)
     {
         const PointsTo &filterSet = getFilterSet(locP.first);


### PR DESCRIPTION
This affects performance. Some basic examples on my local machine (right column is with `std::*`, left is with `Dense*`):
```
mruby
 Ander: 15.70  26.10
 SVFG : 00.94  00.97
 FS   : 31.05  39.89

du
 Ander: 02.36  03.53
 SVFG : 00.13  00.14
 FS   : 15.07  16.59

```

Some things of note:
* I didn't change everything, just most of what can be changed in WPA and related graphs without too much effort (so no template specialisation as necessary by `Dense*`).
* `NodeToPTSSMap` is specifically unchanged because (I believe) it is being used in such a way that would invalidate a `DenseMap` iterator and cause seg faults (in `MRGenerator::CollectPtsChain`).
* `std::map::[]` still takes a lot of time. I believe the main culprit is `PTSMap`. It would make a big difference to move `PTSMap` to be a `DenseMap`, but it would take some effort; needs some template specialisation.
* Getting the clock takes **a lot** more time than it should. Perhaps an option to only time entire analyses (i.e. `*::analyze`) rather than each operation could be useful.
* Memory doesn't seem too affected (looks better, in fact) but the testing I have done wasn't too extensive.