### PR TITLE
Introduce handling of unary operations

### DIFF
--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -56,9 +56,11 @@ public:
     typedef std::vector<const PAGNode*> PAGNodeList;
     typedef std::vector<const CopyPE*> CopyPEList;
     typedef std::vector<const BinaryOPPE*> BinaryOPList;
+    typedef std::vector<const UnaryOPPE*> UnaryOPList;
     typedef std::vector<const CmpPE*> CmpPEList;
     typedef DenseMap<const PAGNode*,CopyPEList> PHINodeMap;
     typedef DenseMap<const PAGNode*,BinaryOPList> BinaryNodeMap;
+    typedef DenseMap<const PAGNode*,UnaryOPList> UnaryNodeMap;
     typedef DenseMap<const PAGNode*,CmpPEList> CmpNodeMap;
     typedef DenseMap<const SVFFunction*,PAGNodeList> FunToArgsListMap;
     typedef DenseMap<const CallBlockNode*,PAGNodeList> CSToArgsListMap;
@@ -88,6 +90,7 @@ private:
     PAGEdgeSet globPAGEdgesSet;	///< Global PAGEdges without control flow information
     PHINodeMap phiNodeMap;	///< A set of phi copy edges
     BinaryNodeMap binaryNodeMap;	///< A set of binary edges
+    UnaryNodeMap unaryNodeMap;	///< A set of unary edges
     CmpNodeMap cmpNodeMap;	///< A set of comparision edges
     FunToArgsListMap funArgsListMap;	///< Map a function to a list of all its formal parameters
     CSToArgsListMap callSiteArgsListMap;	///< Map a callsite to a list of all its actual parameters
@@ -264,6 +267,21 @@ public:
     inline BinaryNodeMap& getBinaryNodeMap()
     {
         return binaryNodeMap;
+    }
+    /// Add unary node information
+    inline void addUnaryNode(const PAGNode* res, const UnaryOPPE* edge)
+    {
+        unaryNodeMap[res].push_back(edge);
+    }
+    /// Whether this PAGNode is an unary node
+    inline bool isUnaryNode(const PAGNode* node) const
+    {
+        return unaryNodeMap.find(node) != unaryNodeMap.end();
+    }
+    /// Get all unary edges
+    inline UnaryNodeMap& getUnaryNodeMap()
+    {
+        return unaryNodeMap;
     }
     /// Add phi node information
     inline void addCmpNode(const PAGNode* res, const CmpPE* edge)
@@ -779,6 +797,8 @@ public:
     CmpPE* addCmpPE(NodeID src, NodeID dst);
     /// Add Copy edge
     BinaryOPPE* addBinaryOPPE(NodeID src, NodeID dst);
+    /// Add Unary edge
+    UnaryOPPE* addUnaryOPPE(NodeID src, NodeID dst);
     /// Add Load edge
     LoadPE* addLoadPE(NodeID src, NodeID dst);
     /// Add Store edge

--- a/include/Graphs/PAGEdge.h
+++ b/include/Graphs/PAGEdge.h
@@ -48,12 +48,12 @@ class PAGEdge : public GenericPAGEdgeTy
 {
 
 public:
-    /// Ten kinds of PAG edges
+    /// Thirteen kinds of PAG edges
     /// Gep represents offset edge for field sensitivity
     /// ThreadFork/ThreadJoin is to model parameter passings between thread spawners and spawnees.
     enum PEDGEK
     {
-        Addr, Copy, Store, Load, Call, Ret, NormalGep, VariantGep, ThreadFork, ThreadJoin, Cmp, BinaryOp
+        Addr, Copy, Store, Load, Call, Ret, NormalGep, VariantGep, ThreadFork, ThreadJoin, Cmp, BinaryOp, UnaryOp
     };
 
 private:
@@ -90,7 +90,8 @@ public:
                edge->getEdgeKind() == PAGEdge::ThreadFork ||
                edge->getEdgeKind() == PAGEdge::ThreadJoin ||
                edge->getEdgeKind() == PAGEdge::Cmp ||
-               edge->getEdgeKind() == PAGEdge::BinaryOp;
+               edge->getEdgeKind() == PAGEdge::BinaryOp ||
+               edge->getEdgeKind() == PAGEdge::UnaryOp;
     }
     ///@}
 
