### PR TITLE
Field-insensitivity

### DIFF
--- a/include/Graphs/ConsG.h
+++ b/include/Graphs/ConsG.h
@@ -300,16 +300,6 @@ public:
     {
         return pag->getBaseObjNode(id);
     }
-    inline void setObjFieldInsensitive(NodeID id)
-    {
-        MemObj* mem =  const_cast<MemObj*>(pag->getBaseObj(id));
-        mem->setFieldInsensitive();
-    }
-    inline bool isFieldInsensitiveObj(NodeID id) const
-    {
-        const MemObj* mem =  pag->getBaseObj(id);
-        return mem->isFieldInsensitive();
-    }
     inline bool isSingleFieldObj(NodeID id) const
     {
         const MemObj* mem = pag->getBaseObj(id);

--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -333,7 +333,7 @@ protected:
             NodeBS fldInsenObjs;
             for(NodeBS::iterator pit = pts.begin(), epit = pts.end(); pit!=epit; ++pit)
             {
-                if(consCG->isFieldInsensitiveObj(*pit))
+                if(isFieldInsensitive(*pit))
                     fldInsenObjs.set(*pit);
             }
             for(NodeBS::iterator pit = fldInsenObjs.begin(), epit = fldInsenObjs.end(); pit!=epit; ++pit)

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -53,7 +53,7 @@ void BVDataPTAImpl::expandFIObjs(const PointsTo& pts, PointsTo& expandedPts)
     expandedPts = pts;;
     for(PointsTo::iterator pit = pts.begin(), epit = pts.end(); pit!=epit; ++pit)
     {
-        if(pag->getBaseObjNode(*pit)==*pit)
+        if (pag->getBaseObjNode(*pit) == *pit || isFieldInsensitive(*pit))
         {
             expandedPts |= pag->getAllFieldsObjNode(*pit);
         }

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -301,9 +301,9 @@ bool Andersen::processGepPts(PointsTo& pts, const GepCGEdge* edge)
             /// then set this memory object to be field insensitive
             if (SVFUtil::isa<VariantGepCGEdge>(edge))
             {
-                if (consCG->isFieldInsensitiveObj(ptd) == false)
+                if (isFieldInsensitive(ptd) == false)
                 {
-                    consCG->setObjFieldInsensitive(ptd);
+                    setObjFieldInsensitive(ptd);
                     consCG->addNodeToBeCollapsed(consCG->getBaseObjNode(ptd));
                 }
                 // add the field-insensitive node into pts.
@@ -415,7 +415,7 @@ bool Andersen::collapseNodePts(NodeID nodeId)
     PointsTo ptsClone = nodePts;
     for (PointsTo::iterator ptsIt = ptsClone.begin(), ptsEit = ptsClone.end(); ptsIt != ptsEit; ptsIt++)
     {
-        if (consCG->isFieldInsensitiveObj(*ptsIt))
+        if (isFieldInsensitive(*ptsIt))
             continue;
 
         if (collapseField(*ptsIt))
@@ -441,7 +441,7 @@ bool Andersen::collapseField(NodeID nodeId)
     double start = stat->getClk();
 
     // set base node field-insensitive.
-    consCG->setObjFieldInsensitive(nodeId);
+    setObjFieldInsensitive(nodeId);
 
     // replace all occurrences of each field with the field-insensitive node
     NodeID baseId = consCG->getFIObjNode(nodeId);

--- a/lib/WPA/AndersenStat.cpp
+++ b/lib/WPA/AndersenStat.cpp
@@ -72,7 +72,7 @@ void AndersenStat::collectCycleInfo(ConstraintGraph* consCG)
         {
             NodeID nodeId = *it;
             PAGNode* pagNode = pta->getPAG()->getPAGNode(nodeId);
-            if (SVFUtil::isa<ObjPN>(pagNode) && consCG->isFieldInsensitiveObj(nodeId))
+            if (SVFUtil::isa<ObjPN>(pagNode) && pta->isFieldInsensitive(nodeId))
             {
                 NodeID baseId = consCG->getBaseObjNode(nodeId);
                 clone.reset(nodeId);

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -324,7 +324,7 @@ bool FlowSensitive::propAlongIndirectEdge(const IndirectSVFGEdge* edge)
         if (propVarPtsFromSrcToDst(ptd, src, dst))
             changed = true;
 
-        if (isFIObjNode(ptd))
+        if (isFieldInsensitive(ptd))
         {
             /// If this is a field-insensitive obj, propagate all field node's pts
             const NodeBS& allFields = getAllFieldsObjNode(ptd);
@@ -476,7 +476,7 @@ bool FlowSensitive::processLoad(const LoadSVFGNode* load)
         if (unionPtsFromIn(load, ptd, dstVar))
             changed = true;
 
-        if (isFIObjNode(ptd))
+        if (isFieldInsensitive(ptd))
         {
             /// If the ptd is a field-insensitive node, we should also get all field nodes'
             /// points-to sets and pass them to pagDst.
@@ -656,7 +656,7 @@ void FlowSensitive::updateConnectedNodes(const SVFGEdgeSetTy& edges)
                 if (propVarPtsAfterCGUpdated(ptd, srcNode, dstNode))
                     changed = true;
 
-                if (isFIObjNode(ptd))
+                if (isFieldInsensitive(ptd))
                 {
                     /// If this is a field-insensitive obj, propagate all field node's pts
                     const NodeBS& allFields = getAllFieldsObjNode(ptd);


### PR DESCRIPTION
I thought some more about using `isFIObj` vs. `isFieldInsensitive` in `processLoad`, and I think `isFieldInsensitive` is more appropriate. It appears to me that it is (sound but) imprecise to use `isFIObj`. Although, yes `o` is an alias of `o.f_n`, it is only a partial alias: the two objects don't necessarily point to the same thing. When you are loading from `q` when `pt(q) = { o }`, you are after `o`'s points-to, not `o.f_n`'s, and `o`'s points-to refers to what was stored to `o` (i.e. the 0th offset into `o`).

Another issue is this does not appear to be what is done in Andersen's, so it is inconsistent. With some preliminary testing, I see that FS points-to sets are not all subsets of Andersen points-to sets. In the test cases I tried, this patch fixes it.

There is a problem I'm unsure about: is it possible for propagation to occur on a non-field-insensitive node which *later* becomes field-insensitive? We'd have to backtrack in that case and redo that propagation. **If** any node that will be field-insensitive during FSPTA is marked field-insensitive by Andersen's (thus for the entire duration of FSPTA), this is not a problem. I am, however, unsure of this because of field collapsing which might be causing complications?

I also would have liked to have the field-insensitivity information encoded in the SVFG (e.g., if `o.f_j` is field-insensitive and `l -- o.f_j --> l'` then `l -- o.f_k --> l'`) rather than having the special cases for field-insensitive objects, but I couldn't seem to correctly update the MSSA appropriately, *or* it was actually the problem in the last paragraph.

So in summary,
* `isFieldInsensitive` for `processLoad` is correct I believe (first/second paragraph)
* For propagation's sake, it is more complicated, and maybe it needs to be thought out which guarantees the Andersen's *implementation* provides w.r.t the SVFG and FSPTA, and the solution may not be correct (third paragraph)
* The solution, if correct, is not perfect (fourth paragraph)
* I also updated `expandFIObjects` to account for field-insensitivity and removed the field-insensitivity functions from the constraint graph since they are repetitions of the ones in PTA