### PR TITLE
Connecting Formal/Actual Parameters/Returns

### DIFF
--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -357,10 +357,10 @@ protected:
     /// Connect VFG nodes between caller and callee for indirect call site
     //@{
     /// Connect actual-param and formal param
-    virtual inline void connectAParamAndFParam(const PAGNode* cs_arg, const PAGNode* fun_arg, const CallBlockNode*, CallSiteID csId, VFGEdgeSetTy& edges)
+    virtual inline void connectAParamAndFParam(const PAGNode* cs_arg, const PAGNode* fun_arg, const CallBlockNode* cbn, CallSiteID csId, VFGEdgeSetTy& edges)
     {
-        NodeID actualParam = getDef(cs_arg);
-        NodeID formalParam = getDef(fun_arg);
+        NodeID actualParam = getActualParmVFGNode(cs_arg, cbn)->getId();
+        NodeID formalParam = getFormalParmVFGNode(fun_arg)->getId();
         VFGEdge* edge = addInterEdgeFromAPToFP(actualParam, formalParam,csId);
         if (edge != NULL)
             edges.insert(edge);

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -357,19 +357,19 @@ protected:
     /// Connect VFG nodes between caller and callee for indirect call site
     //@{
     /// Connect actual-param and formal param
-    virtual inline void connectAParamAndFParam(const PAGNode* cs_arg, const PAGNode* fun_arg, const CallBlockNode* cbn, CallSiteID csId, VFGEdgeSetTy& edges)
+    virtual inline void connectAParamAndFParam(const PAGNode* csArg, const PAGNode* funArg, const CallBlockNode* cbn, CallSiteID csId, VFGEdgeSetTy& edges)
     {
-        NodeID actualParam = getActualParmVFGNode(cs_arg, cbn)->getId();
-        NodeID formalParam = getFormalParmVFGNode(fun_arg)->getId();
+        NodeID actualParam = getActualParmVFGNode(csArg, cbn)->getId();
+        NodeID formalParam = getFormalParmVFGNode(funArg)->getId();
         VFGEdge* edge = addInterEdgeFromAPToFP(actualParam, formalParam,csId);
         if (edge != NULL)
             edges.insert(edge);
     }
     /// Connect formal-ret and actual ret
-    virtual inline void connectFRetAndARet(const PAGNode* fun_return, const PAGNode* cs_return, CallSiteID csId, VFGEdgeSetTy& edges)
+    virtual inline void connectFRetAndARet(const PAGNode* funReturn, const PAGNode* csReturn, CallSiteID csId, VFGEdgeSetTy& edges)
     {
-        NodeID formalRet = getFormalRetVFGNode(fun_return)->getId();
-        NodeID actualRet = getActualRetVFGNode(cs_return)->getId();
+        NodeID formalRet = getFormalRetVFGNode(funReturn)->getId();
+        NodeID actualRet = getActualRetVFGNode(csReturn)->getId();
         VFGEdge* edge = addInterEdgeFromFRToAR(formalRet, actualRet,csId);
         if (edge != NULL)
             edges.insert(edge);

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -368,8 +368,8 @@ protected:
     /// Connect formal-ret and actual ret
     virtual inline void connectFRetAndARet(const PAGNode* fun_return, const PAGNode* cs_return, CallSiteID csId, VFGEdgeSetTy& edges)
     {
-        NodeID formalRet = getDef(fun_return);
-        NodeID actualRet = getDef(cs_return);
+        NodeID formalRet = getFormalRetVFGNode(fun_return)->getId();
+        NodeID actualRet = getActualRetVFGNode(cs_return)->getId();
         VFGEdge* edge = addInterEdgeFromFRToAR(formalRet, actualRet,csId);
         if (edge != NULL)
             edges.insert(edge);


### PR DESCRIPTION
This is for #272. For my test cases, it appears that optimised vs unoptimised are now giving the same results with these changes.

The functions which propagate aparm->fparm/fret->aret slipped my mind whilst making #272, so these nodes were definitely handled by FSPTA but they were being connected a bit weird. Before, for example, some formal parameters had incoming edges from non-actual parameters, I assume for optimisation's sake.

`mruby` also runs as expected, taking 20s vs. 34s for optimised vs. unoptimised.