### PR TITLE
build.sh: use ninja

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ env:
 
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update       ; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install cmake gcc g++ nodejs; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install cmake gcc g++ nodejs ninja-build; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ninja; fi
 
 script:
   - git stash --all

--- a/build.sh
+++ b/build.sh
@@ -144,14 +144,14 @@ then
 	rm -rf ./'Debug-build'
 	mkdir ./'Debug-build'
 	cd ./'Debug-build'
-	cmake -D CMAKE_BUILD_TYPE:STRING=Debug ../
+	cmake -GNinja -D CMAKE_BUILD_TYPE:STRING=Debug ../
 else
 	rm -rf ./'Release-build'
 	mkdir ./'Release-build'
 	cd ./'Release-build'
-	cmake ../
+	cmake -GNinja ../
 fi
-make -j4
+ninja
 
 ########
 # Set up environment variables of SVF

--- a/build.sh
+++ b/build.sh
@@ -151,7 +151,7 @@ else
 	cd ./'Release-build'
 	cmake -GNinja ../
 fi
-ninja
+ninja -v
 
 ########
 # Set up environment variables of SVF


### PR DESCRIPTION
This has the main advantage that ninja uses all cores per default resulting in a faster compilation on machines with more or less than 4 cores.

See #302 for more discussion.