### PR TITLE
Fix handling of calls to memset

### DIFF
--- a/include/Util/ExtAPI.h
+++ b/include/Util/ExtAPI.h
@@ -60,6 +60,7 @@ public:
         EFT_L_A1,
         EFT_L_A2,
         EFT_L_A8,
+        EFT_L_A0__A0R_A1,   //stores arg1 into *arg0 and returns arg0
         EFT_L_A0__A0R_A1R,  //copies the data that arg1 points to into the location
         //  arg0 points to; note that several fields may be
         //  copied at once if both point to structs.

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -949,6 +949,13 @@ void PAGBuilder::handleExtCall(CallSite cs, const SVFFunction *callee)
                 break;
                 break;
             }
+            case ExtAPI::EFT_L_A0__A0R_A1:
+            {
+                addComplexConsForExt(cs.getArgument(0), cs.getArgument(1));
+                if(SVFUtil::isa<PointerType>(inst->getType()))
+                    addCopyEdge(getValueNode(cs.getArgument(0)), getValueNode(inst));
+                break;
+            }
             case ExtAPI::EFT_L_A0__A0R_A1R:
             {
                 addComplexConsForExt(cs.getArgument(0), cs.getArgument(1));

--- a/lib/Util/ExtAPI.cpp
+++ b/lib/Util/ExtAPI.cpp
@@ -271,7 +271,6 @@ static const ei_pair ei_pairs[]=
     {"keypad", ExtAPI::EFT_NOOP},
     {"lchown", ExtAPI::EFT_NOOP},
     {"link", ExtAPI::EFT_NOOP},
-    {"llvm.memset", ExtAPI::EFT_NOOP},
     {"llvm.dbg", ExtAPI::EFT_NOOP},
     {"llvm.stackrestore", ExtAPI::EFT_NOOP},
     {"llvm.va_copy", ExtAPI::EFT_NOOP},
@@ -701,9 +700,6 @@ static const ei_pair ei_pairs[]=
     {"fgets", ExtAPI::EFT_L_A0},
     {"jpeg_std_error", ExtAPI::EFT_L_A0},
     {"memchr", ExtAPI::EFT_L_A0},
-    //This will overwrite *arg0 with non-pointer data -
-    //  assume that no valid pointer values are created.
-    {"memset", ExtAPI::EFT_L_A0},
     //This may return a new ptr if the region was moved.
     {"mremap", ExtAPI::EFT_L_A0},
     {"strchr", ExtAPI::EFT_L_A0},
@@ -728,10 +724,16 @@ static const ei_pair ei_pairs[]=
     {"inet_ntop", ExtAPI::EFT_L_A2},
     {"XGetSubImage", ExtAPI::EFT_L_A8},
 
+    {"memset", ExtAPI::EFT_L_A0__A0R_A1},
+    {"llvm.memset", ExtAPI::EFT_L_A0__A0R_A1},
+    {"llvm.memset.p0i8.i32", ExtAPI::EFT_L_A0__A0R_A1},
+    {"llvm.memset.p0i8.i64", ExtAPI::EFT_L_A0__A0R_A1},
     {"llvm.memcpy", ExtAPI::EFT_L_A0__A0R_A1R},
     {"llvm.memcpy.p0i8.p0i8.i32", ExtAPI::EFT_L_A0__A0R_A1R},
     {"llvm.memcpy.p0i8.p0i8.i64", ExtAPI::EFT_L_A0__A0R_A1R},
     {"llvm.memmove", ExtAPI::EFT_L_A0__A0R_A1R},
+    {"llvm.memmove.p0i8.p0i8.i32", ExtAPI::EFT_L_A0__A0R_A1R},
+    {"llvm.memmove.p0i8.p0i8.i64", ExtAPI::EFT_L_A0__A0R_A1R},
     {"memccpy", ExtAPI::EFT_L_A0__A0R_A1R},
     {"memcpy", ExtAPI::EFT_L_A0__A0R_A1R},
     {"memmove", ExtAPI::EFT_L_A0__A0R_A1R},


### PR DESCRIPTION
Hi there,

I noticed that SVF does not properly represent calls to memset in it's SVFG (i.e., memset does not appear, in contrast to memcpy or memmove).

This fix introduces a new `ExtAPI` type for memset, for which the `PAGBuilder` inserts Load/Store/Copy edges at the right places. For the Load/Store edges, I used `addComplexConsForExt()` to mimic the behavior of `memcpy` and `memmove`.