@@ -311,6 +312,40 @@ public:
 
     /// constructor
     BinaryOPPE(PAGNode* s, PAGNode* d) : PAGEdge(s,d,PAGEdge::BinaryOp)
+    {
+    }
+
+    virtual const std::string toString() const;
+};
+
+/*!
+ * Unary instruction edge
+ */
+class UnaryOPPE: public PAGEdge
+{
+private:
+    UnaryOPPE();                      ///< place holder
+    UnaryOPPE(const UnaryOPPE &);  ///< place holder
+    void operator=(const UnaryOPPE &); ///< place holder
+public:
+    /// Methods for support type inquiry through isa, cast, and dyn_cast:
+    //@{
+    static inline bool classof(const UnaryOPPE *)
+    {
+        return true;
+    }
+    static inline bool classof(const PAGEdge *edge)
+    {
+        return edge->getEdgeKind() == PAGEdge::UnaryOp;
+    }
+    static inline bool classof(const GenericPAGEdgeTy *edge)
+    {
+        return edge->getEdgeKind() == PAGEdge::UnaryOp;
+    }
+    //@}
+
+    /// constructor
+    UnaryOPPE(PAGNode* s, PAGNode* d) : PAGEdge(s,d,PAGEdge::UnaryOp)
     {
     }
 

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -65,6 +65,7 @@ public:
     typedef DenseMap<const PAGEdge*, StmtVFGNode*> PAGEdgeToStmtVFGNodeMapTy;
     typedef DenseMap<const PAGNode*, IntraPHIVFGNode*> PAGNodeToPHIVFGNodeMapTy;
     typedef DenseMap<const PAGNode*, BinaryOPVFGNode*> PAGNodeToBinaryOPVFGNodeMapTy;
+    typedef DenseMap<const PAGNode*, UnaryOPVFGNode*> PAGNodeToUnaryOPVFGNodeMapTy;
     typedef DenseMap<const PAGNode*, CmpVFGNode*> PAGNodeToCmpVFGNodeMapTy;
     typedef DenseMap<const SVFFunction*, VFGNodeSet > FunToVFGNodesMapTy;
 
@@ -89,6 +90,7 @@ protected:
     PAGNodeToFormalRetMapTy PAGNodeToFormalRetMap; ///< map a PAGNode to a formal return
     PAGNodeToPHIVFGNodeMapTy PAGNodeToIntraPHIVFGNodeMap;	///< map a PAGNode to its PHIVFGNode
     PAGNodeToBinaryOPVFGNodeMapTy PAGNodeToBinaryOPVFGNodeMap;	///< map a PAGNode to its BinaryOPVFGNode
+    PAGNodeToUnaryOPVFGNodeMapTy PAGNodeToUnaryOPVFGNodeMap;	///< map a PAGNode to its UnaryOPVFGNode
     PAGNodeToCmpVFGNodeMapTy PAGNodeToCmpVFGNodeMap;	///< map a PAGNode to its CmpVFGNode
     PAGEdgeToStmtVFGNodeMapTy PAGEdgeToStmtVFGNodeMap;	///< map a PAGEdge to its StmtVFGNode
     FunToVFGNodesMapTy funToVFGNodesMap; ///< map a function to its VFGNodes;
@@ -216,6 +218,12 @@ public:
     {
         PAGNodeToBinaryOPVFGNodeMapTy::const_iterator it = PAGNodeToBinaryOPVFGNodeMap.find(pagNode);
         assert(it != PAGNodeToBinaryOPVFGNodeMap.end() && "BinaryOPVFGNode can not be found??");
+        return it->second;
+    }
+    inline UnaryOPVFGNode* getUnaryOPVFGNode(const PAGNode* pagNode) const
+    {
+        PAGNodeToUnaryOPVFGNodeMapTy::const_iterator it = PAGNodeToUnaryOPVFGNodeMap.find(pagNode);
+        assert(it != PAGNodeToUnaryOPVFGNodeMap.end() && "UnaryOPVFGNode can not be found??");
         return it->second;
     }
     inline CmpVFGNode* getCmpVFGNode(const PAGNode* pagNode) const
@@ -602,6 +610,23 @@ protected:
         addVFGNode(sNode,edge->getICFGNode());
         setDef(resNode,sNode);
         PAGNodeToBinaryOPVFGNodeMap[resNode] = sNode;
+    }
+    /// Add a UnaryOperator VFG node
+    inline void addUnaryOPVFGNode(const PAGNode* resNode, PAG::UnaryOPList& oplist)
+    {
+        UnaryOPVFGNode* sNode = new UnaryOPVFGNode(totalVFGNode++, resNode);
+        u32_t pos = 0;
+        const PAGEdge* edge = NULL;
+        for(PAG::UnaryOPList::const_iterator it = oplist.begin(), eit=oplist.end(); it!=eit; ++it,++pos)
+        {
+            edge = *it;
+            sNode->setOpVer(pos, (*it)->getSrcNode());
+        }
+
+        assert(edge && "edge not found?");
+        addVFGNode(sNode,edge->getICFGNode());
+        setDef(resNode,sNode);
+        PAGNodeToUnaryOPVFGNodeMap[resNode] = sNode;
     }
 };
 

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -49,11 +49,11 @@ class VFGNode : public GenericVFGNodeTy
 {
 
 public:
-    /// 20 kinds of ICFG node
+    /// 24 kinds of ICFG node
     /// Gep represents offset edge for field sensitivity
     enum VFGNodeK
     {
-        Addr, Copy, Gep, Store, Load, Cmp, BinaryOp, TPhi, TIntraPhi, TInterPhi,
+        Addr, Copy, Gep, Store, Load, Cmp, BinaryOp, UnaryOp, TPhi, TIntraPhi, TInterPhi,
         MPhi, MIntraPhi, MInterPhi, FRet, ARet, AParm, FParm,
         FunRet, APIN, APOUT, FPIN, FPOUT, NPtr
     };
@@ -414,6 +414,77 @@ public:
     }
     //@}
     /// Operands at a BinaryNode
