### PR TITLE
WIP: GenericGraph: try to fix GraphTraits interface

### DIFF
--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -453,34 +453,36 @@ template<class NodeTy,class EdgeTy> struct GraphTraits<SVF::GenericNode<NodeTy,E
 {
     typedef NodeTy NodeType;
     typedef EdgeTy EdgeType;
+    typedef NodeTy* NodeRef;
+    typedef EdgeTy* EdgeRef;
 
     typedef std::pointer_to_unary_function<EdgeType*, NodeType*> DerefEdge;
 
     // nodes_iterator/begin/end - Allow iteration over all nodes in the graph
     typedef mapped_iterator<typename SVF::GenericNode<NodeTy,EdgeTy>::iterator, DerefEdge> ChildIteratorType;
 
-    static NodeType* getEntryNode(NodeType* pagN)
+    static NodeRef getEntryNode(SVF::GenericNode<NodeTy,EdgeTy>& pagN)
     {
-        return pagN;
+        return static_cast<NodeTy*>(&pagN);
     }
 
-    static inline ChildIteratorType child_begin(const NodeType* N)
+    static inline ChildIteratorType child_begin(NodeRef N)
     {
         return map_iterator(N->OutEdgeBegin(), DerefEdge(edgeDereference));
     }
-    static inline ChildIteratorType child_end(const NodeType* N)
+    static inline ChildIteratorType child_end(NodeRef N)
     {
         return map_iterator(N->OutEdgeEnd(), DerefEdge(edgeDereference));
     }
-    static inline ChildIteratorType direct_child_begin(const NodeType *N)
+    static inline ChildIteratorType direct_child_begin(NodeRef N)
     {
         return map_iterator(N->directOutEdgeBegin(), DerefEdge(edgeDereference));
     }
-    static inline ChildIteratorType direct_child_end(const NodeType *N)
+    static inline ChildIteratorType direct_child_end(NodeRef N)
     {
         return map_iterator(N->directOutEdgeEnd(), DerefEdge(edgeDereference));
     }
-    static NodeType* edgeDereference(EdgeType* edge)
+    static NodeRef edgeDereference(EdgeRef edge)
     {
         return edge->getDstNode();
     }
@@ -495,32 +497,34 @@ struct GraphTraits<Inverse<SVF::GenericNode<NodeTy,EdgeTy>* > >
 {
     typedef NodeTy NodeType;
     typedef EdgeTy EdgeType;
+    typedef NodeTy* NodeRef;
+    typedef EdgeTy* EdgeRef;
 
     typedef std::pointer_to_unary_function<EdgeType*, NodeType*> DerefEdge;
 
     // nodes_iterator/begin/end - Allow iteration over all nodes in the graph
     typedef mapped_iterator<typename SVF::GenericNode<NodeTy,EdgeTy>::iterator, DerefEdge> ChildIteratorType;
 
-    static inline NodeType* getEntryNode(Inverse<NodeType* > G)
+    static inline NodeRef getEntryNode(Inverse<SVF::GenericNode<NodeTy,EdgeTy>>& G)
     {
         return G.Graph;
     }
 
-    static inline ChildIteratorType child_begin(const NodeType* N)
+    static inline ChildIteratorType child_begin(NodeRef N)
     {
         return map_iterator(N->InEdgeBegin(), DerefEdge(edgeDereference));
     }
-    static inline ChildIteratorType child_end(const NodeType* N)
+    static inline ChildIteratorType child_end(NodeRef N)
     {
         return map_iterator(N->InEdgeEnd(), DerefEdge(edgeDereference));
     }
 
-    static inline NodeType* edgeDereference(EdgeType* edge)
+    static inline NodeRef edgeDereference(EdgeRef edge)
     {
         return edge->getSrcNode();
     }
 
-    static inline unsigned getNodeID(const NodeType* N)
+    static inline unsigned getNodeID(NodeRef N)
     {
         return N->getId();
     }
@@ -534,6 +538,8 @@ template<class NodeTy,class EdgeTy> struct GraphTraits<SVF::GenericGraph<NodeTy,
     typedef SVF::GenericGraph<NodeTy,EdgeTy> GenericGraphTy;
     typedef NodeTy NodeType;
     typedef EdgeTy EdgeType;
+    typedef NodeTy NodeRef;
+    typedef EdgeTy EdgeRef;
 
     static NodeType* getEntryNode(GenericGraphTy* pag)
     {

--- a/tools/Example/svf-ex.cpp
+++ b/tools/Example/svf-ex.cpp
@@ -114,6 +114,7 @@ void traverseOnVFG(const SVFG* vfg, Value* val)
     std::set<const VFGNode*> visited;
     worklist.push(vNode);
 
+
     /// Traverse along VFG
     while (!worklist.empty())
     {
@@ -138,6 +139,12 @@ void traverseOnVFG(const SVFG* vfg, Value* val)
         /// can only query VFGNode involving top-level pointers (starting with % or @ in LLVM IR)
         /// PAGNode* pNode = vfg->getLHSTopLevPtr(node);
         /// Value* val = pNode->getValue();
+    }
+
+
+    // LLVM graph traversal functions
+    for (const VFGNode* node : llvm::inverse_depth_first(vNode)) {
+        llvm::errs() << "Node: " << *node;
     }
 }
 


### PR DESCRIPTION
Appearently, the GraphTraits interface does not work with newer LLVMs anymore. I have tested this with the svf example. In my option the depth first search iterator loop should compile but does not.

I have tried to fix the error but had no success. It looks like there are some other type definitions. Currently, I have no time to work further on this. Maybe you want to use my changes to make it compatible again.