### PR TITLE
WIP: remember load/store sizes during graphs building

### DIFF
--- a/include/Graphs/PAGEdge.h
+++ b/include/Graphs/PAGEdge.h
@@ -372,7 +372,7 @@ public:
     }
     //@}
     
-    /// Getter & setter for store size. A (-1) size is an unknown store size
+    /// Getter & setter for load size. A (-1) size is an unknown load size
     //@{
     void setLoadSize(const int size) {
         loadSize = size;

--- a/include/Graphs/PAGEdge.h
+++ b/include/Graphs/PAGEdge.h
@@ -304,6 +304,8 @@ private:
     StorePE();                      ///< place holder
     StorePE(const StorePE &);  ///< place holder
     void operator=(const StorePE &); ///< place holder
+    
+    int storeSize = -1; ///< -1 is an unknown store size
 
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -322,6 +324,17 @@ public:
     }
     //@}
 
+    /// Getter & setter for store size. A (-1) size is an unknown store size
+    //@{
+    void setStoreSize(int size){
+        this->storeSize = size;
+    }
+
+    int getStoreSize(){
+        return this->storeSize;
+    }
+    //@}
+    
     /// constructor
     StorePE(PAGNode* s, PAGNode* d, const IntraBlockNode* st) :
         PAGEdge(s, d, makeEdgeFlagWithStoreInst(PAGEdge::Store, st))
@@ -340,6 +353,8 @@ private:
     LoadPE(const LoadPE &);  ///< place holder
     void operator=(const LoadPE &); ///< place holder
 
+    int loadSize = -1;
+
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
@@ -356,7 +371,18 @@ public:
         return edge->getEdgeKind() == PAGEdge::Load;
     }
     //@}
+    
+    /// Getter & setter for store size. A (-1) size is an unknown store size
+    //@{
+    void setLoadSize(int size){
+        this->loadSize = size;
+    }
 
