### PR TITLE
Add option to control clock a little

### DIFF
--- a/include/MemoryModel/PTAStat.h
+++ b/include/MemoryModel/PTAStat.h
@@ -114,12 +114,22 @@ public:
 
     static const char* NumOfNullPointer;	///< Number of pointers points-to null
 
+    /// If set, only return the clock when getClk is called as getClk(true).
+    /// Retrieving the clock is slow but it should be fine for a few calls.
+    /// This is good for benchmarking when we don't need to know how long processLoad
+    /// takes, for example (many calls), but want to know things like total solve time.
+    /// Does not affect CLOCK_IN_MS.
+    static bool markedClocksOnly;
+
     typedef DenseMap<const char*,u32_t> NUMStatMap;
 
     typedef DenseMap<const char*,double> TIMEStatMap;
 
     PTAStat(PointerAnalysis* p);
     virtual ~PTAStat() {}
+
+    /// Sets setMarkedClocksOnly through MarkedClocksOnly in PTAStat.cpp.
+    static void setMarkedClocksOnly(void);
 
     virtual inline void startClk()
     {
@@ -129,8 +139,14 @@ public:
     {
         endTime = CLOCK_IN_MS();
     }
-    static inline double getClk()
+    /// When mark is true, real clock is always returned. When mark is false, it is
+    /// only returned when markedClocksOnly is not set; this is the default case.
+    static inline double getClk(bool mark=false)
     {
+        // Unideal, but should have no effects on performance, compiler should be smart enough
+        // to inline. It would be best if the global MarkedClocksOnly was directly accessible here.
+        setMarkedClocksOnly();
+        if (markedClocksOnly && !mark) return 0.0;
         return CLOCK_IN_MS();
     }
 

--- a/lib/DDA/ContextDDA.cpp
+++ b/lib/DDA/ContextDDA.cpp
@@ -60,9 +60,9 @@ const CxtPtSet& ContextDDA::computeDDAPts(const CxtVar& var)
     CxtLocDPItem dpm = getDPIm(var, getDefSVFGNode(node));
 
     // start DDA analysis
-    DOTIMESTAT(double start = DDAStat::getClk());
+    DOTIMESTAT(double start = DDAStat::getClk(true));
     const CxtPtSet& cpts = findPT(dpm);
-    DOTIMESTAT(ddaStat->_AnaTimePerQuery = DDAStat::getClk() - start);
+    DOTIMESTAT(ddaStat->_AnaTimePerQuery = DDAStat::getClk(true) - start);
     DOTIMESTAT(ddaStat->_TotalTimeOfQueries += ddaStat->_AnaTimePerQuery);
 
     if(isOutOfBudgetQuery() == false)

--- a/lib/DDA/FlowDDA.cpp
+++ b/lib/DDA/FlowDDA.cpp
@@ -26,9 +26,9 @@ void FlowDDA::computeDDAPts(NodeID id)
     LocDPItem dpm = getDPIm(node->getId(),getDefSVFGNode(node));
 
     /// start DDA analysis
-    DOTIMESTAT(double start = DDAStat::getClk());
+    DOTIMESTAT(double start = DDAStat::getClk(true));
     const PointsTo& pts = findPT(dpm);
-    DOTIMESTAT(ddaStat->_AnaTimePerQuery = DDAStat::getClk() - start);
+    DOTIMESTAT(ddaStat->_AnaTimePerQuery = DDAStat::getClk(true) - start);
     DOTIMESTAT(ddaStat->_TotalTimeOfQueries += ddaStat->_AnaTimePerQuery);
 
     if(isOutOfBudgetQuery() == false)

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -81,9 +81,9 @@ MemSSA::MemSSA(BVDataPTAImpl* p, bool ptrOnlyMSSA) : df(NULL),dt(NULL)
     stat = new MemSSAStat(this);
 
     /// Generate whole program memory regions
-    double mrStart = stat->getClk();
+    double mrStart = stat->getClk(true);
     mrGen->generateMRs();
-    double mrEnd = stat->getClk();
+    double mrEnd = stat->getClk(true);
     timeOfGeneratingMemRegions += (mrEnd - mrStart)/TIMEINTERVAL;
 }
 
@@ -112,21 +112,21 @@ void MemSSA::buildMemSSA(const SVFFunction& fun, DominanceFrontier* f, Dominator
     setCurrentDFDT(f,t);
 
     /// Create mus/chis for loads/stores/calls for memory regions
-    double muchiStart = stat->getClk();
+    double muchiStart = stat->getClk(true);
     createMUCHI(fun);
-    double muchiEnd = stat->getClk();
+    double muchiEnd = stat->getClk(true);
     timeOfCreateMUCHI += (muchiEnd - muchiStart)/TIMEINTERVAL;
 
     /// Insert PHI for memory regions
-    double phiStart = stat->getClk();
+    double phiStart = stat->getClk(true);
     insertPHI(fun);
-    double phiEnd = stat->getClk();
+    double phiEnd = stat->getClk(true);
     timeOfInsertingPHI += (phiEnd - phiStart)/TIMEINTERVAL;
 
     /// SSA rename for memory regions
-    double renameStart = stat->getClk();
+    double renameStart = stat->getClk(true);
     SSARename(fun);
-    double renameEnd = stat->getClk();
+    double renameEnd = stat->getClk(true);
     timeOfSSARenaming += (renameEnd - renameStart)/TIMEINTERVAL;
 
 }

