### PR TITLE
Various Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT COMMAND add_llvm_library)
         include(AddLLVM)
 
         add_definitions(${LLVM_DEFINITIONS})
-        include_directories(${LLVM_INCLUDE_DIRS})
+        include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 
     else()
         message(FATAL_ERROR "\

--- a/include/DDA/DDAClient.h
+++ b/include/DDA/DDAClient.h
@@ -27,7 +27,7 @@ public:
 
     virtual ~DDAClient() {}
 
-    virtual inline void initialise(SVFModule* module) {}
+    virtual inline void initialise(SVFModule*) {}
 
     /// Collect candidate pointers for query.
     virtual inline NodeSet& collectCandidateQueries(PAG* p)
@@ -49,7 +49,7 @@ public:
     }
 
     /// Call back used by DDAVFSolver.
-    virtual inline void handleStatement(const SVFGNode* stmt, NodeID var) {}
+    virtual inline void handleStatement(const SVFGNode*, NodeID) {}
     /// Set PAG graph.
     inline void setPAG(PAG* g)
     {
@@ -73,9 +73,9 @@ public:
     }
     virtual void answerQueries(PointerAnalysis* pta);
 
-    virtual inline void performStat(PointerAnalysis* pta) {}
+    virtual inline void performStat(PointerAnalysis*) {}
 
-    virtual inline void collectWPANum(SVFModule* mod) {}
+    virtual inline void collectWPANum(SVFModule*) {}
 protected:
     void addCandidate(NodeID id)
     {

--- a/include/DDA/DDAVFSolver.h
+++ b/include/DDA/DDAVFSolver.h
@@ -409,7 +409,7 @@ protected:
         unionDDAPts(pts,findPT(dpm));
     }
     /// whether load and store are aliased
-    virtual bool isMustAlias(const DPIm& loadDpm, const DPIm& storeDPm)
+    virtual bool isMustAlias(const DPIm&, const DPIm&)
     {
         return false;
     }
@@ -492,12 +492,12 @@ protected:
     /// Get conservative points-to results when the query is out of budget
     virtual CPtSet getConservativeCPts(const DPIm& dpm) = 0;
     /// Handle condition for context or path analysis (backward analysis)
-    virtual inline bool handleBKCondition(DPIm& oldDpm, const SVFGEdge* edge)
+    virtual inline bool handleBKCondition(DPIm&, const SVFGEdge*)
     {
         return true;
     }
     /// Update call graph
-    virtual inline void updateCallGraphAndSVFG(const DPIm& dpm,const CallBlockNode* cs,SVFGEdgeSet& svfgEdges) {}
+    virtual inline void updateCallGraphAndSVFG(const DPIm&, const CallBlockNode*, SVFGEdgeSet&) {}
     //@}
 
     ///Visited flags to avoid cycles
@@ -605,7 +605,7 @@ protected:
     }
     /// Check heap and array object
     //@{
-    virtual inline bool isHeapCondMemObj(const CVar& var, const StoreSVFGNode* store)
+    virtual inline bool isHeapCondMemObj(const CVar& var, const StoreSVFGNode*)
     {
         const MemObj* mem = _pag->getObject(getPtrNodeID(var));
         assert(mem && "memory object is null??");

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -46,9 +46,9 @@ public:
 private:
     static LLVMModuleSet *llvmModuleSet;
     SVFModule* svfModule;
-    u32_t moduleNum;
-    LLVMContext *cxts;
-    std::unique_ptr<Module> *modules;
+    std::unique_ptr<LLVMContext> cxts;
+    std::vector<std::unique_ptr<Module>> owned_modules;
+    std::vector<std::reference_wrapper<Module>> modules;
 
     /// Function declaration to function definition map
     FunDeclToDefMapTy FunDeclToDefMap;
@@ -58,7 +58,9 @@ private:
     GlobalDefToRepMapTy GlobalDefToRepMap;
 
     /// Constructor
-    LLVMModuleSet(): svfModule(NULL), moduleNum(0), cxts(NULL), modules(NULL) {}
+    LLVMModuleSet(): svfModule(nullptr), cxts(nullptr) {}
+
+    void build();
 
 public:
     static inline LLVMModuleSet *getLLVMModuleSet()
@@ -78,23 +80,21 @@ public:
     SVFModule* buildSVFModule(Module &mod);
     SVFModule* buildSVFModule(const std::vector<std::string> &moduleNameVec);
 
-    void build(const std::vector<std::string> &moduleNameVec);
 
     u32_t getModuleNum() const
     {
-        return moduleNum;
+        return modules.size();
     }
 
     Module *getModule(u32_t idx) const
     {
-        assert(idx < moduleNum && "Out of range.");
-        return modules[idx].get();
+        return &getModuleRef(idx);
     }
 
     Module &getModuleRef(u32_t idx) const
     {
-        assert(idx < moduleNum && "Out of range.");
-        return *(modules[idx].get());
+        assert(idx < getModuleNum() && "Out of range.");
+        return modules[idx];
     }
 
     // Dump modules to files

--- a/include/SVF-FE/LLVMUtil.h
+++ b/include/SVF-FE/LLVMUtil.h
@@ -42,7 +42,7 @@ namespace SVFUtil
 
 
 /// This function servers a allocation wrapper detector
-inline bool isAnAllocationWraper(const Instruction *inst)
+inline bool isAnAllocationWraper(const Instruction*)
 {
     return false;
 }

--- a/include/SVF-FE/PAGBuilder.h
+++ b/include/SVF-FE/PAGBuilder.h
@@ -168,7 +168,7 @@ public:
     void visitCmpInst(CmpInst &I);
 
     /// TODO: do we need to care about these corner cases?
-    void visitVAArgInst(VAArgInst &I)
+    void visitVAArgInst(VAArgInst&)
     {
     }
     void visitExtractElementInst(ExtractElementInst &I);
@@ -187,10 +187,10 @@ public:
     }
 
     /// Instruction not that often
