### PR TITLE
Fix DDAPass being called with a LLVM Module

### DIFF
--- a/include/DDA/DDAPass.h
+++ b/include/DDA/DDAPass.h
@@ -59,13 +59,10 @@ public:
     virtual AliasResult alias(NodeID V1, NodeID V2);
 
     /// We start from here
-    virtual bool runOnModule(SVFModule* module);
+    virtual void runOnModule(SVFModule* module);
 
     /// We start from here
-    virtual bool runOnModule(Module& module)
-    {
-        return runOnModule(module);
-    }
+    virtual bool runOnModule(Module& module);
 
     /// Select a client
     virtual void selectClient(SVFModule* module);

--- a/include/WPA/WPAPass.h
+++ b/include/WPA/WPAPass.h
@@ -51,7 +51,7 @@ class SVFG;
  */
 // excised ", public llvm::AliasAnalysis" as that has a very light interface
 // and I want to see what breaks.
-class WPAPass
+class WPAPass : public ModulePass
 {
     typedef std::vector<PointerAnalysis*> PTAVector;
 
@@ -67,7 +67,7 @@ public:
     };
 
     /// Constructor needs TargetLibraryInfo to be passed to the AliasAnalysis
-    WPAPass()
+    WPAPass() : ModulePass(ID)
     {
 
     }
@@ -117,7 +117,10 @@ public:
     virtual ModRefInfo getModRefInfo(const CallInst* callInst1, const CallInst* callInst2);
 
     /// Run pointer analysis on SVFModule
-    void runOnModule(SVFModule* svfModule);
+    virtual void runOnModule(SVFModule* svfModule);
+
+    /// Run pointer analysis on LLVM module
+    virtual bool runOnModule(Module& module);
 
     /// PTA name
     virtual inline StringRef getPassName() const

--- a/lib/DDA/DDAPass.cpp
+++ b/lib/DDA/DDAPass.cpp
@@ -65,7 +65,7 @@ DDAPass::~DDAPass()
 }
 
 
-bool DDAPass::runOnModule(SVFModule* module)
+void DDAPass::runOnModule(SVFModule* module)
 {
     /// initialization for llvm alias analyzer
     //InitializeAliasAnalysis(this, SymbolTableInfo::getDataLayout(&module));
@@ -78,7 +78,12 @@ bool DDAPass::runOnModule(SVFModule* module)
         if (DDASelected.isSet(i))
             runPointerAnalysis(module, i);
     }
+}
 
+bool DDAPass::runOnModule(Module& module)
+{
+    SVFModule* svfModule = LLVMModuleSet::getLLVMModuleSet()->buildSVFModule(module);
+    runOnModule(svfModule);
     return false;
 }
 

--- a/lib/WPA/WPAPass.cpp
+++ b/lib/WPA/WPAPass.cpp
@@ -47,8 +47,8 @@ using namespace SVF;
 
 char WPAPass::ID = 0;
 
-//static llvm::RegisterPass<WPAPass> WHOLEPROGRAMPA("wpa",
-//        "Whole Program Pointer Analysis Pass");
+static llvm::RegisterPass<WPAPass> WHOLEPROGRAMPA("wpa",
+        "Whole Program Pointer Analysis Pass");
 
 /// register this into alias analysis group
 ///static RegisterAnalysisGroup<AliasAnalysis> AA_GROUP(WHOLEPROGRAMPA);
@@ -112,6 +112,15 @@ void WPAPass::runOnModule(SVFModule* svfModule)
     assert(!ptaVector.empty() && "No pointer analysis is specified.\n");
 }
 
+/*!
+ * We start from here
+ */
+bool WPAPass::runOnModule(Module& module)
+{
+    SVFModule* svfModule = LLVMModuleSet::getLLVMModuleSet()->buildSVFModule(module);
+    runOnModule(svfModule);
+    return false;
+}
 
 /*!
  * Create pointer analysis according to a specified kind and then analyze the module.


### PR DESCRIPTION
This pull request fixes the `DDAPass` to be callable with a LLVM Module directly. See #289 for more details.