### PR TITLE
Fix constructor not setting byteOffset

### DIFF
--- a/include/MemoryModel/LocationSet.h
+++ b/include/MemoryModel/LocationSet.h
@@ -107,7 +107,8 @@ public:
     {}
 
     /// Copy Constructor
-    LocationSet(const LocationSet& ls) : fldIdx(ls.fldIdx)
+    LocationSet(const LocationSet& ls)
+        : fldIdx(ls.fldIdx), byteOffset(ls.byteOffset)
     {
         const ElemNumStridePairVec& vec = ls.getNumStridePair();
         ElemNumStridePairVec::const_iterator it = vec.begin();
@@ -117,7 +118,8 @@ public:
     }
 
     /// Initialization from FieldInfo
-    LocationSet(const FieldInfo& fi) : fldIdx(fi.getFlattenFldIdx())
+    LocationSet(const FieldInfo& fi)
+        : fldIdx(fi.getFlattenFldIdx()), byteOffset(fi.getFlattenByteOffset())
     {
         const ElemNumStridePairVec& vec = fi.getElemNumStridePairVect();
         ElemNumStridePairVec::const_iterator it = vec.begin();


### PR DESCRIPTION
I noticed that the two constructors `LocationSet(const LocationSet& ls)` and `LocationSet(const FieldInfo& fi)` do not set the `byteOffset`. The pull request fixes this issue.