+    //@{
+    inline const PAGNode* getOpVer(u32_t pos) const
+    {
+        OPVers::const_iterator it = opVers.find(pos);
+        assert(it!=opVers.end() && "version is NULL, did not rename?");
+        return it->second;
+    }
+    inline void setOpVer(u32_t pos, const PAGNode* node)
+    {
+        opVers[pos] = node;
+    }
+    inline const PAGNode* getRes() const
+    {
+        return res;
+    }
+    inline u32_t getOpVerNum() const
+    {
+        return opVers.size();
+    }
+    inline OPVers::const_iterator opVerBegin() const
+    {
+        return opVers.begin();
+    }
+    inline OPVers::const_iterator opVerEnd() const
+    {
+        return opVers.end();
+    }
+    //@}
+
+    virtual const std::string toString() const;
+};
+
+/*!
+ * VFGNode for unary operator instructions, e.g., a = -b;
+ */
+class UnaryOPVFGNode: public VFGNode
+{
+public:
+    typedef DenseMap<u32_t,const PAGNode*> OPVers;
+protected:
+    const PAGNode* res;
+    OPVers opVers;
+
+private:
+    UnaryOPVFGNode();                      ///< place holder
+    UnaryOPVFGNode(const UnaryOPVFGNode &);  ///< place holder
+    void operator=(const UnaryOPVFGNode &); ///< place holder
+
+public:
+    /// Constructor
+    UnaryOPVFGNode(NodeID id,const PAGNode* r): VFGNode(id,UnaryOp), res(r)
+    {
+        const UnaryOperator* unary = SVFUtil::dyn_cast<UnaryOperator>(r->getValue());
+        assert(unary && "not a unary operator?");
+    }
+    /// Methods for support type inquiry through isa, cast, and dyn_cast:
+    //@{
+    static inline bool classof(const UnaryOPVFGNode *)
+    {
+        return true;
+    }
+    static inline bool classof(const VFGNode *node)
+    {
+        return node->getNodeKind() == UnaryOp;
+    }
+    static inline bool classof(const GenericVFGNodeTy *node)
+    {
+        return node->getNodeKind() == UnaryOp;
+    }
+    //@}
+    /// Operands at a UnaryNode
     //@{
     inline const PAGNode* getOpVer(u32_t pos) const
     {

--- a/include/SVF-FE/LLVMUtil.h
+++ b/include/SVF-FE/LLVMUtil.h
@@ -585,6 +585,16 @@ inline const ConstantExpr *isBinaryConstantExpr(const Value *val)
     }
     return NULL;
 }