+    int getLoadSize(){
+        return this->loadSize;
+    }
+    //@}
+    
     /// constructor
     LoadPE(PAGNode* s, PAGNode* d) : PAGEdge(s,d,PAGEdge::Load)
     {

--- a/include/Graphs/PAGEdge.h
+++ b/include/Graphs/PAGEdge.h
@@ -326,12 +326,12 @@ public:
 
     /// Getter & setter for store size. A (-1) size is an unknown store size
     //@{
-    void setStoreSize(int size){
-        this->storeSize = size;
+    void setStoreSize(const int size){
+        storeSize = size;
     }
 
-    int getStoreSize(){
-        return this->storeSize;
+    int getStoreSize() const {
+        return storeSize;
     }
     //@}
     
@@ -374,12 +374,12 @@ public:
     
     /// Getter & setter for store size. A (-1) size is an unknown store size
     //@{
-    void setLoadSize(int size){
-        this->loadSize = size;
+    void setLoadSize(const int size) {
+        loadSize = size;
     }
 
-    int getLoadSize(){
-        return this->loadSize;
+    int getLoadSize() const {
+        return loadSize;
     }
     //@}
     

--- a/include/SVF-FE/PAGBuilder.h
+++ b/include/SVF-FE/PAGBuilder.h
@@ -291,14 +291,15 @@ public:
         return edge;
     }
     /// Add Load edge
-    inline LoadPE* addLoadEdge(NodeID src, NodeID dst)
+    inline LoadPE* addLoadEdge(NodeID src, NodeID dst, int size = -1)
     {
         LoadPE *edge = pag->addLoadPE(src, dst);
+        edge->setLoadSize(size);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Store edge
-    inline StorePE* addStoreEdge(NodeID src, NodeID dst)
+    inline StorePE* addStoreEdge(NodeID src, NodeID dst, int size = -1)
     {
         IntraBlockNode* node;
         if(const Instruction* inst = SVFUtil::dyn_cast<Instruction>(curVal))
@@ -306,6 +307,7 @@ public:
         else
             node = NULL;
         StorePE *edge = pag->addStorePE(src, dst, node);
+        edge->setStoreSize(size);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -1028,7 +1028,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
 				if (const LoadInst *load = SVFUtil::dyn_cast<LoadInst>(cs.getArgument(0))) {
 					addStoreEdge(getValueNode(cs.getArgument(1)), getValueNode(load->getPointerOperand()) /*, storeSize */);
 					if (SVFUtil::isa<PointerType>(inst->getType()))
-						addLoadEdge(getValueNode(load->getPointerOperand()), getValueNode(inst));
+						addLoadEdge(getValueNode(load->getPointerOperand()), getValueNode(inst) /*, loadSize */);
 				}
 //				else if (const GetElementPtrInst *gep = SVFUtil::dyn_cast<GetElementPtrInst>(cs.getArgument(0))) {
 //					addStoreEdge(getValueNode(cs.getArgument(1)), getValueNode(cs.getArgument(0)));

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -372,7 +372,8 @@ void PAGBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
             // add gep edge of C1 itself is a constant expression
             processCE(C);
             setCurrentLocation(C, NULL);
-            addStoreEdge(src, field);
+            //int storeSize = SymbolTableInfo::Symbolnfo()->getTypeSizeInBytes(C->getType());
+            addStoreEdge(src, field /*, storeSize */ );
         }
         else
         {
@@ -1025,7 +1026,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
 				/// dst = load base
 				/// store src base
 				if (const LoadInst *load = SVFUtil::dyn_cast<LoadInst>(cs.getArgument(0))) {
-					addStoreEdge(getValueNode(cs.getArgument(1)), getValueNode(load->getPointerOperand()));
+					addStoreEdge(getValueNode(cs.getArgument(1)), getValueNode(load->getPointerOperand()) /*, storeSize */);
 					if (SVFUtil::isa<PointerType>(inst->getType()))
 						addLoadEdge(getValueNode(load->getPointerOperand()), getValueNode(inst));
 				}

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -379,7 +379,7 @@ void PAGBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
         {
             setCurrentLocation(C, NULL);
             //int storeSize = SymbolTableInfo::Symbolnfo()->getTypeSizeInBytes(C->getType());
-			addStoreEdge(src, field /*, storeSize */ );
+            addStoreEdge(src, field /*, storeSize */ );
             /// src should not point to anything yet
             if (C->getType()->isPtrOrPtrVectorTy() && src != pag->getNullPtr())
                 addCopyEdge(pag->getNullPtr(), src);

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -364,7 +364,8 @@ void PAGBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
         if (SVFUtil::isa<GlobalVariable>(C) || SVFUtil::isa<Function>(C))
         {
             setCurrentLocation(C, NULL);
-            addStoreEdge(src, field);
+            //int storeSize = SymbolTableInfo::Symbolnfo()->getTypeSizeInBytes(C->getType());
+            addStoreEdge(src, field /*, storeSize */ );
         }
         else if (SVFUtil::isa<ConstantExpr>(C))
         {
@@ -376,7 +377,8 @@ void PAGBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
         else
         {
             setCurrentLocation(C, NULL);
-            addStoreEdge(src, field);
+            //int storeSize = SymbolTableInfo::Symbolnfo()->getTypeSizeInBytes(C->getType());
+			addStoreEdge(src, field /*, storeSize */ );
             /// src should not point to anything yet
             if (C->getType()->isPtrOrPtrVectorTy() && src != pag->getNullPtr())
                 addCopyEdge(pag->getNullPtr(), src);
@@ -512,7 +514,9 @@ void PAGBuilder::visitLoadInst(LoadInst &inst)
 
     NodeID src = getValueNode(inst.getPointerOperand());
 
-    addLoadEdge(src, dst);
+    int loadSize = SymbolTableInfo::Symbolnfo()->getTypeSizeInBytes(inst.getPointerOperand()->getType());
+
+	addLoadEdge(src, dst, loadSize);
 }
 
 /*!
@@ -529,7 +533,8 @@ void PAGBuilder::visitStoreInst(StoreInst &inst)
 
     NodeID src = getValueNode(inst.getValueOperand());
 
-    addStoreEdge(src, dst);
+    int storeSize = SymbolTableInfo::Symbolnfo()->getTypeSizeInBytes(inst.getValueOperand()->getType());
+	addStoreEdge(src, dst, storeSize);
 
 }
 
@@ -832,7 +837,11 @@ void PAGBuilder::addComplexConsForExt(Value *D, Value *S, u32_t sz)
     std::vector<LocationSet> srcFields;
     std::vector<LocationSet> dstFields;
     const Type *stype = getBaseTypeAndFlattenedFields(S, srcFields);
+    const std::vector<FieldInfo> &sfieldinfo = SymbolTableInfo::Symbolnfo()->getFlattenFieldInfoVec(stype);
+
     const Type *dtype = getBaseTypeAndFlattenedFields(D, dstFields);
+    const std::vector<FieldInfo> &dfieldinfo = SymbolTableInfo::Symbolnfo()->getFlattenFieldInfoVec(dtype);
+
     if(srcFields.size() > dstFields.size())
         fields = dstFields;
     else
@@ -844,14 +853,31 @@ void PAGBuilder::addComplexConsForExt(Value *D, Value *S, u32_t sz)
 
     assert(fields.size() >= sz && "the number of flattened fields is smaller than size");
 
+    /// Use stride pair vector to calculate the size of the element. 
+    /// If it is an array, it will multiply element type size by number of
+    //  elements, otherwise it  will just multiply by one
+    auto calcFldSize = [](const FieldInfo::ElemNumStridePairVec &strideVec, u32_t size){
+        for(auto pair: strideVec)
+            size*= pair.first;
+        return size;
+    };
+    
     //For each field (i), add (Ti = *S + i) and (*D + i = Ti).
     for (u32_t index = 0; index < sz; index++)
     {
         NodeID dField = getGepValNode(D,fields[index],dtype,index);
+        const Type *dtype = dfieldinfo[index].getFlattenElemTy();
+        int storeSize =  calcFldSize(dfieldinfo[index].getElemNumStridePairVect(), 
+                SymbolTableInfo::Symbolnfo()->getTypeSizeInBytes(dtype));
+
         NodeID sField = getGepValNode(S,fields[index],stype,index);
+        const Type *stype = sfieldinfo[index].getFlattenElemTy();
+        int loadSize =  calcFldSize(sfieldinfo[index].getElemNumStridePairVect(), 
+                SymbolTableInfo::Symbolnfo()->getTypeSizeInBytes(stype));
+
         NodeID dummy = pag->addDummyValNode();
-        addLoadEdge(sField,dummy);
-        addStoreEdge(dummy,dField);
+        addLoadEdge(sField,dummy, loadSize);
+        addStoreEdge(dummy,dField, storeSize);
     }
 }
 
@@ -885,7 +911,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 if (vnArg && dummy && obj)
                 {
                     addAddrEdge(obj, dummy);
-                    addStoreEdge(dummy, vnArg);
+                    addStoreEdge(dummy, vnArg /*, storeSize */ );
                 }
             }
             else
@@ -973,7 +999,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 NodeID vnD= getValueNode(cs.getArgument(1));
                 NodeID vnS= getValueNode(cs.getArgument(0));
                 if(vnD && vnS)
-                    addStoreEdge(vnS,vnD);
+                    addStoreEdge(vnS,vnD /*, storeSize */ );
                 break;
             }
             case ExtAPI::EFT_A2R_A1:
@@ -981,7 +1007,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 NodeID vnD= getValueNode(cs.getArgument(2));
                 NodeID vnS= getValueNode(cs.getArgument(1));
                 if(vnD && vnS)
-                    addStoreEdge(vnS,vnD);
+                    addStoreEdge(vnS,vnD /*, storeSize */ );
                 break;
             }
             case ExtAPI::EFT_A4R_A1:
@@ -989,7 +1015,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 NodeID vnD= getValueNode(cs.getArgument(4));
                 NodeID vnS= getValueNode(cs.getArgument(1));
                 if(vnD && vnS)
-                    addStoreEdge(vnS,vnD);
+                    addStoreEdge(vnS,vnD /*, storeSize */ );
                 break;
             }
 			case ExtAPI::EFT_L_A0__A1_A0:
@@ -1030,7 +1056,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 NodeID vnD= getValueNode(cs.getArgument(2));
                 NodeID vnS= getValueNode(cs.getArgument(0));
                 if(vnD && vnS)
-                    addStoreEdge(vnS,vnD);
+                    addStoreEdge(vnS,vnD /*, storeSize */ );
                 break;
             }
             case ExtAPI::EFT_A0R_NEW:
@@ -1079,7 +1105,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                     NodeID vnD = getGepValNode(vArg3, fields[i], type, i);
                     NodeID vnS = getValueNode(vArg1);
                     if(vnD && vnS)
-                        addStoreEdge(vnS,vnD);
+                        addStoreEdge(vnS,vnD /*, storeSize */ );
                 }
                 break;
             }
