### PR TITLE
Make SVFG optimisation consistent

### DIFF
--- a/lib/Graphs/SVFGOPT.cpp
+++ b/lib/Graphs/SVFGOPT.cpp
@@ -492,7 +492,7 @@ void SVFGOPT::bypassMSSAPHINode(const MSSAPHISVFGNode* node)
     for (; inEdgeIt != inEdgeEit; ++inEdgeIt)
     {
         const SVFGEdge* preEdge = *inEdgeIt;
-        const SVFGNode* src_node = preEdge->getSrcNode();
+        const SVFGNode* srcNode = preEdge->getSrcNode();
 
         bool added = false;
         /// add new edges from predecessor to all successors.
@@ -501,14 +501,15 @@ void SVFGOPT::bypassMSSAPHINode(const MSSAPHISVFGNode* node)
         for (; outEdgeIt != outEdgeEit; ++outEdgeIt)
         {
             const SVFGEdge* succEdge = *outEdgeIt;
-            const SVFGNode* dst_node = (*outEdgeIt)->getDstNode();
-            if (addNewSVFGEdge(src_node->getId(), dst_node->getId(), preEdge, succEdge))
+            const SVFGNode* dstNode = (*outEdgeIt)->getDstNode();
+            if (srcNode->getId() != dstNode->getId()
+                && addNewSVFGEdge(srcNode->getId(), dstNode->getId(), preEdge, succEdge))
                 added = true;
             else
             {
                 /// if no new edge is added, the number of dst node's incoming edges may be decreased.
                 /// try to analyze it again.
-                addIntoWorklist(dst_node);
+                addIntoWorklist(dstNode);
             }
         }
 
@@ -516,7 +517,7 @@ void SVFGOPT::bypassMSSAPHINode(const MSSAPHISVFGNode* node)
         {
             /// if no new edge is added, the number of src node's outgoing edges may be decreased.
             /// try to analyze it again.
-            addIntoWorklist(src_node);
+            addIntoWorklist(srcNode);
         }
     }
 


### PR DESCRIPTION
SVFG optimisation was producing different SVFGs for different runs.

My take on the reason:
`handleIntraValueFlow` solves the worklist in different orders because, despite having an underlying *ordered* data structure, it used pointers as keys (no guarantee of what is allocated where)\* where order will obviously differ. In callee `bypassMSSPHINode`, (meaningless) self-loops are introduced which change what optimisations can be performed (we check for empty in/out edges and self-loop = incoming and outgoing edge). So, because of the differing order of the worklist and introduction of self-loops "blocking" optimisations, inconsistent results are produced each run.

From my testing, I've seen a case where better results are produced than any of the inconsistent runs because a final self-loop is never introduced.

I also changed some snake_case to camelCase.

Unfortunately this does not solve why SVFGOPT FSPTA is producing different results to SVFG FSPTA.

\* Regardless, node IDs are inconsistent run to run. This patch doesn't address that. I suspect it might be due to unordered data structures somewhere.