-    void visitResumeInst(ResumeInst &I)   /*returns void*/
+    void visitResumeInst(ResumeInst&)   /*returns void*/
     {
     }
-    void visitUnreachableInst(UnreachableInst &I)   /*returns void*/
+    void visitUnreachableInst(UnreachableInst&)   /*returns void*/
     {
     }
     void visitFenceInst(FenceInst &I)   /*returns void*/
@@ -207,7 +207,7 @@ public:
     }
 
     /// Provide base case for our instruction visit.
-    inline void visitInstruction(Instruction &I)
+    inline void visitInstruction(Instruction&)
     {
         // If a new instruction is added to LLVM that we don't handle.
         // TODO: ignore here:

--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -114,17 +114,10 @@ inline bool cmpPts (const PointsTo& lpts,const PointsTo& rpts)
 }
 
 
-/// Return true if this function is llvm dbg intrinsic function/instruction
-//@{
-inline bool isIntrinsicDbgFun(const Function* fun)
+/// Return true if it is an intrinsic instruction
+inline bool isIntrinsicInst(const Instruction* inst)
 {
-    return fun->getName().startswith("llvm.dbg.declare") ||
-           fun->getName().startswith("llvm.dbg.value");
-}
-/// Return true if it is an intric debug instruction
-inline bool isInstrinsicDbgInst(const Instruction* inst)
-{
-    return SVFUtil::isa<llvm::DbgInfoIntrinsic>(inst);
+    return SVFUtil::isa<llvm::IntrinsicInst>(inst);
 }
 //@}
 
@@ -136,7 +129,7 @@ inline bool isCallSite(const Instruction* inst)
 /// Whether an instruction is a callsite in the application code, excluding llvm intrinsic calls
 inline bool isNonInstricCallSite(const Instruction* inst)
 {
-    if(isInstrinsicDbgInst(inst))
+    if(isIntrinsicInst(inst))
         return false;
     return isCallSite(inst);
 }

--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -667,7 +667,7 @@ private:
 
 public:
     AndersenHLCD(PAG* _pag, PTATY type = AndersenHLCD_WPA) :
-        AndersenHCD(_pag, type), AndersenLCD(_pag, type), Andersen(_pag, type)
+        Andersen(_pag, type), AndersenHCD(_pag, type), AndersenLCD(_pag, type)
     {
     }
 

--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -459,7 +459,7 @@ private:
     //@}
 
 public:
-    AndersenWaveDiffWithType(PAG* _pag, PTATY type = AndersenWaveDiffWithType_WPA): AndersenWaveDiff(pag,type)
+    AndersenWaveDiffWithType(PAG* _pag, PTATY type = AndersenWaveDiffWithType_WPA): AndersenWaveDiff(_pag,type)
     {
         assert(getTypeSystem()!=NULL && "a type system is required for this pointer analysis");
     }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,8 +16,9 @@ file (GLOB SOURCES
 add_llvm_library(Svf STATIC ${SOURCES})
 
 link_directories( ${CMAKE_BINARY_DIR}/lib/Cudd )
-llvm_map_components_to_libnames(llvm_libs bitwriter core ipo irreader instcombine instrumentation target linker analysis scalaropts support )
-target_link_libraries(Cudd)
+llvm_map_components_to_libnames(llvm_libs bitwriter core ipo irreader instcombine instrumentation target linker analysis scalaropts support transformutils)
+target_link_libraries(Svf Cudd)
+target_link_libraries(Svf ${llvm_libs})
 
 
 if(DEFINED IN_SOURCE_BUILD)

--- a/lib/CUDD/CMakeLists.txt
+++ b/lib/CUDD/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
 )
 
 add_llvm_library(Cudd ${SOURCES})
