### PR TITLE
Improve ICFG

### DIFF
--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -114,17 +114,20 @@ inline bool cmpPts (const PointsTo& lpts,const PointsTo& rpts)
 }
 
 
-/// Return true if this function is llvm dbg intrinsic function/instruction
-//@{
-inline bool isIntrinsicDbgFun(const Function* fun)
+/// Return true if it is an intrinsic instruction
+inline bool isIntrinsicInst(const Instruction* inst)
 {
-    return fun->getName().startswith("llvm.dbg.declare") ||
-           fun->getName().startswith("llvm.dbg.value");
-}
-/// Return true if it is an intric debug instruction
-inline bool isInstrinsicDbgInst(const Instruction* inst)
-{
-    return SVFUtil::isa<llvm::DbgInfoIntrinsic>(inst);
+    if (const llvm::CallBase* call = llvm::dyn_cast<llvm::CallBase>(inst)) {
+        const Function* func = call->getCalledFunction();
+        if (func && (func->getIntrinsicID() == llvm::Intrinsic::donothing ||
+                     func->getIntrinsicID() == llvm::Intrinsic::dbg_addr ||
+                     func->getIntrinsicID() == llvm::Intrinsic::dbg_declare ||
+                     func->getIntrinsicID() == llvm::Intrinsic::dbg_label ||
+                     func->getIntrinsicID() == llvm::Intrinsic::dbg_value)) {
+            return true;
+        }
+    }
+    return false;
 }
 //@}
 
@@ -136,7 +139,7 @@ inline bool isCallSite(const Instruction* inst)
 /// Whether an instruction is a callsite in the application code, excluding llvm intrinsic calls
 inline bool isNonInstricCallSite(const Instruction* inst)
 {
-    if(isInstrinsicDbgInst(inst))
+    if(isIntrinsicInst(inst))
         return false;
     return isCallSite(inst);
 }

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -42,14 +42,19 @@ static llvm::cl::opt<bool> DumpLLVMInst("dump-inst", llvm::cl::init(false),
 FunEntryBlockNode::FunEntryBlockNode(NodeID id, const SVFFunction* f) : InterBlockNode(id, FunEntryBlock)
 {
     fun = f;
-    bb = &(f->getLLVMFun()->getEntryBlock());
-
+    // if function is implemented
+    if (f->getLLVMFun()->begin() != f->getLLVMFun()->end()) {
+        bb = &(f->getLLVMFun()->getEntryBlock());
+    }
 }
 
 FunExitBlockNode::FunExitBlockNode(NodeID id, const SVFFunction* f) : InterBlockNode(id, FunExitBlock), fun(f), formalRet(NULL)
 {
     fun = f;
-    bb = SVFUtil::getFunExitBB(f->getLLVMFun());
+    // if function is implemented
+    if (f->getLLVMFun()->begin() != f->getLLVMFun()->end()) {
+        bb = SVFUtil::getFunExitBB(f->getLLVMFun());
+    }
 
 }
 

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -169,9 +169,9 @@ ICFGNode* ICFG::getBlockICFGNode(const Instruction* inst)
     ICFGNode* node;
     if(SVFUtil::isNonInstricCallSite(inst))
         node = getCallBlockNode(inst);
-    else if(SVFUtil::isInstrinsicDbgInst(inst))
+    else if(SVFUtil::isIntrinsicInst(inst))
         node = getIntraBlockNode(inst);
-//			assert (false && "associating an intrinsic debug instruction with an ICFGNode!");
+//			assert (false && "associating an intrinsic instruction with an ICFGNode!");
     else
         node = getIntraBlockNode(inst);
 

--- a/lib/SVF-FE/ICFGBuilder.cpp
+++ b/lib/SVF-FE/ICFGBuilder.cpp
@@ -60,7 +60,7 @@ void ICFGBuilder::processFunEntry(const SVFFunction*  fun, WorkList& worklist)
     FunEntryBlockNode* FunEntryBlockNode = getOrAddFunEntryICFGNode(fun);
     const Instruction* entryInst = &((fun->getLLVMFun()->getEntryBlock()).front());
     InstVec insts;
-    if (isInstrinsicDbgInst(entryInst))
+    if (isIntrinsicInst(entryInst))
         getNextInsts(entryInst, insts);
     else
         insts.push_back(entryInst);
@@ -124,7 +124,7 @@ void ICFGBuilder::processFunExit(const SVFFunction*  fun)
     FunExitBlockNode* FunExitBlockNode = getOrAddFunExitICFGNode(fun);
     const Instruction* exitInst = &(getFunExitBB(fun->getLLVMFun())->back());
     InstVec insts;
-    if (isInstrinsicDbgInst(exitInst))
+    if (isIntrinsicInst(exitInst))
         getPrevInsts(exitInst, insts);
     else
         insts.push_back(exitInst);

--- a/lib/SVF-FE/LLVMUtil.cpp
+++ b/lib/SVF-FE/LLVMUtil.cpp
@@ -214,7 +214,7 @@ void SVFUtil::getNextInsts(const Instruction* curInst, std::vector<const Instruc
     if (!curInst->isTerminator())
     {
         const Instruction* nextInst = curInst->getNextNode();
-        if (isInstrinsicDbgInst(nextInst))
+        if (isIntrinsicInst(nextInst))
             getNextInsts(nextInst, instList);
         else
             instList.push_back(nextInst);
@@ -226,7 +226,7 @@ void SVFUtil::getNextInsts(const Instruction* curInst, std::vector<const Instruc
         for (succ_const_iterator it = succ_begin(BB), ie = succ_end(BB); it != ie; ++it)
         {
             const Instruction* nextInst = &((*it)->front());
-            if (isInstrinsicDbgInst(nextInst))
+            if (isIntrinsicInst(nextInst))
                 getNextInsts(nextInst, instList);
             else
                 instList.push_back(nextInst);
@@ -241,7 +241,7 @@ void SVFUtil::getPrevInsts(const Instruction* curInst, std::vector<const Instruc
     if (curInst != &(curInst->getParent()->front()))
     {
         const Instruction* prevInst = curInst->getPrevNode();
-        if (isInstrinsicDbgInst(prevInst))
+        if (isIntrinsicInst(prevInst))
             getPrevInsts(prevInst, instList);
         else
             instList.push_back(prevInst);
@@ -253,7 +253,7 @@ void SVFUtil::getPrevInsts(const Instruction* curInst, std::vector<const Instruc
         for (const_pred_iterator it = pred_begin(BB), ie = pred_end(BB); it != ie; ++it)
         {
             const Instruction* prevInst = &((*it)->back());
-            if (isInstrinsicDbgInst(prevInst))
+            if (isIntrinsicInst(prevInst))
                 getPrevInsts(prevInst, instList);
             else
                 instList.push_back(prevInst);

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -641,8 +641,8 @@ void PAGBuilder::visitSelectInst(SelectInst &inst)
 void PAGBuilder::visitCallSite(CallSite cs)
 {
 
-    // skip llvm debug info intrinsic
-    if(isInstrinsicDbgInst(cs.getInstruction()))
+    // skip llvm intrinsics
+    if(isIntrinsicInst(cs.getInstruction()))
         return;
 
     DBOUT(DPAGBuild,


### PR DESCRIPTION
This PR contains two changes for the ICFG:
- It ignores all intrinsics now, not just calls to `llvm.dbg.` but also calls to e.g. `llvm.donothing` etc.
- It does not fail anymore, if a function is not implemented (i.e. does not have any BasicBlock).