+
+inline const ConstantExpr *isUnaryConstantExpr(const Value *val)
+{
+    if(const ConstantExpr* constExpr = SVFUtil::dyn_cast<ConstantExpr>(val))
+    {
+        if((constExpr->getOpcode() >= Instruction::UnaryOpsBegin) && (constExpr->getOpcode() <= Instruction::UnaryOpsEnd))
+            return constExpr;
+    }
+    return NULL;
+}
 //@}
 
 /// Get the next instructions following control flow

--- a/include/SVF-FE/PAGBuilder.h
+++ b/include/SVF-FE/PAGBuilder.h
@@ -167,6 +167,7 @@ public:
     // void visitUnwindInst(UnwindInst &I) { /*returns void*/}
 
     void visitBinaryOperator(BinaryOperator &I);
+    void visitUnaryOperator(UnaryOperator &I);
     void visitCmpInst(CmpInst &I);
 
     /// TODO: do we need to care about these corner cases?
@@ -289,6 +290,13 @@ public:
     inline BinaryOPPE* addBinaryOPEdge(NodeID src, NodeID dst)
     {
         BinaryOPPE *edge = pag->addBinaryOPPE(src, dst);
+        setCurrentBBAndValueForPAGEdge(edge);
+        return edge;
+    }
+    /// Add Unary edge
+    inline UnaryOPPE* addUnaryOPEdge(NodeID src, NodeID dst)
+    {
+        UnaryOPPE *edge = pag->addUnaryOPPE(src, dst);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }

--- a/include/Util/BasicTypes.h
+++ b/include/Util/BasicTypes.h
@@ -149,6 +149,7 @@ typedef llvm::SwitchInst SwitchInst;
 typedef llvm::ExtractValueInst  ExtractValueInst;
 typedef llvm::InsertValueInst InsertValueInst;
 typedef llvm::BinaryOperator BinaryOperator;
+typedef llvm::UnaryOperator UnaryOperator;
 typedef llvm::PtrToIntInst PtrToIntInst;
 typedef llvm::VAArgInst VAArgInst;
 typedef llvm::ExtractElementInst ExtractElementInst;

--- a/lib/Graphs/ExternalPAG.cpp
+++ b/lib/Graphs/ExternalPAG.cpp
@@ -231,6 +231,9 @@ static void outputPAGEdge(raw_ostream &o, PAGEdge *pagEdge)
     case PAGEdge::BinaryOp:
         edgeKind = "binary-op";
         break;
+    case PAGEdge::UnaryOp:
+        edgeKind = "unary-op";
+        break;
     case PAGEdge::ThreadFork:
         outs() << "dump-function-pags: found ThreadFork edge.\n";
         break;
