### PR TITLE
Various fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.4.3)
 
+project("SVF")
+
 # To support both in- and out-of-source builds,
 # we check for the presence of the add_llvm_loadable_module command.
 # - if this command is not present, we are building out-of-source

--- a/include/MSSA/MSSAMuChi.h
+++ b/include/MSSA/MSSAMuChi.h
@@ -49,12 +49,12 @@ private:
     /// ver ID 0 is reserved
     static Size_t totalVERNum;
     const MemRegion* mr;
-    VERSION version;
+    MRVERSION version;
     MRVERID vid;
     MSSADef* def;
 public:
     /// Constructor
-    MRVer(const MemRegion* m, VERSION v, MSSADef* d) :
+    MRVer(const MemRegion* m, MRVERSION v, MSSADef* d) :
         mr(m), version(v), vid(totalVERNum++),def(d)
     {
     }
@@ -66,7 +66,7 @@ public:
     }
 
     /// Return SSA version
-    inline VERSION getSSAVersion() const
+    inline MRVERSION getSSAVersion() const
     {
         return version;
     }

--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -42,7 +42,7 @@ namespace SVF
 
 typedef NodeID MRID;
 typedef NodeID MRVERID;
-typedef NodeID VERSION;
+typedef NodeID MRVERSION;
 
 /// Memory Region class
 class MemRegion

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -91,7 +91,7 @@ public:
 
     /// For SSA renaming
     typedef DenseMap<const MemRegion*, std::vector<MRVer*> > MemRegToVerStackMap;
-    typedef DenseMap<const MemRegion*, VERSION> MemRegToCounterMap;
+    typedef DenseMap<const MemRegion*, MRVERSION> MemRegToCounterMap;
 
     /// PAG edge list
     typedef PAG::PAGEdgeList PAGEdgeList;

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -385,7 +385,7 @@ MRVer* MemSSA::newSSAName(const MemRegion* mr, MSSADEF* def)
     assert(0 != mr2VerStackMap.count(mr)
            && "did not find initial stack in map? ");
 
-    VERSION version = mr2CounterMap[mr];
+    MRVERSION version = mr2CounterMap[mr];
     mr2CounterMap[mr] = version + 1;
     MRVer* mrVer = new MRVer(mr, version, def);
     mr2VerStackMap[mr].push_back(mrVer);


### PR DESCRIPTION
1. build.sh: use ninja:
  This has the main advantage that ninja uses all cores per default resulting in a faster compilation on machines with more or less than 4 cores.
2. MSSA: rename VERSION to MRVERSION:
   When SVF is used as a library, VERSION as class name can conflict with already defined preprocessor constants. MRVERSION tries to mitigates this. (I can also rename it to something else, if you prefer this. VERSION has the disadvantage to be a very generic name and all caps, which is often used for preprocessor constants.)
3. CMake: specify project
prevents this warning:
> CMake Warning (dev) in CMakeLists.txt:
>   No project() command is present.  The top-level CMakeLists.txt file must
>   contain a literal, direct call to the project() command.  Add a line of
>   code such as
>
>     project(ProjectName)
>
>   near the top of the file, but after cmake_minimum_required().
>
>   CMake is pretending there is a "project(Project)" command on the first
>   line.
> This warning is for project developers.  Use -Wno-dev to suppress it.