--- a/lib/MTA/LockAnalysis.cpp
+++ b/lib/MTA/LockAnalysis.cpp
@@ -37,7 +37,7 @@ void LockAnalysis::analyze()
     collectLockUnlocksites();
     buildCandidateFuncSetforLock();
 
-    DOTIMESTAT(double lockStart = PTAStat::getClk());
+    DOTIMESTAT(double lockStart = PTAStat::getClk(true));
 
     DBOUT(DGENERAL, outs() << "\tIntra-procedural LockAnalysis\n");
     DBOUT(DMTA, outs() << "\tIntra-procedural LockAnalysis\n");
@@ -51,7 +51,7 @@ void LockAnalysis::analyze()
     DBOUT(DMTA, outs() << "\tInter-procedural LockAnalysis\n");
     analyzeLockSpanCxtStmt();
 
-    DOTIMESTAT(double lockEnd = PTAStat::getClk());
+    DOTIMESTAT(double lockEnd = PTAStat::getClk(true));
     DOTIMESTAT(lockTime += (lockEnd - lockStart) / TIMEINTERVAL);
 
     validateResults();

--- a/lib/MTA/MHP.cpp
+++ b/lib/MTA/MHP.cpp
@@ -99,9 +99,9 @@ void MHP::analyze()
 
     DBOUT(DGENERAL, outs() << pasMsg("MHP interleaving analysis\n"));
     DBOUT(DMTA, outs() << pasMsg("MHP interleaving analysis\n"));
-    DOTIMESTAT(double interleavingStart = PTAStat::getClk());
+    DOTIMESTAT(double interleavingStart = PTAStat::getClk(true));
     analyzeInterleaving();
-    DOTIMESTAT(double interleavingEnd = PTAStat::getClk());
+    DOTIMESTAT(double interleavingEnd = PTAStat::getClk(true));
     DOTIMESTAT(interleavingTime += (interleavingEnd - interleavingStart) / TIMEINTERVAL);
 
 }

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -33,6 +33,9 @@
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "Graphs/PAG.h"
 
+static llvm::cl::opt<bool> MarkedClocksOnly("marked-clocks-only", llvm::cl::init(false),
+                                            llvm::cl::desc("Only measure times where explicitly marked"));
+
 const char* PTAStat:: TotalAnalysisTime = "TotalTime";	///< PAG value nodes
 const char* PTAStat:: SCCDetectionTime = "SCCDetectTime"; ///< Total SCC detection time
 const char* PTAStat:: SCCMergeTime = "SCCMergeTime"; ///< Total SCC merge time
@@ -102,9 +105,16 @@ const char* PTAStat:: MaxNumOfNodesInSCC = "MaxNodesInSCC";	///< max Number of n
 
 const char* PTAStat:: NumOfNullPointer = "NullPointer";	///< Number of pointers points-to null
 
+bool PTAStat::markedClocksOnly = false;
+
 PTAStat::PTAStat(PointerAnalysis* p) : startTime(0), endTime(0), pta(p)
 {
 
+}
+
+void PTAStat::setMarkedClocksOnly(void)
+{
+    markedClocksOnly = MarkedClocksOnly;
 }
 
 void PTAStat::performStat()

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -64,7 +64,7 @@ void FlowSensitive::analyze()
     /// Initialization for the Solver
     initialize();
 
-    double start = stat->getClk();
+    double start = stat->getClk(true);
     /// Start solving constraints
     DBOUT(DGENERAL, outs() << SVFUtil::pasMsg("Start Solving Constraints\n"));
 
@@ -84,7 +84,7 @@ void FlowSensitive::analyze()
 
     DBOUT(DGENERAL, outs() << SVFUtil::pasMsg("Finish Solving Constraints\n"));
 
-    double end = stat->getClk();
+    double end = stat->getClk(true);
     solveTime += (end - start) / TIMEINTERVAL;
 
     if (CTirAliasEval)


### PR DESCRIPTION
`clock()` is really slow, so a lot of overhead is added when we repeatedly call `getClk` in `processLoad`, `processStore`, etc. As it is, it is good for debugging, but not for actual usage and benchmarking. This patch gives a bit of command line control of `getClk`. If `-marked-clocks-only`, only a select few `getClk` calls will succeed (those which happen rarely, usually those which represent a full analysis or similar). I'm unfamiliar with some of the analyses so I may have missed some `getClk`s that should be marked.

Example of the effect, not tested on huge programs:
```
$ ./bin/wpa -fspta mruby.bc | ag totaltime
TotalTime           15.617
TotalTime           0.931
TotalTime           30.524
$ ./bin/wpa -fspta -marked-clocks-only mruby.bc | ag totaltime
TotalTime           9.623
TotalTime           0.897
TotalTime           22.7
```