@@ -463,6 +466,10 @@ bool ExternalPAG::addExternalPAG(const SVFFunction* function)
         else if (extEdgeType == "binary-op")
         {
             pag->addBinaryOPPE(srcId, dstId);
+        }
+        else if (extEdgeType == "unary-op")
+        {
+            pag->addUnaryOPPE(srcId, dstId);
         }
         else
         {

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -203,6 +203,15 @@ const std::string BinaryOPPE::toString() const{
     return rawstr.str();
 }
 
+const std::string UnaryOPPE::toString() const{
+    std::string str;
+    raw_string_ostream rawstr(str);
+    rawstr << "UnaryOPPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    if(getValue())
+        rawstr << *getValue() << getSourceLoc(getValue());
+    return rawstr.str();
+}
+
 const std::string LoadPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
@@ -359,6 +368,23 @@ BinaryOPPE* PAG::addBinaryOPPE(NodeID src, NodeID dst)
         BinaryOPPE* binaryOP = new BinaryOPPE(srcNode, dstNode);
         addEdge(srcNode,dstNode, binaryOP);
         return binaryOP;
+    }
+}
+
+/*!
+ * Add Unary edge
+ */
+UnaryOPPE* PAG::addUnaryOPPE(NodeID src, NodeID dst)
+{
+    PAGNode* srcNode = getPAGNode(src);
+    PAGNode* dstNode = getPAGNode(dst);
+    if(PAGEdge* edge = hasNonlabeledEdge(srcNode,dstNode, PAGEdge::UnaryOp))
+        return SVFUtil::cast<UnaryOPPE>(edge);
+    else
+    {
+        UnaryOPPE* unaryOP = new UnaryOPPE(srcNode, dstNode);
+        addEdge(srcNode,dstNode, unaryOP);
+        return unaryOP;
     }
 }
 
@@ -1125,6 +1151,10 @@ struct DOTGraphTraits<PAG*> : public DefaultDOTGraphTraits
             return "color=grey";
         }
         else if (SVFUtil::isa<BinaryOPPE>(edge))
+        {
+            return "color=grey";
+        }
+        else if (SVFUtil::isa<UnaryOPPE>(edge))
         {
             return "color=grey";
         }

--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -793,6 +793,11 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<PAG*>
             rawstr << "BinOp\n";
             rawstr << getSourceLoc(SVFUtil::cast<IntraBlockNode>(bop->getICFGNode())->getInst());
         }
+        else if(UnaryOPVFGNode* uop = SVFUtil::dyn_cast<UnaryOPVFGNode>(node))
+        {
+            rawstr << "UnOp\n";
+            rawstr << getSourceLoc(SVFUtil::cast<IntraBlockNode>(uop->getICFGNode())->getInst());
+        }
         else if(CmpVFGNode* cmp = SVFUtil::dyn_cast<CmpVFGNode>(node))
         {
             rawstr << "Cmp\n";
@@ -841,6 +846,15 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<PAG*>
         {
             rawstr << tphi->getRes()->getId() << " = Binary(";
             for(BinaryOPVFGNode::OPVers::const_iterator it = tphi->opVerBegin(), eit = tphi->opVerEnd();
+                    it != eit; it++)
+                rawstr << it->second->getId() << ", ";
+            rawstr << ")\n";
+            rawstr << getSourceLoc(tphi->getRes()->getValue());
+        }
+        else if(UnaryOPVFGNode* tphi = SVFUtil::dyn_cast<UnaryOPVFGNode>(node))
+        {
+            rawstr << tphi->getRes()->getId() << " = Unary(";
+            for(UnaryOPVFGNode::OPVers::const_iterator it = tphi->opVerBegin(), eit = tphi->opVerEnd();
                     it != eit; it++)
                 rawstr << it->second->getId() << ", ";
             rawstr << ")\n";

--- a/lib/MemoryModel/PAGBuilderFromFile.cpp
+++ b/lib/MemoryModel/PAGBuilderFromFile.cpp
@@ -180,6 +180,8 @@ void PAGBuilderFromFile::addEdge(NodeID srcID, NodeID dstID,
         pag->addCmpPE(srcID, dstID);
     else if (edge == "binary-op")
         pag->addBinaryOPPE(srcID, dstID);
+    else if (edge == "unary-op")
+        pag->addUnaryOPPE(srcID, dstID);
     else
         assert(false && "format not support, can not create such edge");
 }

--- a/lib/SVF-FE/BreakConstantExpr.cpp
+++ b/lib/SVF-FE/BreakConstantExpr.cpp
@@ -198,6 +198,16 @@ convertExpression (ConstantExpr * CE, Instruction * InsertPt)
         break;
     }
 
+    case Instruction::FNeg:
+    {
+        Instruction::UnaryOps Op = (Instruction::UnaryOps)(CE->getOpcode());
+        NewInst = llvm::UnaryOperator::Create (Op,
+                                                CE->getOperand(0),
+                                                CE->getName(),
+                                                InsertPt);
+        break;
+    }
+
     case Instruction::Trunc:
     case Instruction::ZExt:
     case Instruction::SExt:

--- a/lib/SVF-FE/Graph2Json.cpp
+++ b/lib/SVF-FE/Graph2Json.cpp
@@ -237,6 +237,9 @@ std::string ICFGPrinter::getPAGEdgeKindValue(int kind)
     case (PAGEdge::BinaryOp):
         return "BinaryOp";
         break;
+    case (PAGEdge::UnaryOp):
+        return "UnaryOp";
+        break;
     }
     return "";
 }

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -306,6 +306,16 @@ void PAGBuilder::processCE(const Value *val)
             addBlackHoleAddrEdge(dst);
             setCurrentLocation(cval, cbb);
         }
