### PR TITLE
LLVMModule: fix memory handling

### DIFF
--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -60,6 +60,8 @@ private:
     /// Constructor
     LLVMModuleSet(): svfModule(nullptr), moduleNum(0), cxts(nullptr), modules(NULL) {}
 
+    void build(const std::vector<std::string> &moduleNameVec);
+
 public:
     static inline LLVMModuleSet *getLLVMModuleSet()
     {
@@ -77,8 +79,6 @@ public:
 
     SVFModule* buildSVFModule(Module &mod);
     SVFModule* buildSVFModule(const std::vector<std::string> &moduleNameVec);
-
-    void build(const std::vector<std::string> &moduleNameVec);
 
     u32_t getModuleNum() const
     {

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -47,7 +47,8 @@ private:
     static LLVMModuleSet *llvmModuleSet;
     SVFModule* svfModule;
     std::unique_ptr<LLVMContext> cxts;
-    std::vector<std::unique_ptr<Module>> modules;
+    std::vector<std::unique_ptr<Module>> owned_modules;
+    std::vector<std::reference_wrapper<Module>> modules;
 
     /// Function declaration to function definition map
     FunDeclToDefMapTy FunDeclToDefMap;
@@ -92,7 +93,7 @@ public:
     Module &getModuleRef(u32_t idx) const
     {
         assert(idx < getModuleNum() && "Out of range.");
-        return *(modules[idx].get());
+        return modules[idx];
     }
 
     // Dump modules to files

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -86,8 +86,7 @@ public:
 
     Module *getModule(u32_t idx) const
     {
-        assert(idx < getModuleNum() && "Out of range.");
-        return modules[idx].get();
+        return &getModuleRef(idx);
     }
 
     Module &getModuleRef(u32_t idx) const

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -48,7 +48,7 @@ private:
     SVFModule* svfModule;
     std::unique_ptr<LLVMContext> cxts;
     u32_t moduleNum;
-    std::unique_ptr<Module> *modules;
+    std::vector<std::unique_ptr<Module>> modules;
 
     /// Function declaration to function definition map
     FunDeclToDefMapTy FunDeclToDefMap;
@@ -58,7 +58,7 @@ private:
     GlobalDefToRepMapTy GlobalDefToRepMap;
 
     /// Constructor
-    LLVMModuleSet(): svfModule(nullptr), moduleNum(0), cxts(nullptr), modules(NULL) {}
+    LLVMModuleSet(): svfModule(nullptr), moduleNum(0), cxts(nullptr) {}
 
     void build(const std::vector<std::string> &moduleNameVec);
 

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -47,7 +47,6 @@ private:
     static LLVMModuleSet *llvmModuleSet;
     SVFModule* svfModule;
     std::unique_ptr<LLVMContext> cxts;
-    u32_t moduleNum;
     std::vector<std::unique_ptr<Module>> modules;
 
     /// Function declaration to function definition map
@@ -58,7 +57,7 @@ private:
     GlobalDefToRepMapTy GlobalDefToRepMap;
 
     /// Constructor
-    LLVMModuleSet(): svfModule(nullptr), moduleNum(0), cxts(nullptr) {}
+    LLVMModuleSet(): svfModule(nullptr), cxts(nullptr) {}
 
     void build(const std::vector<std::string> &moduleNameVec);
 
@@ -82,18 +81,18 @@ public:
 
     u32_t getModuleNum() const
     {
-        return moduleNum;
+        return modules.size();
     }
 
     Module *getModule(u32_t idx) const
     {
-        assert(idx < moduleNum && "Out of range.");
+        assert(idx < getModuleNum() && "Out of range.");
         return modules[idx].get();
     }
 
     Module &getModuleRef(u32_t idx) const
     {
-        assert(idx < moduleNum && "Out of range.");
+        assert(idx < getModuleNum() && "Out of range.");
         return *(modules[idx].get());
     }
 

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -60,7 +60,7 @@ private:
     /// Constructor
     LLVMModuleSet(): svfModule(nullptr), cxts(nullptr) {}
 
-    void build(const std::vector<std::string> &moduleNameVec);
+    void build();
 
 public:
     static inline LLVMModuleSet *getLLVMModuleSet()

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -46,8 +46,8 @@ public:
 private:
     static LLVMModuleSet *llvmModuleSet;
     SVFModule* svfModule;
+    std::unique_ptr<LLVMContext> cxts;
     u32_t moduleNum;
-    LLVMContext *cxts;
     std::unique_ptr<Module> *modules;
 
     /// Function declaration to function definition map
@@ -58,7 +58,7 @@ private:
     GlobalDefToRepMapTy GlobalDefToRepMap;
 
     /// Constructor
-    LLVMModuleSet(): svfModule(NULL), moduleNum(0), cxts(NULL), modules(NULL) {}
+    LLVMModuleSet(): svfModule(nullptr), moduleNum(0), cxts(nullptr), modules(NULL) {}
 
 public:
     static inline LLVMModuleSet *getLLVMModuleSet()

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -65,9 +65,7 @@ SVFModule* LLVMModuleSet::buildSVFModule(Module &mod)
     svfModule = new SVFModule(mod.getModuleIdentifier());
     modules.emplace_back(mod);
 
-    initialize();
-    buildFunToFunMap();
-    buildGlobalDefToRepMap();
+    build();
 
     return svfModule;
 }
@@ -95,24 +93,25 @@ SVFModule* LLVMModuleSet::buildSVFModule(const std::vector<std::string> &moduleN
     else
         svfModule = new SVFModule();
 
-    build(moduleNameVec);
-
-	if (!SVFModule::pagReadFromTXT()) {
-		/// building symbol table
-		DBOUT(DGENERAL,SVFUtil::outs() << SVFUtil::pasMsg("Building Symbol table ...\n"));
-		SymbolTableInfo *symInfo = SymbolTableInfo::Symbolnfo();
-		symInfo->buildMemModel(svfModule);
-	}
+    loadModules(moduleNameVec);
+    build();
 
     return svfModule;
 }
 
-void LLVMModuleSet::build(const vector<string> &moduleNameVec)
+void LLVMModuleSet::build()
 {
-    loadModules(moduleNameVec);
     initialize();
     buildFunToFunMap();
     buildGlobalDefToRepMap();
+
+    if (!SVFModule::pagReadFromTXT()) {
+        /// building symbol table
+        DBOUT(DGENERAL,SVFUtil::outs() << SVFUtil::pasMsg("Building Symbol table ...\n"));
+        SymbolTableInfo *symInfo = SymbolTableInfo::Symbolnfo();
+        symInfo->buildMemModel(svfModule);
+    }
+
 }
 
 void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -63,7 +63,6 @@ std::string SVFModule::pagReadFromTxt = "";
 SVFModule* LLVMModuleSet::buildSVFModule(Module &mod)
 {
     svfModule = new SVFModule(mod.getModuleIdentifier());
-    moduleNum = 1;
     modules.emplace_back(std::unique_ptr<Module>(&mod));
 
     initialize();
@@ -118,7 +117,6 @@ void LLVMModuleSet::build(const vector<string> &moduleNameVec)
 
 void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
 {
-    moduleNum = moduleNameVec.size();
     //
     // To avoid the following type bugs (t1 != t3) when parsing multiple modules,
     // We should use only one LLVMContext object for multiple modules in the same thread.
@@ -156,7 +154,7 @@ void LLVMModuleSet::initialize()
     if (SVFMain)
         addSVFMain();
 
-    for (u32_t i = 0; i < moduleNum; ++i)
+    for (u32_t i = 0; i < getModuleNum(); ++i)
     {
         Module *mod = modules[i].get();
 
@@ -191,7 +189,7 @@ void LLVMModuleSet::addSVFMain()
     std::vector<Function *> init_funcs;
     Function * orgMain = 0;
     u32_t k = 0;
-    for (u32_t i = 0; i < moduleNum; ++i)
+    for (u32_t i = 0; i < getModuleNum(); ++i)
     {
         Module *mod = modules[i].get();
         for (auto &func: *mod)
@@ -207,7 +205,7 @@ void LLVMModuleSet::addSVFMain()
             }
         }
     }
-    if(orgMain && moduleNum > 0 && init_funcs.size() > 0)
+    if(orgMain && getModuleNum() > 0 && init_funcs.size() > 0)
     {
         Module & M = *(modules[k].get());
         // char **
@@ -417,7 +415,7 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
 // Dump modules to files
 void LLVMModuleSet::dumpModulesToFile(const std::string suffix)
 {
-    for (u32_t i = 0; i < moduleNum; ++i)
+    for (u32_t i = 0; i < getModuleNum(); ++i)
     {
         Module *mod = getModule(i);
         std::string moduleName = mod->getName().str();

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -64,7 +64,6 @@ SVFModule* LLVMModuleSet::buildSVFModule(Module &mod)
 {
     svfModule = new SVFModule(mod.getModuleIdentifier());
     moduleNum = 1;
-    cxts = &(mod.getContext());
     modules = new unique_ptr<Module>[moduleNum];
     modules[0] = std::unique_ptr<Module>(&mod);
 
@@ -136,7 +135,7 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
     //    assert(t1 != t3);
     // ------------------------------------------------------------------
     //
-    cxts = new LLVMContext[1];
+    cxts = std::make_unique<LLVMContext>();
     modules = new unique_ptr<Module>[moduleNum];
 
     u32_t i = 0;
@@ -145,7 +144,7 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
     {
         const string moduleName = *it;
         SMDiagnostic Err;
-        modules[i] = parseIRFile(moduleName, Err, cxts[0]);
+        modules[i] = parseIRFile(moduleName, Err, *cxts);
         if (!modules[i])
         {
             SVFUtil::errs() << "load module: " << moduleName << "failed!!\n\n";

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -64,8 +64,7 @@ SVFModule* LLVMModuleSet::buildSVFModule(Module &mod)
 {
     svfModule = new SVFModule(mod.getModuleIdentifier());
     moduleNum = 1;
-    modules = new unique_ptr<Module>[moduleNum];
-    modules[0] = std::unique_ptr<Module>(&mod);
+    modules.emplace_back(std::unique_ptr<Module>(&mod));
 
     initialize();
     buildFunToFunMap();
@@ -136,7 +135,6 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
     // ------------------------------------------------------------------
     //
     cxts = std::make_unique<LLVMContext>();
-    modules = new unique_ptr<Module>[moduleNum];
 
     u32_t i = 0;
     for (vector<string>::const_iterator it = moduleNameVec.begin(),
@@ -144,7 +142,7 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
     {
         const string moduleName = *it;
         SMDiagnostic Err;
-        modules[i] = parseIRFile(moduleName, Err, *cxts);
+        modules.emplace_back(parseIRFile(moduleName, Err, *cxts));
         if (!modules[i])
         {
             SVFUtil::errs() << "load module: " << moduleName << "failed!!\n\n";


### PR DESCRIPTION
It does the following:
- module references are not converted to unique_ptr anymore, thus fixing
  a possible use after free
- the cxts pointer is freed, fixing a memleak
- simplify handling of for loops
- unify handling of buildSVFModule(namevector) and buildSVFModule(module)
  As a side effect the SymbolTableInfo is always generated, which works
  around a segfault, see #269

Fixes: #260
Workaround: #269