+target_link_libraries(Cudd m)
 
 set_target_properties(Cudd PROPERTIES COMPILE_FLAGS "-Wno-format -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -O3 -w -DHAVE_IEEE_754 -DSIZEOF_VOID_P=8 -DSIZEOF_LONG=8")
 

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -42,14 +42,19 @@ static llvm::cl::opt<bool> DumpLLVMInst("dump-inst", llvm::cl::init(false),
 FunEntryBlockNode::FunEntryBlockNode(NodeID id, const SVFFunction* f) : InterBlockNode(id, FunEntryBlock)
 {
     fun = f;
-    bb = &(f->getLLVMFun()->getEntryBlock());
-
+    // if function is implemented
+    if (f->getLLVMFun()->begin() != f->getLLVMFun()->end()) {
+        bb = &(f->getLLVMFun()->getEntryBlock());
+    }
 }
 
 FunExitBlockNode::FunExitBlockNode(NodeID id, const SVFFunction* f) : InterBlockNode(id, FunExitBlock), fun(f), formalRet(NULL)
 {
     fun = f;
-    bb = SVFUtil::getFunExitBB(f->getLLVMFun());
+    // if function is implemented
+    if (f->getLLVMFun()->begin() != f->getLLVMFun()->end()) {
+        bb = SVFUtil::getFunExitBB(f->getLLVMFun());
+    }
 
 }
 

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -164,9 +164,9 @@ ICFGNode* ICFG::getBlockICFGNode(const Instruction* inst)
     ICFGNode* node;
     if(SVFUtil::isNonInstricCallSite(inst))
         node = getCallBlockNode(inst);
-    else if(SVFUtil::isInstrinsicDbgInst(inst))
+    else if(SVFUtil::isIntrinsicInst(inst))
         node = getIntraBlockNode(inst);
-//			assert (false && "associating an intrinsic debug instruction with an ICFGNode!");
+//			assert (false && "associating an intrinsic instruction with an ICFGNode!");
     else
         node = getIntraBlockNode(inst);
 

--- a/lib/SVF-FE/ICFGBuilder.cpp
+++ b/lib/SVF-FE/ICFGBuilder.cpp
@@ -60,7 +60,7 @@ void ICFGBuilder::processFunEntry(const SVFFunction*  fun, WorkList& worklist)
     FunEntryBlockNode* FunEntryBlockNode = getOrAddFunEntryICFGNode(fun);
     const Instruction* entryInst = &((fun->getLLVMFun()->getEntryBlock()).front());
     InstVec insts;
-    if (isInstrinsicDbgInst(entryInst))
+    if (isIntrinsicInst(entryInst))
         getNextInsts(entryInst, insts);
     else
         insts.push_back(entryInst);
@@ -124,7 +124,7 @@ void ICFGBuilder::processFunExit(const SVFFunction*  fun)
     FunExitBlockNode* FunExitBlockNode = getOrAddFunExitICFGNode(fun);
     const Instruction* exitInst = &(getFunExitBB(fun->getLLVMFun())->back());
     InstVec insts;
-    if (isInstrinsicDbgInst(exitInst))
+    if (isIntrinsicInst(exitInst))
         getPrevInsts(exitInst, insts);
     else
         insts.push_back(exitInst);

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -63,14 +63,9 @@ std::string SVFModule::pagReadFromTxt = "";
 SVFModule* LLVMModuleSet::buildSVFModule(Module &mod)
 {
     svfModule = new SVFModule(mod.getModuleIdentifier());
-    moduleNum = 1;
-    cxts = &(mod.getContext());
-    modules = new unique_ptr<Module>[moduleNum];
-    modules[0] = std::unique_ptr<Module>(&mod);
+    modules.emplace_back(mod);
 
-    initialize();
-    buildFunToFunMap();
-    buildGlobalDefToRepMap();
+    build();
 
     return svfModule;
 }
@@ -93,35 +88,34 @@ SVFModule* LLVMModuleSet::buildSVFModule(const std::vector<std::string> &moduleN
     else
         SVFModule::setPagFromTXT(Graphtxt.getValue());
 
-    if(moduleNameVec.empty()==false)
+    if(!moduleNameVec.empty())
         svfModule = new SVFModule(*moduleNameVec.begin());
     else
         svfModule = new SVFModule();
 
-    build(moduleNameVec);
-
-	if (!SVFModule::pagReadFromTXT()) {
-		/// building symbol table
-		DBOUT(DGENERAL,SVFUtil::outs() << SVFUtil::pasMsg("Building Symbol table ...\n"));
-		SymbolTableInfo *symInfo = SymbolTableInfo::Symbolnfo();
-		symInfo->buildMemModel(svfModule);
-	}
+    loadModules(moduleNameVec);
+    build();
 
     return svfModule;
 }
 
-void LLVMModuleSet::build(const vector<string> &moduleNameVec)
+void LLVMModuleSet::build()
 {
-    loadModules(moduleNameVec);
     initialize();
     buildFunToFunMap();
     buildGlobalDefToRepMap();
+
+    if (!SVFModule::pagReadFromTXT()) {
+        /// building symbol table
+        DBOUT(DGENERAL,SVFUtil::outs() << SVFUtil::pasMsg("Building Symbol table ...\n"));
+        SymbolTableInfo *symInfo = SymbolTableInfo::Symbolnfo();
+        symInfo->buildMemModel(svfModule);
+    }
+
 }
 
 void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
 {
-    moduleNum = moduleNameVec.size();
-    //
     // To avoid the following type bugs (t1 != t3) when parsing multiple modules,
     // We should use only one LLVMContext object for multiple modules in the same thread.
     // No such problem if only one module is processed by SVF.
@@ -136,21 +130,20 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
     //    assert(t1 != t3);
     // ------------------------------------------------------------------
     //
-    cxts = new LLVMContext[1];
-    modules = new unique_ptr<Module>[moduleNum];
+    cxts = std::make_unique<LLVMContext>();
 
     u32_t i = 0;
-    for (vector<string>::const_iterator it = moduleNameVec.begin(),
-            eit = moduleNameVec.end(); it != eit; ++it, ++i)
-    {
-        const string moduleName = *it;
+    for (const std::string& moduleName : moduleNameVec) {
         SMDiagnostic Err;
-        modules[i] = parseIRFile(moduleName, Err, cxts[0]);
-        if (!modules[i])
+        std::unique_ptr<Module> mod = parseIRFile(moduleName, Err, *cxts);
+        if (mod == nullptr)
         {
             SVFUtil::errs() << "load module: " << moduleName << "failed!!\n\n";
+            // Err.print("SVFModuleLoader", SVFUtil::errs);
             continue;
         }
+        owned_modules.emplace_back(std::move(mod));
+        modules.emplace_back(*mod);
     }
 }
 
@@ -159,12 +152,10 @@ void LLVMModuleSet::initialize()
     if (SVFMain)
         addSVFMain();
 
-    for (u32_t i = 0; i < moduleNum; ++i)
+    for (Module& mod : modules)
     {
-        Module *mod = modules[i].get();
-
         /// Function
-        for (Module::iterator it = mod->begin(), eit = mod->end();
+        for (Module::iterator it = mod.begin(), eit = mod.end();
                 it != eit; ++it)
         {
             Function *func = &*it;
@@ -172,16 +163,16 @@ void LLVMModuleSet::initialize()
         }
 
         /// GlobalVariable
-        for (Module::global_iterator it = mod->global_begin(),
-                eit = mod->global_end(); it != eit; ++it)
+        for (Module::global_iterator it = mod.global_begin(),
+                eit = mod.global_end(); it != eit; ++it)
         {
             GlobalVariable *global = &*it;
             svfModule->addGlobalSet(global);
         }
 
         /// GlobalAlias
-        for (Module::alias_iterator it = mod->alias_begin(),
-                eit = mod->alias_end(); it != eit; ++it)
+        for (Module::alias_iterator it = mod.alias_begin(),
+                eit = mod.alias_end(); it != eit; ++it)
         {
             GlobalAlias *alias = &*it;
             svfModule->addAliasSet(alias);
@@ -193,11 +184,10 @@ void LLVMModuleSet::addSVFMain()
 {
     std::vector<Function *> init_funcs;
     Function * orgMain = 0;
-    u32_t k = 0;
-    for (u32_t i = 0; i < moduleNum; ++i)
+    Module* mainMod = nullptr;
+    for (Module& mod : modules)
     {
-        Module *mod = modules[i].get();
-        for (auto &func: *mod)
+        for (auto &func: mod)
         {
             if(func.getName().startswith(SVF_GLOBAL_SUB_I_XXX))
                 init_funcs.push_back(&func);
@@ -206,13 +196,14 @@ void LLVMModuleSet::addSVFMain()
             if(func.getName().equals("main"))
             {
                 orgMain = &func;
-                k = i;
+                mainMod = &mod;
             }
         }
     }
-    if(orgMain && moduleNum > 0 && init_funcs.size() > 0)
+    if(orgMain && getModuleNum() > 0 && init_funcs.size() > 0)
     {
-        Module & M = *(modules[k].get());
+        assert(mainMod && "Module with main function not found.");
+        Module & M = *mainMod;
         // char **
         Type * i8ptr2 = PointerType::getInt8PtrTy(M.getContext())->getPointerTo();
         Type * i32 = IntegerType::getInt32Ty(M.getContext());
@@ -420,10 +411,9 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
 // Dump modules to files
 void LLVMModuleSet::dumpModulesToFile(const std::string suffix)
 {
-    for (u32_t i = 0; i < moduleNum; ++i)
+    for (Module& mod : modules)
     {
-        Module *mod = getModule(i);
-        std::string moduleName = mod->getName().str();
+        std::string moduleName = mod.getName().str();
         std::string OutputFilename;
         std::size_t pos = moduleName.rfind('.');
         if (pos != std::string::npos)
@@ -435,9 +425,9 @@ void LLVMModuleSet::dumpModulesToFile(const std::string suffix)
         raw_fd_ostream OS(OutputFilename.c_str(), EC, llvm::sys::fs::F_None);
 
 #if (LLVM_VERSION_MAJOR >= 7)
-        WriteBitcodeToFile(*mod, OS);
-#else
         WriteBitcodeToFile(mod, OS);
+#else
+        WriteBitcodeToFile(&mod, OS);
 #endif
 
         OS.flush();

--- a/lib/SVF-FE/LLVMUtil.cpp
+++ b/lib/SVF-FE/LLVMUtil.cpp
@@ -214,7 +214,7 @@ void SVFUtil::getNextInsts(const Instruction* curInst, std::vector<const Instruc
     if (!curInst->isTerminator())
     {
         const Instruction* nextInst = curInst->getNextNode();
-        if (isInstrinsicDbgInst(nextInst))
+        if (isIntrinsicInst(nextInst))
             getNextInsts(nextInst, instList);
         else
             instList.push_back(nextInst);
@@ -226,7 +226,7 @@ void SVFUtil::getNextInsts(const Instruction* curInst, std::vector<const Instruc
         for (succ_const_iterator it = succ_begin(BB), ie = succ_end(BB); it != ie; ++it)
         {
             const Instruction* nextInst = &((*it)->front());
-            if (isInstrinsicDbgInst(nextInst))
+            if (isIntrinsicInst(nextInst))
                 getNextInsts(nextInst, instList);
             else
                 instList.push_back(nextInst);
@@ -241,7 +241,7 @@ void SVFUtil::getPrevInsts(const Instruction* curInst, std::vector<const Instruc
     if (curInst != &(curInst->getParent()->front()))
     {
         const Instruction* prevInst = curInst->getPrevNode();
-        if (isInstrinsicDbgInst(prevInst))
+        if (isIntrinsicInst(prevInst))
             getPrevInsts(prevInst, instList);
         else
             instList.push_back(prevInst);
@@ -253,7 +253,7 @@ void SVFUtil::getPrevInsts(const Instruction* curInst, std::vector<const Instruc
         for (const_pred_iterator it = pred_begin(BB), ie = pred_end(BB); it != ie; ++it)
         {
             const Instruction* prevInst = &((*it)->back());
-            if (isInstrinsicDbgInst(prevInst))
+            if (isIntrinsicInst(prevInst))
                 getPrevInsts(prevInst, instList);
             else
                 instList.push_back(prevInst);

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -641,8 +641,8 @@ void PAGBuilder::visitSelectInst(SelectInst &inst)
 void PAGBuilder::visitCallSite(CallSite cs)
 {
 
-    // skip llvm debug info intrinsic
-    if(isInstrinsicDbgInst(cs.getInstruction()))
+    // skip llvm intrinsics
+    if(isIntrinsicInst(cs.getInstruction()))
         return;
 
     DBOUT(DPAGBuild,


### PR DESCRIPTION
Some unrelated changes:
- Some fixes of compiler warnings
- Include LLVM with `-isystem` to suppress header warnings
- ICFG: ignore all intrinsics like `lllvm.donothing` not only debug ones
- LLVMModule: change memory handling and unify calls to buildSVFModule, fixes #260 and workaround #269 
- allow building of shared libraries
- ICFG: allow unimplemented functions (that don't have basic blocks)