+        else if (isUnaryConstantExpr(ref))
+        {
+            // we don't handle unary constant expression like fneg(x) now
+            const Value* cval = getCurrentValue();
+            const BasicBlock* cbb = getCurrentBB();
+            setCurrentLocation(ref, NULL);
+            NodeID dst = pag->getValueNode(ref);
+            addBlackHoleAddrEdge(dst);
+            setCurrentLocation(cval, cbb);
+        }
         else if (SVFUtil::isa<ConstantAggregate>(ref))
         {
             // we don't handle constant agrgregate like constant vectors
@@ -596,6 +606,21 @@ void PAGBuilder::visitBinaryOperator(BinaryOperator &inst)
         NodeID src = getValueNode(opnd);
         const BinaryOPPE* binayPE = addBinaryOPEdge(src, dst);
         pag->addBinaryNode(pag->getPAGNode(dst),binayPE);
+    }
+}
+
+/*!
+ * Visit Unary Operator
+ */
+void PAGBuilder::visitUnaryOperator(UnaryOperator &inst)
+{
+    NodeID dst = getValueNode(&inst);
+    for (u32_t i = 0; i < inst.getNumOperands(); i++)
+    {
+        Value* opnd = inst.getOperand(i);
+        NodeID src = getValueNode(opnd);
+        const UnaryOPPE* unaryPE = addUnaryOPEdge(src, dst);
+        pag->addUnaryNode(pag->getPAGNode(dst),unaryPE);
     }
 }
 

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -540,6 +540,11 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule)
                 for (u32_t i = 0; i < binary->getNumOperands(); i++)
                     collectSym(binary->getOperand(i));
             }
+            else if (const UnaryOperator *unary = SVFUtil::dyn_cast<UnaryOperator>(inst))
+            {
+                for (u32_t i = 0; i < unary->getNumOperands(); i++)
+                    collectSym(unary->getOperand(i));
+            }
             else if (const CmpInst *cmp = SVFUtil::dyn_cast<CmpInst>(inst))
             {
                 for (u32_t i = 0; i < cmp->getNumOperands(); i++)

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -203,7 +203,7 @@ bool FlowSensitive::processSVFGNode(SVFGNode* node)
     {
         changed = true;
     }
-    else if(SVFUtil::isa<CmpVFGNode>(node) || SVFUtil::isa<BinaryOPVFGNode>(node))
+    else if(SVFUtil::isa<CmpVFGNode>(node) || SVFUtil::isa<BinaryOPVFGNode>(node) || SVFUtil::dyn_cast<UnaryOPVFGNode>(node))
     {
 
     }


### PR DESCRIPTION
Hi there,

while trying to analyze larger projects, including the SPEC CPU 2017 suite, we realized that some WPA analyses failed because SVF does not handle the `fneg` LLVM instruction or, more generally, does not handle unary operations at all, in contrast to binary operations. `fneg` is currently the only unary operation in LLVM, but the category might be extended in the future.

This patch adds support for unary operations to SVF. The support is implemented analogous to binary ops, in PAG, VFG, SVFG, etc. We tested the patch with our previously failing analyses on the SPEC CPU suite, which are now successfully running through.

The failing behavior we observed without this patch seems quite similar to #306 (and hence also #296), so this patch might also fix those.