@@ -1102,7 +1128,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 {
                     NodeID vnS = getGepValNode(vArg, fields[i], type, i);
                     if(vnD && vnS)
-                        addStoreEdge(vnS,vnD);
+                        addStoreEdge(vnS,vnD /*, storeSize */ );
                 }
                 break;
             }
@@ -1112,7 +1138,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 Value *vDst = cs.getArgument(1);
                 NodeID src = pag->getValueNode(vSrc);
                 NodeID dst = pag->getValueNode(vDst);
-                addStoreEdge(src, dst);
+                addStoreEdge(src, dst /*, storeSize */ );
                 break;
             }
             case ExtAPI::CPP_EFT_A0R_A1:
@@ -1122,7 +1148,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 {
                     NodeID vnD = pag->getValueNode(cs.getArgument(0));
                     NodeID vnS = pag->getValueNode(cs.getArgument(1));
-                    addStoreEdge(vnS, vnD);
+                    addStoreEdge(vnS, vnD /*, storeSize */ );
                 }
                 break;
             }
@@ -1135,8 +1161,8 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                     NodeID vnS = getValueNode(cs.getArgument(1));
                     assert(vnD && vnS && "dst or src not exist?");
                     NodeID dummy = pag->addDummyValNode();
-                    addLoadEdge(vnS,dummy);
-                    addStoreEdge(dummy,vnD);
+                    addLoadEdge(vnS,dummy /*, loadSize */ );
+                    addStoreEdge(dummy,vnD /*, storeSize */ );
                 }
                 break;
             }
@@ -1148,7 +1174,7 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                     NodeID vnS = getValueNode(cs.getArgument(1));
                     assert(vnS && "src not exist?");
                     NodeID dummy = pag->addDummyValNode();
-                    addLoadEdge(vnS,dummy);
+                    addLoadEdge(vnS,dummy /*, loadSize */ );
                 }
                 break;
             }


### PR DESCRIPTION
Hello.. 

Following up on our discussion in #232, here is a work in progress PR and I appreciate any feedbacks. 

Especially in following:

- In `addComplexConsForExt`, I am trying to get the total size of each field. Apparently, only utilizing `SymbolTableInfo::getTypeSizeInBytes` return the size for the element itself but not if it was an array. So I wrote a lambda that calculates the size. but I feel there is an easier way? Please let me know. 
- Due to my limited knowledge in SVF, I did not know how to get the size for quite a few of the invocations of `addLoadEdge` & `addStoreEdge` .. but I did left a comment there to point them out and I made the added argument optional for backward compatibility. Any advice here is appreciated. 
- Finally, do we need to propagate this further to VFG? or PAG is the place for it? 

Any feedback is welcomed :) 

Thanks. 