### PR TITLE
Use DenseMap for PtsMap.

### DIFF
--- a/include/DDA/DDAClient.h
+++ b/include/DDA/DDAClient.h
@@ -102,7 +102,7 @@ private:
 class FunptrDDAClient : public DDAClient
 {
 private:
-    typedef std::map<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
+    typedef SVFMap<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
     VTablePtrToCallSiteMap vtableToCallSiteMap;
 public:
     FunptrDDAClient(SVFModule* module) : DDAClient(module) {}
@@ -122,7 +122,7 @@ class AliasDDAClient : public DDAClient
 {
 
 public:
-    typedef std::set<const PAGNode*> PAGNodeSet;
+    typedef SVFSet<const PAGNode*> PAGNodeSet;
 
     AliasDDAClient(SVFModule* module) : DDAClient(module) {}
     ~AliasDDAClient() {}
@@ -133,7 +133,7 @@ public:
     virtual void performStat(PointerAnalysis* pta);
 
 private:
-    typedef std::map<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
+    typedef SVFMap<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
     VTablePtrToCallSiteMap vtableToCallSiteMap;
     PAGNodeSet loadSrcNodes;
     PAGNodeSet storeDstNodes;

--- a/include/DDA/DDAClient.h
+++ b/include/DDA/DDAClient.h
@@ -32,20 +32,20 @@ public:
     virtual inline void initialise(SVFModule*) {}
 
     /// Collect candidate pointers for query.
-    virtual inline NodeSet& collectCandidateQueries(PAG* p)
+    virtual inline OrderedNodeSet& collectCandidateQueries(PAG* p)
     {
         setPAG(p);
         if (solveAll)
             candidateQueries = pag->getAllValidPtrs();
         else
         {
-            for (NodeSet::iterator it = userInput.begin(), eit = userInput.end(); it != eit; ++it)
+            for (OrderedNodeSet::iterator it = userInput.begin(), eit = userInput.end(); it != eit; ++it)
                 addCandidate(*it);
         }
         return candidateQueries;
     }
     /// Get candidate queries
-    inline const NodeSet& getCandidateQueries() const
+    inline const OrderedNodeSet& getCandidateQueries() const
     {
         return candidateQueries;
     }
@@ -88,10 +88,10 @@ protected:
     PAG*   pag;					///< PAG graph used by current DDA analysis
     SVFModule* module;		///< LLVM module
     NodeID curPtr;				///< current pointer being queried
-    NodeSet candidateQueries;	///< store all candidate pointers to be queried
+    OrderedNodeSet candidateQueries;	///< store all candidate pointers to be queried
 
 private:
-    NodeSet userInput;           ///< User input queries
+    OrderedNodeSet userInput;           ///< User input queries
     bool solveAll;				///< TRUE if all top level pointers are being queried
 };
 
@@ -102,14 +102,14 @@ private:
 class FunptrDDAClient : public DDAClient
 {
 private:
-    typedef Map<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
+    typedef OrderedMap<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
     VTablePtrToCallSiteMap vtableToCallSiteMap;
 public:
     FunptrDDAClient(SVFModule* module) : DDAClient(module) {}
     ~FunptrDDAClient() {}
 
     /// Only collect function pointers as query candidates.
-    virtual NodeSet& collectCandidateQueries(PAG* p);
+    virtual OrderedNodeSet& collectCandidateQueries(PAG* p);
     virtual void performStat(PointerAnalysis* pta);
 };
 
@@ -122,18 +122,18 @@ class AliasDDAClient : public DDAClient
 {
 
 public:
-    typedef Set<const PAGNode*> PAGNodeSet;
+    typedef OrderedSet<const PAGNode*> PAGNodeSet;
 
     AliasDDAClient(SVFModule* module) : DDAClient(module) {}
     ~AliasDDAClient() {}
 
     /// Only collect function pointers as query candidates.
-    virtual NodeSet& collectCandidateQueries(PAG* pag);
+    virtual OrderedNodeSet& collectCandidateQueries(PAG* pag);
 
     virtual void performStat(PointerAnalysis* pta);
 
 private:
-    typedef Map<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
+    typedef OrderedMap<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
     VTablePtrToCallSiteMap vtableToCallSiteMap;
     PAGNodeSet loadSrcNodes;
     PAGNodeSet storeDstNodes;

--- a/include/DDA/DDAClient.h
+++ b/include/DDA/DDAClient.h
@@ -102,7 +102,7 @@ private:
 class FunptrDDAClient : public DDAClient
 {
 private:
-    typedef SVFMap<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
+    typedef Map<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
     VTablePtrToCallSiteMap vtableToCallSiteMap;
 public:
     FunptrDDAClient(SVFModule* module) : DDAClient(module) {}
@@ -122,7 +122,7 @@ class AliasDDAClient : public DDAClient
 {
 
 public:
-    typedef SVFSet<const PAGNode*> PAGNodeSet;
+    typedef Set<const PAGNode*> PAGNodeSet;
 
     AliasDDAClient(SVFModule* module) : DDAClient(module) {}
     ~AliasDDAClient() {}
@@ -133,7 +133,7 @@ public:
     virtual void performStat(PointerAnalysis* pta);
 
 private:
-    typedef SVFMap<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
+    typedef Map<NodeID,const CallBlockNode*> VTablePtrToCallSiteMap;
     VTablePtrToCallSiteMap vtableToCallSiteMap;
     PAGNodeSet loadSrcNodes;
     PAGNodeSet storeDstNodes;

--- a/include/DDA/DDAPass.h
+++ b/include/DDA/DDAPass.h
@@ -28,7 +28,7 @@ public:
     /// Pass ID
     static char ID;
     typedef SCCDetection<SVFG*> SVFGSCC;
-    typedef Set<const SVFGEdge*> SVFGEdgeSet;
+    typedef OrderedSet<const SVFGEdge*> SVFGEdgeSet;
     typedef std::vector<PointerAnalysis*> PTAVector;
 
     DDAPass() : ModulePass(ID), _pta(NULL), _client(NULL) {}

--- a/include/DDA/DDAPass.h
+++ b/include/DDA/DDAPass.h
@@ -28,7 +28,7 @@ public:
     /// Pass ID
     static char ID;
     typedef SCCDetection<SVFG*> SVFGSCC;
-    typedef DenseSet<const SVFGEdge*> SVFGEdgeSet;
+    typedef SVFSet<const SVFGEdge*> SVFGEdgeSet;
     typedef std::vector<PointerAnalysis*> PTAVector;
 
     DDAPass() : ModulePass(ID), _pta(NULL), _client(NULL) {}

--- a/include/DDA/DDAPass.h
+++ b/include/DDA/DDAPass.h
@@ -28,7 +28,7 @@ public:
     /// Pass ID
     static char ID;
     typedef SCCDetection<SVFG*> SVFGSCC;
-    typedef SVFSet<const SVFGEdge*> SVFGEdgeSet;
+    typedef Set<const SVFGEdge*> SVFGEdgeSet;
     typedef std::vector<PointerAnalysis*> PTAVector;
 
     DDAPass() : ModulePass(ID), _pta(NULL), _client(NULL) {}

--- a/include/DDA/DDAVFSolver.h
+++ b/include/DDA/DDAVFSolver.h
@@ -33,10 +33,10 @@ public:
     typedef OrderedMap<DPIm, CPtSet> DPImToCPtSetMap;
     typedef OrderedMap<DPIm,CVar> DPMToCVarMap;
     typedef OrderedMap<DPIm,DPIm> DPMToDPMMap;
-    typedef Map<NodeID, DPTItemSet> LocToDPMVecMap;
-    typedef Set<const SVFGEdge* > ConstSVFGEdgeSet;
+    typedef OrderedMap<NodeID, DPTItemSet> LocToDPMVecMap;
+    typedef OrderedSet<const SVFGEdge* > ConstSVFGEdgeSet;
     typedef SVFGEdge::SVFGEdgeSetTy SVFGEdgeSet;
-    typedef Map<const SVFGNode*, DPTItemSet> StoreToPMSetMap;
+    typedef OrderedMap<const SVFGNode*, DPTItemSet> StoreToPMSetMap;
 
     ///Constructor
     DDAVFSolver(): outOfBudgetQuery(false),_pag(NULL),_svfg(NULL),_ander(NULL),_callGraph(NULL), _callGraphSCC(NULL), _svfgSCC(NULL), ddaStat(NULL)

--- a/include/DDA/DDAVFSolver.h
+++ b/include/DDA/DDAVFSolver.h
@@ -33,8 +33,8 @@ public:
     typedef std::map<DPIm, CPtSet> DPImToCPtSetMap;
     typedef std::map<DPIm,CVar> DPMToCVarMap;
     typedef std::map<DPIm,DPIm> DPMToDPMMap;
-    typedef DenseMap<NodeID, DPTItemSet> LocToDPMVecMap;
-    typedef DenseSet<const SVFGEdge* > ConstSVFGEdgeSet;
+    typedef SVFMap<NodeID, DPTItemSet> LocToDPMVecMap;
+    typedef SVFSet<const SVFGEdge* > ConstSVFGEdgeSet;
     typedef SVFGEdge::SVFGEdgeSetTy SVFGEdgeSet;
     typedef std::map<const SVFGNode*, DPTItemSet> StoreToPMSetMap;
 

--- a/include/DDA/DDAVFSolver.h
+++ b/include/DDA/DDAVFSolver.h
@@ -29,14 +29,14 @@ public:
     typedef SCCDetection<PTACallGraph*> CallGraphSCC;
     typedef PTACallGraphEdge::CallInstSet CallInstSet;
     typedef PAG::CallSiteSet CallSiteSet;
-    typedef std::set<DPIm> DPTItemSet;
-    typedef std::map<DPIm, CPtSet> DPImToCPtSetMap;
-    typedef std::map<DPIm,CVar> DPMToCVarMap;
-    typedef std::map<DPIm,DPIm> DPMToDPMMap;
+    typedef SVFSet<DPIm> DPTItemSet;
+    typedef SVFMap<DPIm, CPtSet> DPImToCPtSetMap;
+    typedef SVFMap<DPIm,CVar> DPMToCVarMap;
+    typedef SVFMap<DPIm,DPIm> DPMToDPMMap;
     typedef SVFMap<NodeID, DPTItemSet> LocToDPMVecMap;
     typedef SVFSet<const SVFGEdge* > ConstSVFGEdgeSet;
     typedef SVFGEdge::SVFGEdgeSetTy SVFGEdgeSet;
-    typedef std::map<const SVFGNode*, DPTItemSet> StoreToPMSetMap;
+    typedef SVFMap<const SVFGNode*, DPTItemSet> StoreToPMSetMap;
 
     ///Constructor
     DDAVFSolver(): outOfBudgetQuery(false),_pag(NULL),_svfg(NULL),_ander(NULL),_callGraph(NULL), _callGraphSCC(NULL), _svfgSCC(NULL), ddaStat(NULL)

--- a/include/DDA/DDAVFSolver.h
+++ b/include/DDA/DDAVFSolver.h
@@ -29,14 +29,14 @@ public:
     typedef SCCDetection<PTACallGraph*> CallGraphSCC;
     typedef PTACallGraphEdge::CallInstSet CallInstSet;
     typedef PAG::CallSiteSet CallSiteSet;
-    typedef SVFSet<DPIm> DPTItemSet;
-    typedef SVFMap<DPIm, CPtSet> DPImToCPtSetMap;
-    typedef SVFMap<DPIm,CVar> DPMToCVarMap;
-    typedef SVFMap<DPIm,DPIm> DPMToDPMMap;
-    typedef SVFMap<NodeID, DPTItemSet> LocToDPMVecMap;
-    typedef SVFSet<const SVFGEdge* > ConstSVFGEdgeSet;
+    typedef OrderedSet<DPIm> DPTItemSet;
+    typedef OrderedMap<DPIm, CPtSet> DPImToCPtSetMap;
+    typedef OrderedMap<DPIm,CVar> DPMToCVarMap;
+    typedef OrderedMap<DPIm,DPIm> DPMToDPMMap;
+    typedef Map<NodeID, DPTItemSet> LocToDPMVecMap;
+    typedef Set<const SVFGEdge* > ConstSVFGEdgeSet;
     typedef SVFGEdge::SVFGEdgeSetTy SVFGEdgeSet;
-    typedef SVFMap<const SVFGNode*, DPTItemSet> StoreToPMSetMap;
+    typedef Map<const SVFGNode*, DPTItemSet> StoreToPMSetMap;
 
     ///Constructor
     DDAVFSolver(): outOfBudgetQuery(false),_pag(NULL),_svfg(NULL),_ander(NULL),_callGraph(NULL), _callGraphSCC(NULL), _svfgSCC(NULL), ddaStat(NULL)

--- a/include/Graphs/ConsG.h
+++ b/include/Graphs/ConsG.h
@@ -45,10 +45,10 @@ class ConstraintGraph :  public GenericGraph<ConstraintNode,ConstraintEdge>
 {
 
 public:
-    typedef SVFMap<NodeID, ConstraintNode *> ConstraintNodeIDToNodeMapTy;
+    typedef Map<NodeID, ConstraintNode *> ConstraintNodeIDToNodeMapTy;
     typedef ConstraintEdge::ConstraintEdgeSetTy::iterator ConstraintNodeIter;
-    typedef SVFMap<NodeID, NodeID> NodeToRepMap;
-    typedef SVFMap<NodeID, NodeBS> NodeToSubsMap;
+    typedef Map<NodeID, NodeID> NodeToRepMap;
+    typedef Map<NodeID, NodeBS> NodeToSubsMap;
     typedef FIFOWorkList<NodeID> WorkList;
 
 protected:

--- a/include/Graphs/ConsG.h
+++ b/include/Graphs/ConsG.h
@@ -45,10 +45,10 @@ class ConstraintGraph :  public GenericGraph<ConstraintNode,ConstraintEdge>
 {
 
 public:
-    typedef DenseMap<NodeID, ConstraintNode *> ConstraintNodeIDToNodeMapTy;
+    typedef SVFMap<NodeID, ConstraintNode *> ConstraintNodeIDToNodeMapTy;
     typedef ConstraintEdge::ConstraintEdgeSetTy::iterator ConstraintNodeIter;
-    typedef DenseMap<NodeID, NodeID> NodeToRepMap;
-    typedef DenseMap<NodeID, NodeBS> NodeToSubsMap;
+    typedef SVFMap<NodeID, NodeID> NodeToRepMap;
+    typedef SVFMap<NodeID, NodeBS> NodeToSubsMap;
     typedef FIFOWorkList<NodeID> WorkList;
 
 protected:

--- a/include/Graphs/ExternalPAG.h
+++ b/include/Graphs/ExternalPAG.h
@@ -24,19 +24,19 @@ class ExternalPAG
 private:
     /// Maps function names to the entry nodes of the extpag which implements
     /// it. This is to connect arguments and callsites.
-    static DenseMap<const SVFFunction*, DenseMap<int, PAGNode *>>
+    static SVFMap<const SVFFunction*, SVFMap<int, PAGNode *>>
             functionToExternalPAGEntries;
-    static DenseMap<const SVFFunction*, PAGNode *> functionToExternalPAGReturns;
+    static SVFMap<const SVFFunction*, PAGNode *> functionToExternalPAGReturns;
 
     /// Name of the function this external PAG represents.
     std::string functionName;
 
     /// Value nodes in this external PAG, represented by NodeIDs
     /// because we will rebuild these nodes in the main PAG.
-    DenseNodeSet valueNodes;
+    NodeSet valueNodes;
     /// Object nodes in this external PAG, represented by NodeIDs
     /// because we will rebuild these nodes in the main PAG.
-    DenseNodeSet objectNodes;
+    NodeSet objectNodes;
     /// Edges in this external PAG, represented by the parts of an Edge because
     /// we will rebuild these edges in the main PAG.
     std::set<std::tuple<NodeID, NodeID, std::string, int>>edges;
@@ -45,7 +45,7 @@ private:
 
     /// Nodes in the ExternalPAG which call edges should connect to.
     /// argNodes[0] is arg 0, argNodes[1] is arg 1, ...
-    DenseMap<int, NodeID> argNodes;
+    SVFMap<int, NodeID> argNodes;
     /// Node from which return edges connect.
     NodeID returnNode;
 
@@ -101,11 +101,11 @@ public:
         return functionName;
     }
 
-    DenseNodeSet &getValueNodes()
+    NodeSet &getValueNodes()
     {
         return valueNodes;
     }
-    DenseNodeSet &getObjectNodes()
+    NodeSet &getObjectNodes()
     {
         return objectNodes;
     }
@@ -114,7 +114,7 @@ public:
         return edges;
     }
 
-    DenseMap<int, NodeID> &getArgNodes()
+    SVFMap<int, NodeID> &getArgNodes()
     {
         return argNodes;
     }

--- a/include/Graphs/ExternalPAG.h
+++ b/include/Graphs/ExternalPAG.h
@@ -24,9 +24,9 @@ class ExternalPAG
 private:
     /// Maps function names to the entry nodes of the extpag which implements
     /// it. This is to connect arguments and callsites.
-    static SVFMap<const SVFFunction*, SVFMap<int, PAGNode *>>
+    static Map<const SVFFunction*, Map<int, PAGNode *>>
             functionToExternalPAGEntries;
-    static SVFMap<const SVFFunction*, PAGNode *> functionToExternalPAGReturns;
+    static Map<const SVFFunction*, PAGNode *> functionToExternalPAGReturns;
 
     /// Name of the function this external PAG represents.
     std::string functionName;
@@ -39,13 +39,13 @@ private:
     NodeSet objectNodes;
     /// Edges in this external PAG, represented by the parts of an Edge because
     /// we will rebuild these edges in the main PAG.
-    SVFSet<std::tuple<NodeID, NodeID, std::string, int>>edges;
+    OrderedSet<std::tuple<NodeID, NodeID, std::string, int>> edges;
 
     // Special nodes.
 
     /// Nodes in the ExternalPAG which call edges should connect to.
     /// argNodes[0] is arg 0, argNodes[1] is arg 1, ...
-    SVFMap<int, NodeID> argNodes;
+    Map<int, NodeID> argNodes;
     /// Node from which return edges connect.
     NodeID returnNode;
 
@@ -109,12 +109,12 @@ public:
     {
         return objectNodes;
     }
-    SVFSet<std::tuple<NodeID, NodeID, std::string, int>> &getEdges()
+    OrderedSet<std::tuple<NodeID, NodeID, std::string, int>> &getEdges()
     {
         return edges;
     }
 
-    SVFMap<int, NodeID> &getArgNodes()
+    Map<int, NodeID> &getArgNodes()
     {
         return argNodes;
     }

--- a/include/Graphs/ExternalPAG.h
+++ b/include/Graphs/ExternalPAG.h
@@ -39,7 +39,7 @@ private:
     NodeSet objectNodes;
     /// Edges in this external PAG, represented by the parts of an Edge because
     /// we will rebuild these edges in the main PAG.
-    std::set<std::tuple<NodeID, NodeID, std::string, int>>edges;
+    SVFSet<std::tuple<NodeID, NodeID, std::string, int>>edges;
 
     // Special nodes.
 
@@ -109,7 +109,7 @@ public:
     {
         return objectNodes;
     }
-    std::set<std::tuple<NodeID, NodeID, std::string, int>> &getEdges()
+    SVFSet<std::tuple<NodeID, NodeID, std::string, int>> &getEdges()
     {
         return edges;
     }

--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -331,7 +331,7 @@ public:
     typedef NodeTy NodeType;
     typedef EdgeTy EdgeType;
     /// NodeID to GenericNode map
-    typedef SVFMap<NodeID, NodeType*> IDToNodeMapTy;
+    typedef Map<NodeID, NodeType*> IDToNodeMapTy;
 
     /// Node Iterators
     //@{

--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -133,7 +133,7 @@ public:
     typedef EdgeTy EdgeType;
     /// Edge kind
     typedef s32_t GNodeK;
-    typedef SVFSet<EdgeType*, typename EdgeType::equalGEdge> GEdgeSetTy;
+    typedef OrderedSet<EdgeType*, typename EdgeType::equalGEdge> GEdgeSetTy;
     /// Edge iterator
     ///@{
     typedef typename GEdgeSetTy::iterator iterator;

--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -133,7 +133,7 @@ public:
     typedef EdgeTy EdgeType;
     /// Edge kind
     typedef s32_t GNodeK;
-    typedef std::set<EdgeType*, typename EdgeType::equalGEdge> GEdgeSetTy;
+    typedef SVFSet<EdgeType*, typename EdgeType::equalGEdge> GEdgeSetTy;
     /// Edge iterator
     ///@{
     typedef typename GEdgeSetTy::iterator iterator;

--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -331,7 +331,7 @@ public:
     typedef NodeTy NodeType;
     typedef EdgeTy EdgeType;
     /// NodeID to GenericNode map
-    typedef DenseMap<NodeID, NodeType*> IDToNodeMapTy;
+    typedef SVFMap<NodeID, NodeType*> IDToNodeMapTy;
 
     /// Node Iterators
     //@{

--- a/include/Graphs/ICFG.h
+++ b/include/Graphs/ICFG.h
@@ -48,16 +48,16 @@ class ICFG : public GenericICFGTy
 
 public:
 
-    typedef SVFMap<NodeID, ICFGNode *> ICFGNodeIDToNodeMapTy;
+    typedef Map<NodeID, ICFGNode *> ICFGNodeIDToNodeMapTy;
     typedef ICFGEdge::ICFGEdgeSetTy ICFGEdgeSetTy;
     typedef ICFGNodeIDToNodeMapTy::iterator iterator;
     typedef ICFGNodeIDToNodeMapTy::const_iterator const_iterator;
 
-    typedef SVFMap<const SVFFunction*, FunEntryBlockNode *> FunToFunEntryNodeMapTy;
-    typedef SVFMap<const SVFFunction*, FunExitBlockNode *> FunToFunExitNodeMapTy;
-    typedef SVFMap<const Instruction*, CallBlockNode *> CSToCallNodeMapTy;
-    typedef SVFMap<const Instruction*, RetBlockNode *> CSToRetNodeMapTy;
-    typedef SVFMap<const Instruction*, IntraBlockNode *> InstToBlockNodeMapTy;
+    typedef Map<const SVFFunction*, FunEntryBlockNode *> FunToFunEntryNodeMapTy;
+    typedef Map<const SVFFunction*, FunExitBlockNode *> FunToFunExitNodeMapTy;
+    typedef Map<const Instruction*, CallBlockNode *> CSToCallNodeMapTy;
+    typedef Map<const Instruction*, RetBlockNode *> CSToRetNodeMapTy;
+    typedef Map<const Instruction*, IntraBlockNode *> InstToBlockNodeMapTy;
 
     NodeID totalICFGNode;
 

--- a/include/Graphs/ICFG.h
+++ b/include/Graphs/ICFG.h
@@ -48,16 +48,16 @@ class ICFG : public GenericICFGTy
 
 public:
 
-    typedef DenseMap<NodeID, ICFGNode *> ICFGNodeIDToNodeMapTy;
+    typedef SVFMap<NodeID, ICFGNode *> ICFGNodeIDToNodeMapTy;
     typedef ICFGEdge::ICFGEdgeSetTy ICFGEdgeSetTy;
     typedef ICFGNodeIDToNodeMapTy::iterator iterator;
     typedef ICFGNodeIDToNodeMapTy::const_iterator const_iterator;
 
-    typedef DenseMap<const SVFFunction*, FunEntryBlockNode *> FunToFunEntryNodeMapTy;
-    typedef DenseMap<const SVFFunction*, FunExitBlockNode *> FunToFunExitNodeMapTy;
-    typedef DenseMap<const Instruction*, CallBlockNode *> CSToCallNodeMapTy;
-    typedef DenseMap<const Instruction*, RetBlockNode *> CSToRetNodeMapTy;
-    typedef DenseMap<const Instruction*, IntraBlockNode *> InstToBlockNodeMapTy;
+    typedef SVFMap<const SVFFunction*, FunEntryBlockNode *> FunToFunEntryNodeMapTy;
+    typedef SVFMap<const SVFFunction*, FunExitBlockNode *> FunToFunExitNodeMapTy;
+    typedef SVFMap<const Instruction*, CallBlockNode *> CSToCallNodeMapTy;
+    typedef SVFMap<const Instruction*, RetBlockNode *> CSToRetNodeMapTy;
+    typedef SVFMap<const Instruction*, IntraBlockNode *> InstToBlockNodeMapTy;
 
     NodeID totalICFGNode;
 

--- a/include/Graphs/ICFGNode.h
+++ b/include/Graphs/ICFGNode.h
@@ -64,8 +64,8 @@ public:
 
     typedef ICFGEdge::ICFGEdgeSetTy::iterator iterator;
     typedef ICFGEdge::ICFGEdgeSetTy::const_iterator const_iterator;
-    typedef DenseSet<const CallPE *> CallPESet;
-    typedef DenseSet<const RetPE *> RetPESet;
+    typedef SVFSet<const CallPE *> CallPESet;
+    typedef SVFSet<const RetPE *> RetPESet;
     typedef std::list<const VFGNode*> VFGNodeList;
 
 public:

--- a/include/Graphs/ICFGNode.h
+++ b/include/Graphs/ICFGNode.h
@@ -64,8 +64,8 @@ public:
 
     typedef ICFGEdge::ICFGEdgeSetTy::iterator iterator;
     typedef ICFGEdge::ICFGEdgeSetTy::const_iterator const_iterator;
-    typedef SVFSet<const CallPE *> CallPESet;
-    typedef SVFSet<const RetPE *> RetPESet;
+    typedef Set<const CallPE *> CallPESet;
+    typedef Set<const RetPE *> RetPESet;
     typedef std::list<const VFGNode*> VFGNodeList;
 
 public:

--- a/include/Graphs/ICFGStat.h
+++ b/include/Graphs/ICFGStat.h
@@ -54,7 +54,7 @@ private:
     int numOfIntraEdges;
 
 public:
-    typedef DenseSet<const ICFGNode *> ICFGNodeSet;
+    typedef SVFSet<const ICFGNode *> ICFGNodeSet;
 
     ICFGStat(ICFG *cfg) : PTAStat(NULL), icfg(cfg)
     {

--- a/include/Graphs/ICFGStat.h
+++ b/include/Graphs/ICFGStat.h
@@ -54,7 +54,7 @@ private:
     int numOfIntraEdges;
 
 public:
-    typedef SVFSet<const ICFGNode *> ICFGNodeSet;
+    typedef Set<const ICFGNode *> ICFGNodeSet;
 
     ICFGStat(ICFG *cfg) : PTAStat(NULL), icfg(cfg)
     {

--- a/include/Graphs/OfflineConsG.h
+++ b/include/Graphs/OfflineConsG.h
@@ -46,8 +46,8 @@ class OfflineConsG: public ConstraintGraph
 
 public:
     typedef SCCDetection<OfflineConsG*> OSCC;
-    typedef std::set<LoadCGEdge*> LoadEdges;
-    typedef std::set<StoreCGEdge*> StoreEdges;
+    typedef SVFSet<LoadCGEdge*> LoadEdges;
+    typedef SVFSet<StoreCGEdge*> StoreEdges;
 
 protected:
     NodeSet refNodes;

--- a/include/Graphs/OfflineConsG.h
+++ b/include/Graphs/OfflineConsG.h
@@ -46,8 +46,8 @@ class OfflineConsG: public ConstraintGraph
 
 public:
     typedef SCCDetection<OfflineConsG*> OSCC;
-    typedef SVFSet<LoadCGEdge*> LoadEdges;
-    typedef SVFSet<StoreCGEdge*> StoreEdges;
+    typedef Set<LoadCGEdge*> LoadEdges;
+    typedef Set<StoreCGEdge*> StoreEdges;
 
 protected:
     NodeSet refNodes;

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -48,7 +48,7 @@ class PAG : public GenericGraph<PAGNode,PAGEdge>
 
 public:
     typedef Set<const CallBlockNode*> CallSiteSet;
-    typedef Map<const CallBlockNode*,NodeID> CallSiteToFunPtrMap;
+    typedef OrderedMap<const CallBlockNode*,NodeID> CallSiteToFunPtrMap;
     typedef Map<NodeID,CallSiteSet> FunPtrToCallSitesMap;
     typedef Map<NodeID,NodeBS> MemObjToFieldsMap;
     typedef Set<const PAGEdge*> PAGEdgeSet;

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -47,34 +47,34 @@ class PAG : public GenericGraph<PAGNode,PAGEdge>
 {
 
 public:
-    typedef SVFSet<const CallBlockNode*> CallSiteSet;
-    typedef SVFMap<const CallBlockNode*,NodeID> CallSiteToFunPtrMap;
-    typedef SVFMap<NodeID,CallSiteSet> FunPtrToCallSitesMap;
-    typedef SVFMap<NodeID,NodeBS> MemObjToFieldsMap;
-    typedef SVFSet<const PAGEdge*> PAGEdgeSet;
+    typedef Set<const CallBlockNode*> CallSiteSet;
+    typedef Map<const CallBlockNode*,NodeID> CallSiteToFunPtrMap;
+    typedef Map<NodeID,CallSiteSet> FunPtrToCallSitesMap;
+    typedef Map<NodeID,NodeBS> MemObjToFieldsMap;
+    typedef Set<const PAGEdge*> PAGEdgeSet;
     typedef std::vector<const PAGEdge*> PAGEdgeList;
     typedef std::vector<const PAGNode*> PAGNodeList;
     typedef std::vector<const CopyPE*> CopyPEList;
     typedef std::vector<const BinaryOPPE*> BinaryOPList;
     typedef std::vector<const UnaryOPPE*> UnaryOPList;
     typedef std::vector<const CmpPE*> CmpPEList;
-    typedef SVFMap<const PAGNode*,CopyPEList> PHINodeMap;
-    typedef SVFMap<const PAGNode*,BinaryOPList> BinaryNodeMap;
-    typedef SVFMap<const PAGNode*,UnaryOPList> UnaryNodeMap;
-    typedef SVFMap<const PAGNode*,CmpPEList> CmpNodeMap;
-    typedef SVFMap<const SVFFunction*,PAGNodeList> FunToArgsListMap;
-    typedef SVFMap<const CallBlockNode*,PAGNodeList> CSToArgsListMap;
-    typedef SVFMap<const RetBlockNode*,const PAGNode*> CSToRetMap;
-    typedef SVFMap<const SVFFunction*,const PAGNode*> FunToRetMap;
-    typedef SVFMap<const SVFFunction*,PAGEdgeSet> FunToPAGEdgeSetMap;
-    typedef SVFMap<const ICFGNode*,PAGEdgeList> Inst2PAGEdgesMap;
-    typedef SVFMap<NodeID, NodeID> NodeToNodeMap;
+    typedef Map<const PAGNode*,CopyPEList> PHINodeMap;
+    typedef Map<const PAGNode*,BinaryOPList> BinaryNodeMap;
+    typedef Map<const PAGNode*,UnaryOPList> UnaryNodeMap;
+    typedef Map<const PAGNode*,CmpPEList> CmpNodeMap;
+    typedef Map<const SVFFunction*,PAGNodeList> FunToArgsListMap;
+    typedef Map<const CallBlockNode*,PAGNodeList> CSToArgsListMap;
+    typedef Map<const RetBlockNode*,const PAGNode*> CSToRetMap;
+    typedef Map<const SVFFunction*,const PAGNode*> FunToRetMap;
+    typedef Map<const SVFFunction*,PAGEdgeSet> FunToPAGEdgeSetMap;
+    typedef Map<const ICFGNode*,PAGEdgeList> Inst2PAGEdgesMap;
+    typedef Map<NodeID, NodeID> NodeToNodeMap;
     typedef std::pair<NodeID, Size_t> NodeOffset;
     typedef std::pair<NodeID, LocationSet> NodeLocationSet;
-    typedef SVFMap<NodeOffset,NodeID> NodeOffsetMap;
-    typedef SVFMap<NodeLocationSet,NodeID> NodeLocationSetMap;
-    typedef SVFMap<const Value*, NodeLocationSetMap> GepValPNMap;
-    typedef SVFMap<NodePair,NodeID> NodePairSetMap;
+    typedef Map<NodeOffset,NodeID> NodeOffsetMap;
+    typedef Map<NodeLocationSet,NodeID> NodeLocationSetMap;
+    typedef Map<const Value*, NodeLocationSetMap> GepValPNMap;
+    typedef Map<NodePair,NodeID> NodePairSetMap;
 
 private:
     SymbolTableInfo* symInfo;

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -47,34 +47,34 @@ class PAG : public GenericGraph<PAGNode,PAGEdge>
 {
 
 public:
-    typedef DenseSet<const CallBlockNode*> CallSiteSet;
-    typedef DenseMap<const CallBlockNode*,NodeID> CallSiteToFunPtrMap;
-    typedef DenseMap<NodeID,CallSiteSet> FunPtrToCallSitesMap;
-    typedef DenseMap<NodeID,NodeBS> MemObjToFieldsMap;
-    typedef DenseSet<const PAGEdge*> PAGEdgeSet;
+    typedef SVFSet<const CallBlockNode*> CallSiteSet;
+    typedef SVFMap<const CallBlockNode*,NodeID> CallSiteToFunPtrMap;
+    typedef SVFMap<NodeID,CallSiteSet> FunPtrToCallSitesMap;
+    typedef SVFMap<NodeID,NodeBS> MemObjToFieldsMap;
+    typedef SVFSet<const PAGEdge*> PAGEdgeSet;
     typedef std::vector<const PAGEdge*> PAGEdgeList;
     typedef std::vector<const PAGNode*> PAGNodeList;
     typedef std::vector<const CopyPE*> CopyPEList;
     typedef std::vector<const BinaryOPPE*> BinaryOPList;
     typedef std::vector<const UnaryOPPE*> UnaryOPList;
     typedef std::vector<const CmpPE*> CmpPEList;
-    typedef DenseMap<const PAGNode*,CopyPEList> PHINodeMap;
-    typedef DenseMap<const PAGNode*,BinaryOPList> BinaryNodeMap;
-    typedef DenseMap<const PAGNode*,UnaryOPList> UnaryNodeMap;
-    typedef DenseMap<const PAGNode*,CmpPEList> CmpNodeMap;
-    typedef DenseMap<const SVFFunction*,PAGNodeList> FunToArgsListMap;
-    typedef DenseMap<const CallBlockNode*,PAGNodeList> CSToArgsListMap;
-    typedef DenseMap<const RetBlockNode*,const PAGNode*> CSToRetMap;
-    typedef DenseMap<const SVFFunction*,const PAGNode*> FunToRetMap;
-    typedef DenseMap<const SVFFunction*,PAGEdgeSet> FunToPAGEdgeSetMap;
-    typedef DenseMap<const ICFGNode*,PAGEdgeList> Inst2PAGEdgesMap;
-    typedef DenseMap<NodeID, NodeID> NodeToNodeMap;
+    typedef SVFMap<const PAGNode*,CopyPEList> PHINodeMap;
+    typedef SVFMap<const PAGNode*,BinaryOPList> BinaryNodeMap;
+    typedef SVFMap<const PAGNode*,UnaryOPList> UnaryNodeMap;
+    typedef SVFMap<const PAGNode*,CmpPEList> CmpNodeMap;
+    typedef SVFMap<const SVFFunction*,PAGNodeList> FunToArgsListMap;
+    typedef SVFMap<const CallBlockNode*,PAGNodeList> CSToArgsListMap;
+    typedef SVFMap<const RetBlockNode*,const PAGNode*> CSToRetMap;
+    typedef SVFMap<const SVFFunction*,const PAGNode*> FunToRetMap;
+    typedef SVFMap<const SVFFunction*,PAGEdgeSet> FunToPAGEdgeSetMap;
+    typedef SVFMap<const ICFGNode*,PAGEdgeList> Inst2PAGEdgesMap;
+    typedef SVFMap<NodeID, NodeID> NodeToNodeMap;
     typedef std::pair<NodeID, Size_t> NodeOffset;
     typedef std::pair<NodeID, LocationSet> NodeLocationSet;
-    typedef DenseMap<NodeOffset,NodeID,DenseMapInfo<std::pair<NodeID,Size_t> > > NodeOffsetMap;
-    typedef std::map<NodeLocationSet,NodeID> NodeLocationSetMap;
-    typedef std::map<const Value*, NodeLocationSetMap> GepValPNMap;
-    typedef DenseMap<NodePair,NodeID> NodePairSetMap;
+    typedef SVFMap<NodeOffset,NodeID> NodeOffsetMap;
+    typedef SVFMap<NodeLocationSet,NodeID> NodeLocationSetMap;
+    typedef SVFMap<const Value*, NodeLocationSetMap> GepValPNMap;
+    typedef SVFMap<NodePair,NodeID> NodePairSetMap;
 
 private:
     SymbolTableInfo* symInfo;

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -102,7 +102,7 @@ private:
     bool fromFile; ///< Whether the PAG is built according to user specified data from a txt file
     /// Valid pointers for pointer analysis resolution connected by PAG edges (constraints)
     /// this set of candidate pointers can change during pointer resolution (e.g. adding new object nodes)
-    NodeSet candidatePointers;
+    OrderedNodeSet candidatePointers;
     NodeID nodeNumAfterPAGBuild; // initial node number after building PAG, excluding later added nodes, e.g., gepobj nodes
     ICFG* icfg; // ICFG
     CallSiteSet callSiteSet; /// all the callsites of a program
@@ -123,7 +123,7 @@ public:
     }
 
     /// Return valid pointers
-    inline NodeSet& getAllValidPtrs()
+    inline OrderedNodeSet& getAllValidPtrs()
     {
         return candidatePointers;
     }

--- a/include/Graphs/PAGEdge.h
+++ b/include/Graphs/PAGEdge.h
@@ -167,11 +167,11 @@ public:
     //@}
 
     typedef GenericNode<PAGNode,PAGEdge>::GEdgeSetTy PAGEdgeSetTy;
-    typedef DenseMap<EdgeID, PAGEdgeSetTy> PAGEdgeToSetMapTy;
+    typedef SVFMap<EdgeID, PAGEdgeSetTy> PAGEdgeToSetMapTy;
     typedef PAGEdgeToSetMapTy PAGKindToEdgeSetMapTy;
 
 private:
-    typedef DenseMap<const ICFGNode*, u32_t> Inst2LabelMap;
+    typedef SVFMap<const ICFGNode*, u32_t> Inst2LabelMap;
     static Inst2LabelMap inst2LabelMap; ///< Call site Instruction to label map
     static u64_t callEdgeLabelCounter;  ///< Call site Instruction counter
     static u64_t storeEdgeLabelCounter;  ///< Store Instruction counter

--- a/include/Graphs/PAGEdge.h
+++ b/include/Graphs/PAGEdge.h
@@ -167,11 +167,11 @@ public:
     //@}
 
     typedef GenericNode<PAGNode,PAGEdge>::GEdgeSetTy PAGEdgeSetTy;
-    typedef SVFMap<EdgeID, PAGEdgeSetTy> PAGEdgeToSetMapTy;
+    typedef Map<EdgeID, PAGEdgeSetTy> PAGEdgeToSetMapTy;
     typedef PAGEdgeToSetMapTy PAGKindToEdgeSetMapTy;
 
 private:
-    typedef SVFMap<const ICFGNode*, u32_t> Inst2LabelMap;
+    typedef Map<const ICFGNode*, u32_t> Inst2LabelMap;
     static Inst2LabelMap inst2LabelMap; ///< Call site Instruction to label map
     static u64_t callEdgeLabelCounter;  ///< Call site Instruction counter
     static u64_t storeEdgeLabelCounter;  ///< Store Instruction counter

--- a/include/Graphs/PTACallGraph.h
+++ b/include/Graphs/PTACallGraph.h
@@ -52,7 +52,7 @@ class PTACallGraphEdge : public GenericCallGraphEdgeTy
 {
 
 public:
-    typedef std::set<const CallBlockNode*> CallInstSet;
+    typedef SVFSet<const CallBlockNode*> CallInstSet;
     enum CEDGEK
     {
         CallRetEdge,TDForkEdge,TDJoinEdge,HareParForEdge

--- a/include/Graphs/PTACallGraph.h
+++ b/include/Graphs/PTACallGraph.h
@@ -220,13 +220,13 @@ class PTACallGraph : public GenericCallGraphTy
 
 public:
     typedef PTACallGraphEdge::CallGraphEdgeSet CallGraphEdgeSet;
-    typedef DenseMap<const SVFFunction*, PTACallGraphNode *> FunToCallGraphNodeMap;
-    typedef DenseMap<const CallBlockNode*, CallGraphEdgeSet> CallInstToCallGraphEdgesMap;
+    typedef SVFMap<const SVFFunction*, PTACallGraphNode *> FunToCallGraphNodeMap;
+    typedef SVFMap<const CallBlockNode*, CallGraphEdgeSet> CallInstToCallGraphEdgesMap;
     typedef std::pair<const CallBlockNode*, const SVFFunction*> CallSitePair;
-    typedef DenseMap<CallSitePair, CallSiteID> CallSiteToIdMap;
-    typedef DenseMap<CallSiteID, CallSitePair> IdToCallSiteMap;
-    typedef DenseSet<const SVFFunction*> FunctionSet;
-    typedef DenseMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
+    typedef SVFMap<CallSitePair, CallSiteID> CallSiteToIdMap;
+    typedef SVFMap<CallSiteID, CallSitePair> IdToCallSiteMap;
+    typedef SVFSet<const SVFFunction*> FunctionSet;
+    typedef SVFMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
     typedef CallGraphEdgeSet::iterator CallGraphEdgeIter;
     typedef CallGraphEdgeSet::const_iterator CallGraphEdgeConstIter;
 

--- a/include/Graphs/PTACallGraph.h
+++ b/include/Graphs/PTACallGraph.h
@@ -52,7 +52,7 @@ class PTACallGraphEdge : public GenericCallGraphEdgeTy
 {
 
 public:
-    typedef SVFSet<const CallBlockNode*> CallInstSet;
+    typedef Set<const CallBlockNode*> CallInstSet;
     enum CEDGEK
     {
         CallRetEdge,TDForkEdge,TDJoinEdge,HareParForEdge
@@ -119,20 +119,20 @@ public:
 
     /// Iterators for direct and indirect callsites
     //@{
-    inline CallInstSet::iterator directCallsBegin() const
+    inline CallInstSet::const_iterator directCallsBegin() const
     {
         return directCalls.begin();
     }
-    inline CallInstSet::iterator directCallsEnd() const
+    inline CallInstSet::const_iterator directCallsEnd() const
     {
         return directCalls.end();
     }
 
-    inline CallInstSet::iterator indirectCallsBegin() const
+    inline CallInstSet::const_iterator indirectCallsBegin() const
     {
         return indirectCalls.begin();
     }
-    inline CallInstSet::iterator indirectCallsEnd() const
+    inline CallInstSet::const_iterator indirectCallsEnd() const
     {
         return indirectCalls.end();
     }
@@ -220,13 +220,13 @@ class PTACallGraph : public GenericCallGraphTy
 
 public:
     typedef PTACallGraphEdge::CallGraphEdgeSet CallGraphEdgeSet;
-    typedef SVFMap<const SVFFunction*, PTACallGraphNode *> FunToCallGraphNodeMap;
-    typedef SVFMap<const CallBlockNode*, CallGraphEdgeSet> CallInstToCallGraphEdgesMap;
+    typedef Map<const SVFFunction*, PTACallGraphNode *> FunToCallGraphNodeMap;
+    typedef Map<const CallBlockNode*, CallGraphEdgeSet> CallInstToCallGraphEdgesMap;
     typedef std::pair<const CallBlockNode*, const SVFFunction*> CallSitePair;
-    typedef SVFMap<CallSitePair, CallSiteID> CallSiteToIdMap;
-    typedef SVFMap<CallSiteID, CallSitePair> IdToCallSiteMap;
-    typedef SVFSet<const SVFFunction*> FunctionSet;
-    typedef SVFMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
+    typedef Map<CallSitePair, CallSiteID> CallSiteToIdMap;
+    typedef Map<CallSiteID, CallSitePair> IdToCallSiteMap;
+    typedef Set<const SVFFunction*> FunctionSet;
+    typedef Map<const CallBlockNode*, FunctionSet> CallEdgeMap;
     typedef CallGraphEdgeSet::iterator CallGraphEdgeIter;
     typedef CallGraphEdgeSet::const_iterator CallGraphEdgeConstIter;
 

--- a/include/Graphs/PTACallGraph.h
+++ b/include/Graphs/PTACallGraph.h
@@ -226,7 +226,7 @@ public:
     typedef Map<CallSitePair, CallSiteID> CallSiteToIdMap;
     typedef Map<CallSiteID, CallSitePair> IdToCallSiteMap;
     typedef Set<const SVFFunction*> FunctionSet;
-    typedef Map<const CallBlockNode*, FunctionSet> CallEdgeMap;
+    typedef OrderedMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
     typedef CallGraphEdgeSet::iterator CallGraphEdgeIter;
     typedef CallGraphEdgeSet::const_iterator CallGraphEdgeConstIter;
 

--- a/include/Graphs/SVFG.h
+++ b/include/Graphs/SVFG.h
@@ -73,16 +73,16 @@ class SVFG : public VFG
 
 public:
     typedef VFGNodeIDToNodeMapTy SVFGNodeIDToNodeMapTy;
-    typedef DenseMap<const PAGNode*, NodeID> PAGNodeToDefMapTy;
-    typedef DenseMap<const MRVer*, NodeID> MSSAVarToDefMapTy;
+    typedef SVFMap<const PAGNode*, NodeID> PAGNodeToDefMapTy;
+    typedef SVFMap<const MRVer*, NodeID> MSSAVarToDefMapTy;
     typedef NodeBS ActualINSVFGNodeSet;
     typedef NodeBS ActualOUTSVFGNodeSet;
     typedef NodeBS FormalINSVFGNodeSet;
     typedef NodeBS FormalOUTSVFGNodeSet;
-    typedef DenseMap<const CallBlockNode*, ActualINSVFGNodeSet>  CallSiteToActualINsMapTy;
-    typedef DenseMap<const CallBlockNode*, ActualOUTSVFGNodeSet>  CallSiteToActualOUTsMapTy;
-    typedef DenseMap<const SVFFunction*, FormalINSVFGNodeSet>  FunctionToFormalINsMapTy;
-    typedef DenseMap<const SVFFunction*, FormalOUTSVFGNodeSet>  FunctionToFormalOUTsMapTy;
+    typedef SVFMap<const CallBlockNode*, ActualINSVFGNodeSet>  CallSiteToActualINsMapTy;
+    typedef SVFMap<const CallBlockNode*, ActualOUTSVFGNodeSet>  CallSiteToActualOUTsMapTy;
+    typedef SVFMap<const SVFFunction*, FormalINSVFGNodeSet>  FunctionToFormalINsMapTy;
+    typedef SVFMap<const SVFFunction*, FormalOUTSVFGNodeSet>  FunctionToFormalOUTsMapTy;
     typedef MemSSA::MUSet MUSet;
     typedef MemSSA::CHISet CHISet;
     typedef MemSSA::PHISet PHISet;

--- a/include/Graphs/SVFG.h
+++ b/include/Graphs/SVFG.h
@@ -73,16 +73,16 @@ class SVFG : public VFG
 
 public:
     typedef VFGNodeIDToNodeMapTy SVFGNodeIDToNodeMapTy;
-    typedef SVFMap<const PAGNode*, NodeID> PAGNodeToDefMapTy;
-    typedef SVFMap<const MRVer*, NodeID> MSSAVarToDefMapTy;
+    typedef Map<const PAGNode*, NodeID> PAGNodeToDefMapTy;
+    typedef Map<const MRVer*, NodeID> MSSAVarToDefMapTy;
     typedef NodeBS ActualINSVFGNodeSet;
     typedef NodeBS ActualOUTSVFGNodeSet;
     typedef NodeBS FormalINSVFGNodeSet;
     typedef NodeBS FormalOUTSVFGNodeSet;
-    typedef SVFMap<const CallBlockNode*, ActualINSVFGNodeSet>  CallSiteToActualINsMapTy;
-    typedef SVFMap<const CallBlockNode*, ActualOUTSVFGNodeSet>  CallSiteToActualOUTsMapTy;
-    typedef SVFMap<const SVFFunction*, FormalINSVFGNodeSet>  FunctionToFormalINsMapTy;
-    typedef SVFMap<const SVFFunction*, FormalOUTSVFGNodeSet>  FunctionToFormalOUTsMapTy;
+    typedef Map<const CallBlockNode*, ActualINSVFGNodeSet>  CallSiteToActualINsMapTy;
+    typedef Map<const CallBlockNode*, ActualOUTSVFGNodeSet>  CallSiteToActualOUTsMapTy;
+    typedef Map<const SVFFunction*, FormalINSVFGNodeSet>  FunctionToFormalINsMapTy;
+    typedef Map<const SVFFunction*, FormalOUTSVFGNodeSet>  FunctionToFormalOUTsMapTy;
     typedef MemSSA::MUSet MUSet;
     typedef MemSSA::CHISet CHISet;
     typedef MemSSA::PHISet PHISet;

--- a/include/Graphs/SVFGEdge.h
+++ b/include/Graphs/SVFGEdge.h
@@ -43,7 +43,7 @@ class IndirectSVFGEdge : public VFGEdge
 {
 
 public:
-    typedef DenseSet<const MRVer*> MRVerSet;
+    typedef SVFSet<const MRVer*> MRVerSet;
 private:
     MRVerSet mrs;
     PointsTo cpts;

--- a/include/Graphs/SVFGEdge.h
+++ b/include/Graphs/SVFGEdge.h
@@ -43,7 +43,7 @@ class IndirectSVFGEdge : public VFGEdge
 {
 
 public:
-    typedef SVFSet<const MRVer*> MRVerSet;
+    typedef Set<const MRVer*> MRVerSet;
 private:
     MRVerSet mrs;
     PointsTo cpts;

--- a/include/Graphs/SVFGNode.h
+++ b/include/Graphs/SVFGNode.h
@@ -259,7 +259,7 @@ public:
 class MSSAPHISVFGNode : public MRSVFGNode
 {
 public:
-    typedef SVFMap<u32_t,const MRVer*> OPVers;
+    typedef Map<u32_t,const MRVer*> OPVers;
 
 protected:
     const MemSSA::MDEF* res;

--- a/include/Graphs/SVFGNode.h
+++ b/include/Graphs/SVFGNode.h
@@ -259,7 +259,7 @@ public:
 class MSSAPHISVFGNode : public MRSVFGNode
 {
 public:
-    typedef DenseMap<u32_t,const MRVer*> OPVers;
+    typedef SVFMap<u32_t,const MRVer*> OPVers;
 
 protected:
     const MemSSA::MDEF* res;

--- a/include/Graphs/SVFGOPT.h
+++ b/include/Graphs/SVFGOPT.h
@@ -55,8 +55,8 @@ namespace SVF
  */
 class SVFGOPT : public SVFG
 {
-    typedef DenseSet<SVFGNode*> SVFGNodeSet;
-    typedef DenseMap<NodeID, NodeID> NodeIDToNodeIDMap;
+    typedef SVFSet<SVFGNode*> SVFGNodeSet;
+    typedef SVFMap<NodeID, NodeID> NodeIDToNodeIDMap;
     typedef FIFOWorkList<const MSSAPHISVFGNode*> WorkList;
 
 public:

--- a/include/Graphs/SVFGOPT.h
+++ b/include/Graphs/SVFGOPT.h
@@ -55,8 +55,8 @@ namespace SVF
  */
 class SVFGOPT : public SVFG
 {
-    typedef SVFSet<SVFGNode*> SVFGNodeSet;
-    typedef SVFMap<NodeID, NodeID> NodeIDToNodeIDMap;
+    typedef Set<SVFGNode*> SVFGNodeSet;
+    typedef Map<NodeID, NodeID> NodeIDToNodeIDMap;
     typedef FIFOWorkList<const MSSAPHISVFGNode*> WorkList;
 
 public:

--- a/include/Graphs/SVFGStat.h
+++ b/include/Graphs/SVFGStat.h
@@ -93,7 +93,7 @@ class SVFGStat : public PTAStat
 {
 public:
     typedef Set<const SVFGNode*> SVFGNodeSet;
-    typedef Set<const SVFGEdge*> SVFGEdgeSet;
+    typedef OrderedSet<const SVFGEdge*> SVFGEdgeSet;
     typedef SCCDetection<SVFG*> SVFGSCC;
 
     SVFGStat(SVFG* g);

--- a/include/Graphs/SVFGStat.h
+++ b/include/Graphs/SVFGStat.h
@@ -92,8 +92,8 @@ private:
 class SVFGStat : public PTAStat
 {
 public:
-    typedef DenseSet<const SVFGNode*> SVFGNodeSet;
-    typedef DenseSet<const SVFGEdge*> SVFGEdgeSet;
+    typedef SVFSet<const SVFGNode*> SVFGNodeSet;
+    typedef SVFSet<const SVFGEdge*> SVFGEdgeSet;
     typedef SCCDetection<SVFG*> SVFGSCC;
 
     SVFGStat(SVFG* g);

--- a/include/Graphs/SVFGStat.h
+++ b/include/Graphs/SVFGStat.h
@@ -92,8 +92,8 @@ private:
 class SVFGStat : public PTAStat
 {
 public:
-    typedef SVFSet<const SVFGNode*> SVFGNodeSet;
-    typedef SVFSet<const SVFGEdge*> SVFGEdgeSet;
+    typedef Set<const SVFGNode*> SVFGNodeSet;
+    typedef Set<const SVFGEdge*> SVFGEdgeSet;
     typedef SCCDetection<SVFG*> SVFGSCC;
 
     SVFGStat(SVFG* g);

--- a/include/Graphs/ThreadCallGraph.h
+++ b/include/Graphs/ThreadCallGraph.h
@@ -159,17 +159,17 @@ class ThreadCallGraph: public PTACallGraph
 {
 
 public:
-    typedef std::set<const CallBlockNode*> InstSet;
+    typedef SVFSet<const CallBlockNode*> InstSet;
     typedef InstSet CallSiteSet;
     typedef std::vector<const Instruction*> InstVector;
-    typedef std::map<const Instruction*, InstSet> CallToInstMap;
-    typedef std::set<CallSiteSet*> CtxSet;
+    typedef SVFMap<const Instruction*, InstSet> CallToInstMap;
+    typedef SVFSet<CallSiteSet*> CtxSet;
     typedef ThreadForkEdge::ForkEdgeSet ForkEdgeSet;
-    typedef std::map<const CallBlockNode*, ForkEdgeSet> CallInstToForkEdgesMap;
+    typedef SVFMap<const CallBlockNode*, ForkEdgeSet> CallInstToForkEdgesMap;
     typedef ThreadJoinEdge::JoinEdgeSet JoinEdgeSet;
-    typedef std::map<const CallBlockNode*, JoinEdgeSet> CallInstToJoinEdgesMap;
+    typedef SVFMap<const CallBlockNode*, JoinEdgeSet> CallInstToJoinEdgesMap;
     typedef HareParForEdge::ParForEdgeSet ParForEdgeSet;
-    typedef std::map<const CallBlockNode*, ParForEdgeSet> CallInstToParForEdgesMap;
+    typedef SVFMap<const CallBlockNode*, ParForEdgeSet> CallInstToParForEdgesMap;
 
     /// Constructor
     ThreadCallGraph();

--- a/include/Graphs/ThreadCallGraph.h
+++ b/include/Graphs/ThreadCallGraph.h
@@ -159,17 +159,17 @@ class ThreadCallGraph: public PTACallGraph
 {
 
 public:
-    typedef SVFSet<const CallBlockNode*> InstSet;
+    typedef Set<const CallBlockNode*> InstSet;
     typedef InstSet CallSiteSet;
     typedef std::vector<const Instruction*> InstVector;
-    typedef SVFMap<const Instruction*, InstSet> CallToInstMap;
-    typedef SVFSet<CallSiteSet*> CtxSet;
+    typedef Map<const Instruction*, InstSet> CallToInstMap;
+    typedef Set<CallSiteSet*> CtxSet;
     typedef ThreadForkEdge::ForkEdgeSet ForkEdgeSet;
-    typedef SVFMap<const CallBlockNode*, ForkEdgeSet> CallInstToForkEdgesMap;
+    typedef Map<const CallBlockNode*, ForkEdgeSet> CallInstToForkEdgesMap;
     typedef ThreadJoinEdge::JoinEdgeSet JoinEdgeSet;
-    typedef SVFMap<const CallBlockNode*, JoinEdgeSet> CallInstToJoinEdgesMap;
+    typedef Map<const CallBlockNode*, JoinEdgeSet> CallInstToJoinEdgesMap;
     typedef HareParForEdge::ParForEdgeSet ParForEdgeSet;
-    typedef SVFMap<const CallBlockNode*, ParForEdgeSet> CallInstToParForEdgesMap;
+    typedef Map<const CallBlockNode*, ParForEdgeSet> CallInstToParForEdgesMap;
 
     /// Constructor
     ThreadCallGraph();
@@ -268,11 +268,11 @@ public:
 
     /// Fork sites iterators
     //@{
-    inline CallSiteSet::iterator forksitesBegin() const
+    inline CallSiteSet::const_iterator forksitesBegin() const
     {
         return forksites.begin();
     }
-    inline CallSiteSet::iterator forksitesEnd() const
+    inline CallSiteSet::const_iterator forksitesEnd() const
     {
         return forksites.end();
     }
@@ -280,11 +280,11 @@ public:
 
     /// Join sites iterators
     //@{
-    inline CallSiteSet::iterator joinsitesBegin() const
+    inline CallSiteSet::const_iterator joinsitesBegin() const
     {
         return joinsites.begin();
     }
-    inline CallSiteSet::iterator joinsitesEnd() const
+    inline CallSiteSet::const_iterator joinsitesEnd() const
     {
         return joinsites.end();
     }
@@ -292,11 +292,11 @@ public:
 
     /// hare_parallel_for sites iterators
     //@{
-    inline CallSiteSet::iterator parForSitesBegin() const
+    inline CallSiteSet::const_iterator parForSitesBegin() const
     {
         return parForSites.begin();
     }
-    inline CallSiteSet::iterator parForSitesEnd() const
+    inline CallSiteSet::const_iterator parForSitesEnd() const
     {
         return parForSites.end();
     }

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -55,19 +55,19 @@ public:
         ORIGSVFGK, PTRONLYSVFGK
     };
 
-    typedef DenseMap<NodeID, VFGNode *> VFGNodeIDToNodeMapTy;
-    typedef DenseSet<VFGNode*> VFGNodeSet;
-    typedef DenseMap<const PAGNode*, NodeID> PAGNodeToDefMapTy;
-    typedef DenseMap<std::pair<NodeID,const CallBlockNode*>, ActualParmVFGNode *> PAGNodeToActualParmMapTy;
-    typedef DenseMap<const PAGNode*, ActualRetVFGNode *> PAGNodeToActualRetMapTy;
-    typedef DenseMap<const PAGNode*, FormalParmVFGNode *> PAGNodeToFormalParmMapTy;
-    typedef DenseMap<const PAGNode*, FormalRetVFGNode *> PAGNodeToFormalRetMapTy;
-    typedef DenseMap<const PAGEdge*, StmtVFGNode*> PAGEdgeToStmtVFGNodeMapTy;
-    typedef DenseMap<const PAGNode*, IntraPHIVFGNode*> PAGNodeToPHIVFGNodeMapTy;
-    typedef DenseMap<const PAGNode*, BinaryOPVFGNode*> PAGNodeToBinaryOPVFGNodeMapTy;
-    typedef DenseMap<const PAGNode*, UnaryOPVFGNode*> PAGNodeToUnaryOPVFGNodeMapTy;
-    typedef DenseMap<const PAGNode*, CmpVFGNode*> PAGNodeToCmpVFGNodeMapTy;
-    typedef DenseMap<const SVFFunction*, VFGNodeSet > FunToVFGNodesMapTy;
+    typedef SVFMap<NodeID, VFGNode *> VFGNodeIDToNodeMapTy;
+    typedef SVFSet<VFGNode*> VFGNodeSet;
+    typedef SVFMap<const PAGNode*, NodeID> PAGNodeToDefMapTy;
+    typedef SVFMap<std::pair<NodeID,const CallBlockNode*>, ActualParmVFGNode *> PAGNodeToActualParmMapTy;
+    typedef SVFMap<const PAGNode*, ActualRetVFGNode *> PAGNodeToActualRetMapTy;
+    typedef SVFMap<const PAGNode*, FormalParmVFGNode *> PAGNodeToFormalParmMapTy;
+    typedef SVFMap<const PAGNode*, FormalRetVFGNode *> PAGNodeToFormalRetMapTy;
+    typedef SVFMap<const PAGEdge*, StmtVFGNode*> PAGEdgeToStmtVFGNodeMapTy;
+    typedef SVFMap<const PAGNode*, IntraPHIVFGNode*> PAGNodeToPHIVFGNodeMapTy;
+    typedef SVFMap<const PAGNode*, BinaryOPVFGNode*> PAGNodeToBinaryOPVFGNodeMapTy;
+    typedef SVFMap<const PAGNode*, UnaryOPVFGNode*> PAGNodeToUnaryOPVFGNodeMapTy;
+    typedef SVFMap<const PAGNode*, CmpVFGNode*> PAGNodeToCmpVFGNodeMapTy;
+    typedef SVFMap<const SVFFunction*, VFGNodeSet > FunToVFGNodesMapTy;
 
     typedef FormalParmVFGNode::CallPESet CallPESet;
     typedef FormalRetVFGNode::RetPESet RetPESet;
@@ -77,8 +77,8 @@ public:
     typedef VFGNodeIDToNodeMapTy::iterator iterator;
     typedef VFGNodeIDToNodeMapTy::const_iterator const_iterator;
     typedef PAG::PAGEdgeSet PAGEdgeSet;
-    typedef DenseSet<const VFGNode*> GlobalVFGNodeSet;
-    typedef DenseSet<const PAGNode*> PAGNodeSet;
+    typedef SVFSet<const VFGNode*> GlobalVFGNodeSet;
+    typedef SVFSet<const PAGNode*> PAGNodeSet;
 
 
 protected:

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -55,19 +55,19 @@ public:
         ORIGSVFGK, PTRONLYSVFGK
     };
 
-    typedef SVFMap<NodeID, VFGNode *> VFGNodeIDToNodeMapTy;
-    typedef SVFSet<VFGNode*> VFGNodeSet;
-    typedef SVFMap<const PAGNode*, NodeID> PAGNodeToDefMapTy;
-    typedef SVFMap<std::pair<NodeID,const CallBlockNode*>, ActualParmVFGNode *> PAGNodeToActualParmMapTy;
-    typedef SVFMap<const PAGNode*, ActualRetVFGNode *> PAGNodeToActualRetMapTy;
-    typedef SVFMap<const PAGNode*, FormalParmVFGNode *> PAGNodeToFormalParmMapTy;
-    typedef SVFMap<const PAGNode*, FormalRetVFGNode *> PAGNodeToFormalRetMapTy;
-    typedef SVFMap<const PAGEdge*, StmtVFGNode*> PAGEdgeToStmtVFGNodeMapTy;
-    typedef SVFMap<const PAGNode*, IntraPHIVFGNode*> PAGNodeToPHIVFGNodeMapTy;
-    typedef SVFMap<const PAGNode*, BinaryOPVFGNode*> PAGNodeToBinaryOPVFGNodeMapTy;
-    typedef SVFMap<const PAGNode*, UnaryOPVFGNode*> PAGNodeToUnaryOPVFGNodeMapTy;
-    typedef SVFMap<const PAGNode*, CmpVFGNode*> PAGNodeToCmpVFGNodeMapTy;
-    typedef SVFMap<const SVFFunction*, VFGNodeSet > FunToVFGNodesMapTy;
+    typedef Map<NodeID, VFGNode *> VFGNodeIDToNodeMapTy;
+    typedef Set<VFGNode*> VFGNodeSet;
+    typedef Map<const PAGNode*, NodeID> PAGNodeToDefMapTy;
+    typedef Map<std::pair<NodeID,const CallBlockNode*>, ActualParmVFGNode *> PAGNodeToActualParmMapTy;
+    typedef Map<const PAGNode*, ActualRetVFGNode *> PAGNodeToActualRetMapTy;
+    typedef Map<const PAGNode*, FormalParmVFGNode *> PAGNodeToFormalParmMapTy;
+    typedef Map<const PAGNode*, FormalRetVFGNode *> PAGNodeToFormalRetMapTy;
+    typedef Map<const PAGEdge*, StmtVFGNode*> PAGEdgeToStmtVFGNodeMapTy;
+    typedef Map<const PAGNode*, IntraPHIVFGNode*> PAGNodeToPHIVFGNodeMapTy;
+    typedef Map<const PAGNode*, BinaryOPVFGNode*> PAGNodeToBinaryOPVFGNodeMapTy;
+    typedef Map<const PAGNode*, UnaryOPVFGNode*> PAGNodeToUnaryOPVFGNodeMapTy;
+    typedef Map<const PAGNode*, CmpVFGNode*> PAGNodeToCmpVFGNodeMapTy;
+    typedef Map<const SVFFunction*, VFGNodeSet > FunToVFGNodesMapTy;
 
     typedef FormalParmVFGNode::CallPESet CallPESet;
     typedef FormalRetVFGNode::RetPESet RetPESet;
@@ -77,8 +77,8 @@ public:
     typedef VFGNodeIDToNodeMapTy::iterator iterator;
     typedef VFGNodeIDToNodeMapTy::const_iterator const_iterator;
     typedef PAG::PAGEdgeSet PAGEdgeSet;
-    typedef SVFSet<const VFGNode*> GlobalVFGNodeSet;
-    typedef SVFSet<const PAGNode*> PAGNodeSet;
+    typedef Set<const VFGNode*> GlobalVFGNodeSet;
+    typedef Set<const PAGNode*> PAGNodeSet;
 
 
 protected:

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -60,8 +60,8 @@ public:
 
     typedef VFGEdge::VFGEdgeSetTy::iterator iterator;
     typedef VFGEdge::VFGEdgeSetTy::const_iterator const_iterator;
-    typedef DenseSet<const CallPE*> CallPESet;
-    typedef DenseSet<const RetPE*> RetPESet;
+    typedef SVFSet<const CallPE*> CallPESet;
+    typedef SVFSet<const RetPE*> RetPESet;
 
 public:
     /// Constructor
@@ -310,7 +310,7 @@ public:
 class CmpVFGNode: public VFGNode
 {
 public:
-    typedef DenseMap<u32_t,const PAGNode*> OPVers;
+    typedef SVFMap<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -381,7 +381,7 @@ public:
 class BinaryOPVFGNode: public VFGNode
 {
 public:
-    typedef DenseMap<u32_t,const PAGNode*> OPVers;
+    typedef SVFMap<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -452,7 +452,7 @@ public:
 class UnaryOPVFGNode: public VFGNode
 {
 public:
-    typedef DenseMap<u32_t,const PAGNode*> OPVers;
+    typedef SVFMap<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -563,7 +563,7 @@ class PHIVFGNode : public VFGNode
 {
 
 public:
-    typedef DenseMap<u32_t,const PAGNode*> OPVers;
+    typedef SVFMap<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -635,7 +635,7 @@ class IntraPHIVFGNode : public PHIVFGNode
 {
 
 public:
-    typedef DenseMap<u32_t,const ICFGNode*> OPIncomingBBs;
+    typedef SVFMap<u32_t,const ICFGNode*> OPIncomingBBs;
 
 private:
     OPIncomingBBs opIncomingBBs;

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -60,8 +60,8 @@ public:
 
     typedef VFGEdge::VFGEdgeSetTy::iterator iterator;
     typedef VFGEdge::VFGEdgeSetTy::const_iterator const_iterator;
-    typedef SVFSet<const CallPE*> CallPESet;
-    typedef SVFSet<const RetPE*> RetPESet;
+    typedef Set<const CallPE*> CallPESet;
+    typedef Set<const RetPE*> RetPESet;
 
 public:
     /// Constructor
@@ -310,7 +310,7 @@ public:
 class CmpVFGNode: public VFGNode
 {
 public:
-    typedef SVFMap<u32_t,const PAGNode*> OPVers;
+    typedef Map<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -381,7 +381,7 @@ public:
 class BinaryOPVFGNode: public VFGNode
 {
 public:
-    typedef SVFMap<u32_t,const PAGNode*> OPVers;
+    typedef Map<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -452,7 +452,7 @@ public:
 class UnaryOPVFGNode: public VFGNode
 {
 public:
-    typedef SVFMap<u32_t,const PAGNode*> OPVers;
+    typedef Map<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -563,7 +563,7 @@ class PHIVFGNode : public VFGNode
 {
 
 public:
-    typedef SVFMap<u32_t,const PAGNode*> OPVers;
+    typedef Map<u32_t,const PAGNode*> OPVers;
 protected:
     const PAGNode* res;
     OPVers opVers;
@@ -635,7 +635,7 @@ class IntraPHIVFGNode : public PHIVFGNode
 {
 
 public:
-    typedef SVFMap<u32_t,const ICFGNode*> OPIncomingBBs;
+    typedef Map<u32_t,const ICFGNode*> OPIncomingBBs;
 
 private:
     OPIncomingBBs opIncomingBBs;

--- a/include/MSSA/MSSAMuChi.h
+++ b/include/MSSA/MSSAMuChi.h
@@ -624,7 +624,7 @@ class MSSAPHI : public MSSADEF
 {
 
 public:
-    typedef DenseMap<u32_t,const MRVer*> OPVers;
+    typedef SVFMap<u32_t,const MRVer*> OPVers;
 private:
     const BasicBlock* bb;
     OPVers opVers;

--- a/include/MSSA/MSSAMuChi.h
+++ b/include/MSSA/MSSAMuChi.h
@@ -624,7 +624,7 @@ class MSSAPHI : public MSSADEF
 {
 
 public:
-    typedef SVFMap<u32_t,const MRVer*> OPVers;
+    typedef Map<u32_t,const MRVer*> OPVers;
 private:
     const BasicBlock* bb;
     OPVers opVers;

--- a/include/MSSA/MemPartition.h
+++ b/include/MSSA/MemPartition.h
@@ -73,9 +73,9 @@ private:
 class IntraDisjointMRG : public MRGenerator
 {
 public:
-    typedef SVFMap<PointsTo, PointsToList> PtsToSubPtsMap;
-    typedef SVFMap<const SVFFunction*, PtsToSubPtsMap> FunToPtsMap;
-    typedef SVFMap<const SVFFunction*, PointsToList> FunToInterMap;
+    typedef OrderedMap<PointsTo, PointsToList> PtsToSubPtsMap;
+    typedef Map<const SVFFunction*, PtsToSubPtsMap> FunToPtsMap;
+    typedef Map<const SVFFunction*, PointsToList> FunToInterMap;
 
     IntraDisjointMRG(BVDataPTAImpl* p, bool ptrOnly) : MRGenerator(p, ptrOnly)
     {}

--- a/include/MSSA/MemPartition.h
+++ b/include/MSSA/MemPartition.h
@@ -74,8 +74,8 @@ class IntraDisjointMRG : public MRGenerator
 {
 public:
     typedef std::map<PointsTo, PointsToList> PtsToSubPtsMap;
-    typedef DenseMap<const SVFFunction*, PtsToSubPtsMap> FunToPtsMap;
-    typedef DenseMap<const SVFFunction*, PointsToList> FunToInterMap;
+    typedef SVFMap<const SVFFunction*, PtsToSubPtsMap> FunToPtsMap;
+    typedef SVFMap<const SVFFunction*, PointsToList> FunToInterMap;
 
     IntraDisjointMRG(BVDataPTAImpl* p, bool ptrOnly) : MRGenerator(p, ptrOnly)
     {}

--- a/include/MSSA/MemPartition.h
+++ b/include/MSSA/MemPartition.h
@@ -73,7 +73,7 @@ private:
 class IntraDisjointMRG : public MRGenerator
 {
 public:
-    typedef std::map<PointsTo, PointsToList> PtsToSubPtsMap;
+    typedef SVFMap<PointsTo, PointsToList> PtsToSubPtsMap;
     typedef SVFMap<const SVFFunction*, PtsToSubPtsMap> FunToPtsMap;
     typedef SVFMap<const SVFFunction*, PointsToList> FunToInterMap;
 

--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -139,11 +139,11 @@ public:
     //@{
     //@}
     ///Define mem region set
-    typedef std::set<const MemRegion*, MemRegion::equalMemRegion> MRSet;
+    typedef SVFSet<const MemRegion*, MemRegion::equalMemRegion> MRSet;
     typedef SVFMap<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
-    typedef std::set<PointsTo, MemRegion::equalPointsTo> PointsToList;
-    typedef std::map<const SVFFunction*, PointsToList > FunToPointsToMap;
-    typedef std::map<PointsTo, PointsTo, MemRegion::equalPointsTo > PtsToRepPtsSetMap;
+    typedef SVFSet<PointsTo, MemRegion::equalPointsTo> PointsToList;
+    typedef SVFMap<const SVFFunction*, PointsToList > FunToPointsToMap;
+    typedef SVFMap<PointsTo, PointsTo, MemRegion::equalPointsTo > PtsToRepPtsSetMap;
 
     /// Map a function to its region set
     typedef SVFMap<const SVFFunction*, MRSet> FunToMRsMap;
@@ -152,7 +152,7 @@ public:
     //@{
     typedef SVFMap<const LoadPE*, MRSet> LoadsToMRsMap;
     typedef SVFMap<const StorePE*, MRSet> StoresToMRsMap;
-    typedef std::map<const CallBlockNode*, MRSet> CallSiteToMRsMap;
+    typedef SVFMap<const CallBlockNode*, MRSet> CallSiteToMRsMap;
     //@}
 
     /// Map loads/stores/callsites to their cpts set
@@ -170,7 +170,7 @@ public:
     typedef SVFMap<const CallBlockNode*, NodeBS> CallSiteToNodeBSMap;
     //@}
 
-    typedef std::map<NodeID, NodeBS> NodeToPTSSMap;
+    typedef SVFMap<NodeID, NodeBS> NodeToPTSSMap;
 
     /// PAG edge list
     typedef PAG::PAGEdgeList PAGEdgeList;

--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -139,11 +139,11 @@ public:
     //@{
     //@}
     ///Define mem region set
-    typedef SVFSet<const MemRegion*, MemRegion::equalMemRegion> MRSet;
+    typedef OrderedSet<const MemRegion*, MemRegion::equalMemRegion> MRSet;
     typedef SVFMap<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
-    typedef SVFSet<PointsTo, MemRegion::equalPointsTo> PointsToList;
+    typedef OrderedSet<PointsTo, MemRegion::equalPointsTo> PointsToList;
     typedef SVFMap<const SVFFunction*, PointsToList > FunToPointsToMap;
-    typedef SVFMap<PointsTo, PointsTo, MemRegion::equalPointsTo > PtsToRepPtsSetMap;
+    typedef OrderedMap<PointsTo, PointsTo, MemRegion::equalPointsTo > PtsToRepPtsSetMap;
 
     /// Map a function to its region set
     typedef SVFMap<const SVFFunction*, MRSet> FunToMRsMap;

--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -140,34 +140,34 @@ public:
     //@}
     ///Define mem region set
     typedef std::set<const MemRegion*, MemRegion::equalMemRegion> MRSet;
-    typedef DenseMap<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
+    typedef SVFMap<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
     typedef std::set<PointsTo, MemRegion::equalPointsTo> PointsToList;
     typedef std::map<const SVFFunction*, PointsToList > FunToPointsToMap;
     typedef std::map<PointsTo, PointsTo, MemRegion::equalPointsTo > PtsToRepPtsSetMap;
 
     /// Map a function to its region set
-    typedef DenseMap<const SVFFunction*, MRSet> FunToMRsMap;
+    typedef SVFMap<const SVFFunction*, MRSet> FunToMRsMap;
     /// Map loads/stores to its mem regions,
     /// TODO:visitAtomicCmpXchgInst, visitAtomicRMWInst??
     //@{
-    typedef DenseMap<const LoadPE*, MRSet> LoadsToMRsMap;
-    typedef DenseMap<const StorePE*, MRSet> StoresToMRsMap;
+    typedef SVFMap<const LoadPE*, MRSet> LoadsToMRsMap;
+    typedef SVFMap<const StorePE*, MRSet> StoresToMRsMap;
     typedef std::map<const CallBlockNode*, MRSet> CallSiteToMRsMap;
     //@}
 
     /// Map loads/stores/callsites to their cpts set
     //@{
-    typedef DenseMap<const LoadPE*, PointsTo> LoadsToPointsToMap;
-    typedef DenseMap<const StorePE*, PointsTo> StoresToPointsToMap;
-    typedef DenseMap<const CallBlockNode*, PointsTo> CallSiteToPointsToMap;
+    typedef SVFMap<const LoadPE*, PointsTo> LoadsToPointsToMap;
+    typedef SVFMap<const StorePE*, PointsTo> StoresToPointsToMap;
+    typedef SVFMap<const CallBlockNode*, PointsTo> CallSiteToPointsToMap;
     //@}
 
     /// Maps Mod-Ref analysis
     //@{
     /// Map a function to its indirect refs/mods of memory objects
-    typedef DenseMap<const SVFFunction*, NodeBS> FunToNodeBSMap;
+    typedef SVFMap<const SVFFunction*, NodeBS> FunToNodeBSMap;
     /// Map a callsite to its indirect refs/mods of memory objects
-    typedef DenseMap<const CallBlockNode*, NodeBS> CallSiteToNodeBSMap;
+    typedef SVFMap<const CallBlockNode*, NodeBS> CallSiteToNodeBSMap;
     //@}
 
     typedef std::map<NodeID, NodeBS> NodeToPTSSMap;

--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -140,37 +140,37 @@ public:
     //@}
     ///Define mem region set
     typedef OrderedSet<const MemRegion*, MemRegion::equalMemRegion> MRSet;
-    typedef SVFMap<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
+    typedef Map<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
     typedef OrderedSet<PointsTo, MemRegion::equalPointsTo> PointsToList;
-    typedef SVFMap<const SVFFunction*, PointsToList > FunToPointsToMap;
+    typedef Map<const SVFFunction*, PointsToList > FunToPointsToMap;
     typedef OrderedMap<PointsTo, PointsTo, MemRegion::equalPointsTo > PtsToRepPtsSetMap;
 
     /// Map a function to its region set
-    typedef SVFMap<const SVFFunction*, MRSet> FunToMRsMap;
+    typedef Map<const SVFFunction*, MRSet> FunToMRsMap;
     /// Map loads/stores to its mem regions,
     /// TODO:visitAtomicCmpXchgInst, visitAtomicRMWInst??
     //@{
-    typedef SVFMap<const LoadPE*, MRSet> LoadsToMRsMap;
-    typedef SVFMap<const StorePE*, MRSet> StoresToMRsMap;
-    typedef SVFMap<const CallBlockNode*, MRSet> CallSiteToMRsMap;
+    typedef Map<const LoadPE*, MRSet> LoadsToMRsMap;
+    typedef Map<const StorePE*, MRSet> StoresToMRsMap;
+    typedef Map<const CallBlockNode*, MRSet> CallSiteToMRsMap;
     //@}
 
     /// Map loads/stores/callsites to their cpts set
     //@{
-    typedef SVFMap<const LoadPE*, PointsTo> LoadsToPointsToMap;
-    typedef SVFMap<const StorePE*, PointsTo> StoresToPointsToMap;
-    typedef SVFMap<const CallBlockNode*, PointsTo> CallSiteToPointsToMap;
+    typedef Map<const LoadPE*, PointsTo> LoadsToPointsToMap;
+    typedef Map<const StorePE*, PointsTo> StoresToPointsToMap;
+    typedef Map<const CallBlockNode*, PointsTo> CallSiteToPointsToMap;
     //@}
 
     /// Maps Mod-Ref analysis
     //@{
     /// Map a function to its indirect refs/mods of memory objects
-    typedef SVFMap<const SVFFunction*, NodeBS> FunToNodeBSMap;
+    typedef Map<const SVFFunction*, NodeBS> FunToNodeBSMap;
     /// Map a callsite to its indirect refs/mods of memory objects
-    typedef SVFMap<const CallBlockNode*, NodeBS> CallSiteToNodeBSMap;
+    typedef Map<const CallBlockNode*, NodeBS> CallSiteToNodeBSMap;
     //@}
 
-    typedef SVFMap<NodeID, NodeBS> NodeToPTSSMap;
+    typedef Map<NodeID, NodeBS> NodeToPTSSMap;
 
     /// PAG edge list
     typedef PAG::PAGEdgeList PAGEdgeList;

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -61,9 +61,9 @@ public:
     typedef MSSAPHI<Condition> PHI;
     typedef MSSADEF MDEF;
 
-    typedef std::set<MU*> MUSet;
-    typedef std::set<CHI*> CHISet;
-    typedef std::set<PHI*> PHISet;
+    typedef SVFSet<MU*> MUSet;
+    typedef SVFSet<CHI*> CHISet;
+    typedef SVFSet<PHI*> PHISet;
 
     ///Define mem region set
     typedef MRGenerator::MRSet MRSet;

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -71,27 +71,27 @@ public:
     /// Map loads/stores to its mem regions,
     /// TODO:visitAtomicCmpXchgInst, visitAtomicRMWInst??
     //@{
-    typedef DenseMap<const LoadPE*, MUSet> LoadToMUSetMap;
-    typedef DenseMap<const StorePE*, CHISet> StoreToChiSetMap;
-    typedef DenseMap<const CallBlockNode*, MUSet> CallSiteToMUSetMap;
-    typedef DenseMap<const CallBlockNode*, CHISet> CallSiteToCHISetMap;
-    typedef DenseMap<const BasicBlock*, PHISet> BBToPhiSetMap;
+    typedef SVFMap<const LoadPE*, MUSet> LoadToMUSetMap;
+    typedef SVFMap<const StorePE*, CHISet> StoreToChiSetMap;
+    typedef SVFMap<const CallBlockNode*, MUSet> CallSiteToMUSetMap;
+    typedef SVFMap<const CallBlockNode*, CHISet> CallSiteToCHISetMap;
+    typedef SVFMap<const BasicBlock*, PHISet> BBToPhiSetMap;
     //@}
 
     /// Map from fun to its entry chi set and return mu set
-    typedef DenseMap<const SVFFunction*, CHISet> FunToEntryChiSetMap;
-    typedef DenseMap<const SVFFunction*, MUSet> FunToReturnMuSetMap;
+    typedef SVFMap<const SVFFunction*, CHISet> FunToEntryChiSetMap;
+    typedef SVFMap<const SVFFunction*, MUSet> FunToReturnMuSetMap;
 
     /// For phi insertion
     //@{
     typedef std::vector<const BasicBlock*> BBList;
-    typedef DenseMap<const BasicBlock*, MRSet> BBToMRSetMap;
-    typedef DenseMap<const MemRegion*, BBList> MemRegToBBsMap;
+    typedef SVFMap<const BasicBlock*, MRSet> BBToMRSetMap;
+    typedef SVFMap<const MemRegion*, BBList> MemRegToBBsMap;
     //@}
 
     /// For SSA renaming
-    typedef DenseMap<const MemRegion*, std::vector<MRVer*> > MemRegToVerStackMap;
-    typedef DenseMap<const MemRegion*, MRVERSION> MemRegToCounterMap;
+    typedef SVFMap<const MemRegion*, std::vector<MRVer*> > MemRegToVerStackMap;
+    typedef SVFMap<const MemRegion*, MRVERSION> MemRegToCounterMap;
 
     /// PAG edge list
     typedef PAG::PAGEdgeList PAGEdgeList;

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -61,9 +61,9 @@ public:
     typedef MSSAPHI<Condition> PHI;
     typedef MSSADEF MDEF;
 
-    typedef SVFSet<MU*> MUSet;
-    typedef SVFSet<CHI*> CHISet;
-    typedef SVFSet<PHI*> PHISet;
+    typedef OrderedSet<MU*> MUSet;
+    typedef OrderedSet<CHI*> CHISet;
+    typedef OrderedSet<PHI*> PHISet;
 
     ///Define mem region set
     typedef MRGenerator::MRSet MRSet;
@@ -71,27 +71,27 @@ public:
     /// Map loads/stores to its mem regions,
     /// TODO:visitAtomicCmpXchgInst, visitAtomicRMWInst??
     //@{
-    typedef SVFMap<const LoadPE*, MUSet> LoadToMUSetMap;
-    typedef SVFMap<const StorePE*, CHISet> StoreToChiSetMap;
-    typedef SVFMap<const CallBlockNode*, MUSet> CallSiteToMUSetMap;
-    typedef SVFMap<const CallBlockNode*, CHISet> CallSiteToCHISetMap;
-    typedef SVFMap<const BasicBlock*, PHISet> BBToPhiSetMap;
+    typedef Map<const LoadPE*, MUSet> LoadToMUSetMap;
+    typedef Map<const StorePE*, CHISet> StoreToChiSetMap;
+    typedef Map<const CallBlockNode*, MUSet> CallSiteToMUSetMap;
+    typedef Map<const CallBlockNode*, CHISet> CallSiteToCHISetMap;
+    typedef Map<const BasicBlock*, PHISet> BBToPhiSetMap;
     //@}
 
     /// Map from fun to its entry chi set and return mu set
-    typedef SVFMap<const SVFFunction*, CHISet> FunToEntryChiSetMap;
-    typedef SVFMap<const SVFFunction*, MUSet> FunToReturnMuSetMap;
+    typedef Map<const SVFFunction*, CHISet> FunToEntryChiSetMap;
+    typedef Map<const SVFFunction*, MUSet> FunToReturnMuSetMap;
 
     /// For phi insertion
     //@{
     typedef std::vector<const BasicBlock*> BBList;
-    typedef SVFMap<const BasicBlock*, MRSet> BBToMRSetMap;
-    typedef SVFMap<const MemRegion*, BBList> MemRegToBBsMap;
+    typedef Map<const BasicBlock*, MRSet> BBToMRSetMap;
+    typedef Map<const MemRegion*, BBList> MemRegToBBsMap;
     //@}
 
     /// For SSA renaming
-    typedef SVFMap<const MemRegion*, std::vector<MRVer*> > MemRegToVerStackMap;
-    typedef SVFMap<const MemRegion*, MRVERSION> MemRegToCounterMap;
+    typedef Map<const MemRegion*, std::vector<MRVer*> > MemRegToVerStackMap;
+    typedef Map<const MemRegion*, MRVERSION> MemRegToCounterMap;
 
     /// PAG edge list
     typedef PAG::PAGEdgeList PAGEdgeList;

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -61,9 +61,9 @@ public:
     typedef MSSAPHI<Condition> PHI;
     typedef MSSADEF MDEF;
 
-    typedef OrderedSet<MU*> MUSet;
-    typedef OrderedSet<CHI*> CHISet;
-    typedef OrderedSet<PHI*> PHISet;
+    typedef Set<MU*> MUSet;
+    typedef Set<CHI*> CHISet;
+    typedef Set<PHI*> PHISet;
 
     ///Define mem region set
     typedef MRGenerator::MRSet MRSet;
@@ -235,7 +235,7 @@ private:
     /// Rename mu set
     inline void RenameMuSet(const MUSet& muSet)
     {
-        for (MUSet::iterator mit = muSet.begin(), emit = muSet.end();
+        for (MUSet::const_iterator mit = muSet.begin(), emit = muSet.end();
                 mit != emit; ++mit)
         {
             MU* mu = (*mit);
@@ -246,7 +246,7 @@ private:
     /// Rename chi set
     inline void RenameChiSet(const CHISet& chiSet, MRVector& memRegs)
     {
-        for (CHISet::iterator cit = chiSet.begin(), ecit = chiSet.end();
+        for (CHISet::const_iterator cit = chiSet.begin(), ecit = chiSet.end();
                 cit != ecit; ++cit)
         {
             CHI* chi = (*cit);
@@ -259,7 +259,7 @@ private:
     /// Rename result (LHS) of phis
     inline void RenamePhiRes(const PHISet& phiSet, MRVector& memRegs)
     {
-        for (PHISet::iterator iter = phiSet.begin(), eiter = phiSet.end();
+        for (PHISet::const_iterator iter = phiSet.begin(), eiter = phiSet.end();
                 iter != eiter; ++iter)
         {
             PHI* phi = *iter;
@@ -271,7 +271,7 @@ private:
     /// Rename operands (RHS) of phis
     inline void RenamePhiOps(const PHISet& phiSet, u32_t pos, MRVector&)
     {
-        for (PHISet::iterator iter = phiSet.begin(), eiter = phiSet.end();
+        for (PHISet::const_iterator iter = phiSet.begin(), eiter = phiSet.end();
                 iter != eiter; ++iter)
         {
             PHI* phi = *iter;

--- a/include/MTA/FSMPTA.h
+++ b/include/MTA/FSMPTA.h
@@ -29,14 +29,14 @@ public:
     typedef PointerAnalysis::CallSiteSet CallSiteSet;
     typedef PointerAnalysis::CallEdgeMap CallEdgeMap;
     typedef PointerAnalysis::FunctionSet FunctionSet;
-    typedef std::set<const SVFGNode*> SVFGNodeSet;
+    typedef SVFSet<const SVFGNode*> SVFGNodeSet;
     typedef std::vector<const SVFGNode*> SVFGNodeVec;
     typedef NodeBS SVFGNodeIDSet;
-    typedef std::set<const Instruction*> InstSet;
+    typedef SVFSet<const Instruction*> InstSet;
     typedef std::pair<NodeID,NodeID> NodeIDPair;
 
     typedef std::pair<const StmtSVFGNode*, LockAnalysis::LockSpan> SVFGNodeLockSpanPair;
-    typedef std::map<SVFGNodeLockSpanPair, bool> PairToBoolMap;
+    typedef SVFMap<SVFGNodeLockSpanPair, bool> PairToBoolMap;
     /// Constructor
     MTASVFGBuilder(MHP* m, LockAnalysis* la) : SVFGBuilder(), mhp(m), lockana(la)
     {
@@ -99,15 +99,15 @@ private:
     MHP* mhp;
     LockAnalysis* lockana;
 
-    std::set<NodeIDPair> recordedges;
-    std::map<NodeIDPair, PointsTo> edge2pts;
+    SVFSet<NodeIDPair> recordedges;
+    SVFMap<NodeIDPair, PointsTo> edge2pts;
 
 
-    std::map<const StmtSVFGNode*, SVFGNodeIDSet> prevset;
-    std::map<const StmtSVFGNode*, SVFGNodeIDSet> succset;
+    SVFMap<const StmtSVFGNode*, SVFGNodeIDSet> prevset;
+    SVFMap<const StmtSVFGNode*, SVFGNodeIDSet> succset;
 
-    std::map<const StmtSVFGNode*, bool> headmap;
-    std::map<const StmtSVFGNode*, bool> tailmap;
+    SVFMap<const StmtSVFGNode*, bool> headmap;
+    SVFMap<const StmtSVFGNode*, bool> tailmap;
 
     PairToBoolMap pairheadmap;
     PairToBoolMap pairtailmap;

--- a/include/MTA/FSMPTA.h
+++ b/include/MTA/FSMPTA.h
@@ -29,14 +29,14 @@ public:
     typedef PointerAnalysis::CallSiteSet CallSiteSet;
     typedef PointerAnalysis::CallEdgeMap CallEdgeMap;
     typedef PointerAnalysis::FunctionSet FunctionSet;
-    typedef SVFSet<const SVFGNode*> SVFGNodeSet;
+    typedef Set<const SVFGNode*> SVFGNodeSet;
     typedef std::vector<const SVFGNode*> SVFGNodeVec;
     typedef NodeBS SVFGNodeIDSet;
-    typedef SVFSet<const Instruction*> InstSet;
+    typedef Set<const Instruction*> InstSet;
     typedef std::pair<NodeID,NodeID> NodeIDPair;
 
     typedef std::pair<const StmtSVFGNode*, LockAnalysis::LockSpan> SVFGNodeLockSpanPair;
-    typedef SVFMap<SVFGNodeLockSpanPair, bool> PairToBoolMap;
+    typedef Map<SVFGNodeLockSpanPair, bool> PairToBoolMap;
     /// Constructor
     MTASVFGBuilder(MHP* m, LockAnalysis* la) : SVFGBuilder(), mhp(m), lockana(la)
     {
@@ -99,15 +99,15 @@ private:
     MHP* mhp;
     LockAnalysis* lockana;
 
-    SVFSet<NodeIDPair> recordedges;
-    SVFMap<NodeIDPair, PointsTo> edge2pts;
+    Set<NodeIDPair> recordedges;
+    Map<NodeIDPair, PointsTo> edge2pts;
 
 
-    SVFMap<const StmtSVFGNode*, SVFGNodeIDSet> prevset;
-    SVFMap<const StmtSVFGNode*, SVFGNodeIDSet> succset;
+    Map<const StmtSVFGNode*, SVFGNodeIDSet> prevset;
+    Map<const StmtSVFGNode*, SVFGNodeIDSet> succset;
 
-    SVFMap<const StmtSVFGNode*, bool> headmap;
-    SVFMap<const StmtSVFGNode*, bool> tailmap;
+    Map<const StmtSVFGNode*, bool> headmap;
+    Map<const StmtSVFGNode*, bool> tailmap;
 
     PairToBoolMap pairheadmap;
     PairToBoolMap pairtailmap;

--- a/include/MTA/LockAnalysis.h
+++ b/include/MTA/LockAnalysis.h
@@ -40,27 +40,27 @@ public:
 
     typedef NodeBS LockSet;
     typedef TCT::InstVec InstVec;
-    typedef std::set<const Instruction*> InstSet;
+    typedef SVFSet<const Instruction*> InstSet;
     typedef InstSet CISpan;
-    typedef std::map<const Instruction*, CISpan>CILockToSpan;
-    typedef std::set<const Function*> FunSet;
-    typedef std::map<const Instruction*, InstSet> InstToInstSetMap;
-    typedef std::map<const CxtStmt, ValDomain> CxtStmtToLockFlagMap;
+    typedef SVFMap<const Instruction*, CISpan>CILockToSpan;
+    typedef SVFSet<const Function*> FunSet;
+    typedef SVFMap<const Instruction*, InstSet> InstToInstSetMap;
+    typedef SVFMap<const CxtStmt, ValDomain> CxtStmtToLockFlagMap;
     typedef FIFOWorkList<CxtStmt> CxtStmtWorkList;
-    typedef std::set<CxtStmt> LockSpan;
-    typedef std::set<CxtStmt> CxtStmtSet;
-    typedef std::set<CxtLock> CxtLockSet;
+    typedef SVFSet<CxtStmt> LockSpan;
+    typedef SVFSet<CxtStmt> CxtStmtSet;
+    typedef SVFSet<CxtLock> CxtLockSet;
 
-    typedef std::map<CxtLock, LockSpan> CxtLockToSpan;
-    typedef std::map<CxtLock, NodeBS> CxtLockToLockSet;
-    typedef std::map<const Instruction*, NodeBS> LockSiteToLockSet;
-    typedef std::map<const Instruction*, LockSpan> InstToCxtStmtSet;
-    typedef std::map<const CxtStmt, CxtLockSet> CxtStmtToCxtLockSet;
+    typedef SVFMap<CxtLock, LockSpan> CxtLockToSpan;
+    typedef SVFMap<CxtLock, NodeBS> CxtLockToLockSet;
+    typedef SVFMap<const Instruction*, NodeBS> LockSiteToLockSet;
+    typedef SVFMap<const Instruction*, LockSpan> InstToCxtStmtSet;
+    typedef SVFMap<const CxtStmt, CxtLockSet> CxtStmtToCxtLockSet;
     typedef FIFOWorkList<CxtLockProc> CxtLockProcVec;
     typedef set<CxtLockProc> CxtLockProcSet;
 
     typedef std::pair<const Function*,const Function*> FuncPair;
-    typedef std::map<FuncPair, bool> FuncPairToBool;
+    typedef SVFMap<FuncPair, bool> FuncPairToBool;
 
     LockAnalysis(TCT* t) : tct(t), lockTime(0),numOfTotalQueries(0), numOfLockedQueries(0), lockQueriesTime(0)
     {

--- a/include/MTA/LockAnalysis.h
+++ b/include/MTA/LockAnalysis.h
@@ -40,27 +40,27 @@ public:
 
     typedef NodeBS LockSet;
     typedef TCT::InstVec InstVec;
-    typedef SVFSet<const Instruction*> InstSet;
+    typedef Set<const Instruction*> InstSet;
     typedef InstSet CISpan;
-    typedef SVFMap<const Instruction*, CISpan>CILockToSpan;
-    typedef SVFSet<const Function*> FunSet;
-    typedef SVFMap<const Instruction*, InstSet> InstToInstSetMap;
-    typedef SVFMap<const CxtStmt, ValDomain> CxtStmtToLockFlagMap;
+    typedef Map<const Instruction*, CISpan>CILockToSpan;
+    typedef Set<const Function*> FunSet;
+    typedef Map<const Instruction*, InstSet> InstToInstSetMap;
+    typedef Map<const CxtStmt, ValDomain> CxtStmtToLockFlagMap;
     typedef FIFOWorkList<CxtStmt> CxtStmtWorkList;
-    typedef SVFSet<CxtStmt> LockSpan;
-    typedef SVFSet<CxtStmt> CxtStmtSet;
-    typedef SVFSet<CxtLock> CxtLockSet;
+    typedef Set<CxtStmt> LockSpan;
+    typedef Set<CxtStmt> CxtStmtSet;
+    typedef Set<CxtLock> CxtLockSet;
 
-    typedef SVFMap<CxtLock, LockSpan> CxtLockToSpan;
-    typedef SVFMap<CxtLock, NodeBS> CxtLockToLockSet;
-    typedef SVFMap<const Instruction*, NodeBS> LockSiteToLockSet;
-    typedef SVFMap<const Instruction*, LockSpan> InstToCxtStmtSet;
-    typedef SVFMap<const CxtStmt, CxtLockSet> CxtStmtToCxtLockSet;
+    typedef Map<CxtLock, LockSpan> CxtLockToSpan;
+    typedef Map<CxtLock, NodeBS> CxtLockToLockSet;
+    typedef Map<const Instruction*, NodeBS> LockSiteToLockSet;
+    typedef Map<const Instruction*, LockSpan> InstToCxtStmtSet;
+    typedef Map<const CxtStmt, CxtLockSet> CxtStmtToCxtLockSet;
     typedef FIFOWorkList<CxtLockProc> CxtLockProcVec;
     typedef set<CxtLockProc> CxtLockProcSet;
 
     typedef std::pair<const Function*,const Function*> FuncPair;
-    typedef SVFMap<FuncPair, bool> FuncPairToBool;
+    typedef Map<FuncPair, bool> FuncPairToBool;
 
     LockAnalysis(TCT* t) : tct(t), lockTime(0),numOfTotalQueries(0), numOfLockedQueries(0), lockQueriesTime(0)
     {

--- a/include/MTA/MHP.h
+++ b/include/MTA/MHP.h
@@ -26,19 +26,19 @@ class MHP
 {
 
 public:
-    typedef std::set<const Function*> FunSet;
-    typedef std::set<const Instruction*> InstSet;
-    typedef std::set<const StmtSVFGNode*> SVFGNodeSet;
+    typedef SVFSet<const Function*> FunSet;
+    typedef SVFSet<const Instruction*> InstSet;
+    typedef SVFSet<const StmtSVFGNode*> SVFGNodeSet;
     typedef TCT::InstVec InstVec;
     typedef FIFOWorkList<CxtThreadStmt> CxtThreadStmtWorkList;
-    typedef std::set<CxtThreadStmt> CxtThreadStmtSet;
-    typedef std::map<const CxtThreadStmt,NodeBS> ThreadStmtToThreadInterleav;
-    typedef std::map<const Instruction*,CxtThreadStmtSet> InstToThreadStmtSetMap;
+    typedef SVFSet<CxtThreadStmt> CxtThreadStmtSet;
+    typedef SVFMap<const CxtThreadStmt,NodeBS> ThreadStmtToThreadInterleav;
+    typedef SVFMap<const Instruction*,CxtThreadStmtSet> InstToThreadStmtSetMap;
 
-    typedef std::set<CxtStmt> LockSpan;
+    typedef SVFSet<CxtStmt> LockSpan;
 
     typedef std::pair<const Function*,const Function*> FuncPair;
-    typedef std::map<FuncPair, bool> FuncPairToBool;
+    typedef SVFMap<FuncPair, bool> FuncPairToBool;
 
     /// Constructor
     MHP(TCT* t);
@@ -273,12 +273,12 @@ public:
     };
 
     typedef TCT::InstVec InstVec;
-    typedef std::map<const CxtStmt,ValDomain> CxtStmtToAliveFlagMap;
-    typedef std::map<const CxtStmt,NodeBS> CxtStmtToTIDMap;
-    typedef std::set<NodePair> ThreadPairSet;
-    typedef std::map<const CxtStmt, const Loop*> CxtStmtToLoopMap;
+    typedef SVFMap<const CxtStmt,ValDomain> CxtStmtToAliveFlagMap;
+    typedef SVFMap<const CxtStmt,NodeBS> CxtStmtToTIDMap;
+    typedef SVFSet<NodePair> ThreadPairSet;
+    typedef SVFMap<const CxtStmt, const Loop*> CxtStmtToLoopMap;
     typedef FIFOWorkList<CxtStmt> CxtStmtWorkList;
-    typedef std::map<const Instruction*, PTASCEV> forkjoinToPTASCEVMap;
+    typedef SVFMap<const Instruction*, PTASCEV> forkjoinToPTASCEVMap;
     ForkJoinAnalysis(TCT* t) : tct(t)
     {
         collectSCEVInfo();

--- a/include/MTA/MHP.h
+++ b/include/MTA/MHP.h
@@ -26,19 +26,19 @@ class MHP
 {
 
 public:
-    typedef SVFSet<const Function*> FunSet;
-    typedef SVFSet<const Instruction*> InstSet;
-    typedef SVFSet<const StmtSVFGNode*> SVFGNodeSet;
+    typedef Set<const Function*> FunSet;
+    typedef Set<const Instruction*> InstSet;
+    typedef Set<const StmtSVFGNode*> SVFGNodeSet;
     typedef TCT::InstVec InstVec;
     typedef FIFOWorkList<CxtThreadStmt> CxtThreadStmtWorkList;
-    typedef SVFSet<CxtThreadStmt> CxtThreadStmtSet;
-    typedef SVFMap<const CxtThreadStmt,NodeBS> ThreadStmtToThreadInterleav;
-    typedef SVFMap<const Instruction*,CxtThreadStmtSet> InstToThreadStmtSetMap;
+    typedef Set<CxtThreadStmt> CxtThreadStmtSet;
+    typedef Map<const CxtThreadStmt,NodeBS> ThreadStmtToThreadInterleav;
+    typedef Map<const Instruction*,CxtThreadStmtSet> InstToThreadStmtSetMap;
 
-    typedef SVFSet<CxtStmt> LockSpan;
+    typedef Set<CxtStmt> LockSpan;
 
     typedef std::pair<const Function*,const Function*> FuncPair;
-    typedef SVFMap<FuncPair, bool> FuncPairToBool;
+    typedef Map<FuncPair, bool> FuncPairToBool;
 
     /// Constructor
     MHP(TCT* t);
@@ -273,12 +273,12 @@ public:
     };
 
     typedef TCT::InstVec InstVec;
-    typedef SVFMap<const CxtStmt,ValDomain> CxtStmtToAliveFlagMap;
-    typedef SVFMap<const CxtStmt,NodeBS> CxtStmtToTIDMap;
-    typedef SVFSet<NodePair> ThreadPairSet;
-    typedef SVFMap<const CxtStmt, const Loop*> CxtStmtToLoopMap;
+    typedef Map<const CxtStmt,ValDomain> CxtStmtToAliveFlagMap;
+    typedef Map<const CxtStmt,NodeBS> CxtStmtToTIDMap;
+    typedef Set<NodePair> ThreadPairSet;
+    typedef Map<const CxtStmt, const Loop*> CxtStmtToLoopMap;
     typedef FIFOWorkList<CxtStmt> CxtStmtWorkList;
-    typedef SVFMap<const Instruction*, PTASCEV> forkjoinToPTASCEVMap;
+    typedef Map<const Instruction*, PTASCEV> forkjoinToPTASCEVMap;
     ForkJoinAnalysis(TCT* t) : tct(t)
     {
         collectSCEVInfo();

--- a/include/MTA/MTA.h
+++ b/include/MTA/MTA.h
@@ -31,10 +31,10 @@ class MTA: public ModulePass
 {
 
 public:
-    typedef SVFSet<const LoadInst*> LoadSet;
-    typedef SVFSet<const StoreInst*> StoreSet;
-    typedef SVFMap<const Function*, ScalarEvolution*> FunToSEMap;
-    typedef SVFMap<const Function*, LoopInfo*> FunToLoopInfoMap;
+    typedef Set<const LoadInst*> LoadSet;
+    typedef Set<const StoreInst*> StoreSet;
+    typedef Map<const Function*, ScalarEvolution*> FunToSEMap;
+    typedef Map<const Function*, LoopInfo*> FunToLoopInfoMap;
 
     /// Pass ID
     static char ID;

--- a/include/MTA/MTA.h
+++ b/include/MTA/MTA.h
@@ -31,10 +31,10 @@ class MTA: public ModulePass
 {
 
 public:
-    typedef std::set<const LoadInst*> LoadSet;
-    typedef std::set<const StoreInst*> StoreSet;
-    typedef std::map<const Function*, ScalarEvolution*> FunToSEMap;
-    typedef std::map<const Function*, LoopInfo*> FunToLoopInfoMap;
+    typedef SVFSet<const LoadInst*> LoadSet;
+    typedef SVFSet<const StoreInst*> StoreSet;
+    typedef SVFMap<const Function*, ScalarEvolution*> FunToSEMap;
+    typedef SVFMap<const Function*, LoopInfo*> FunToLoopInfoMap;
 
     /// Pass ID
     static char ID;

--- a/include/MTA/MTAAnnotator.h
+++ b/include/MTA/MTAAnnotator.h
@@ -22,7 +22,7 @@ class MTAAnnotator: public Annotator
 {
 
 public:
-    typedef std::set<const Instruction*> InstSet;
+    typedef SVFSet<const Instruction*> InstSet;
     /// Constructor
     MTAAnnotator(): mhp(NULL),lsa(NULL)
     {

--- a/include/MTA/MTAAnnotator.h
+++ b/include/MTA/MTAAnnotator.h
@@ -22,7 +22,7 @@ class MTAAnnotator: public Annotator
 {
 
 public:
-    typedef SVFSet<const Instruction*> InstSet;
+    typedef Set<const Instruction*> InstSet;
     /// Constructor
     MTAAnnotator(): mhp(NULL),lsa(NULL)
     {

--- a/include/MTA/MTAResultValidator.h
+++ b/include/MTA/MTAResultValidator.h
@@ -113,12 +113,12 @@ protected:
 
 private:
 
-    SVFMap<NodeID, const CallInst*> csnumToInstMap;
-    SVFMap<NodeID, CallStrCxt> vthdToCxt;
-    SVFMap<NodeID, NodeID> vthdTorthd;
-    SVFMap<NodeID, NodeID> rthdTovthd;
+    Map<NodeID, const CallInst*> csnumToInstMap;
+    Map<NodeID, CallStrCxt> vthdToCxt;
+    Map<NodeID, NodeID> vthdTorthd;
+    Map<NodeID, NodeID> rthdTovthd;
 
-    SVFMap<NodeID, SVFSet<NodeID>> rthdToChildren;
+    Map<NodeID, Set<NodeID>> rthdToChildren;
 
     MHP::InstToThreadStmtSetMap instToTSMap; // Map a instruction to CxtThreadStmtSet
     MHP::ThreadStmtToThreadInterleav threadStmtToInterLeaving; /// Map a statement to its thread interleavings

--- a/include/MTA/MTAResultValidator.h
+++ b/include/MTA/MTAResultValidator.h
@@ -113,12 +113,12 @@ protected:
 
 private:
 
-    std::map<NodeID, const CallInst*> csnumToInstMap;
-    std::map<NodeID, CallStrCxt> vthdToCxt;
-    std::map<NodeID, NodeID> vthdTorthd;
-    std::map<NodeID, NodeID> rthdTovthd;
+    SVFMap<NodeID, const CallInst*> csnumToInstMap;
+    SVFMap<NodeID, CallStrCxt> vthdToCxt;
+    SVFMap<NodeID, NodeID> vthdTorthd;
+    SVFMap<NodeID, NodeID> rthdTovthd;
 
-    std::map<NodeID, std::set<NodeID>> rthdToChildren;
+    SVFMap<NodeID, SVFSet<NodeID>> rthdToChildren;
 
     MHP::InstToThreadStmtSetMap instToTSMap; // Map a instruction to CxtThreadStmtSet
     MHP::ThreadStmtToThreadInterleav threadStmtToInterLeaving; /// Map a statement to its thread interleavings

--- a/include/MTA/MTAStat.h
+++ b/include/MTA/MTAStat.h
@@ -25,7 +25,7 @@ class MTAStat : public PTAStat
 {
 
 public:
-    typedef std::set<const Instruction*> InstSet;
+    typedef SVFSet<const Instruction*> InstSet;
 
     /// Constructor
     MTAStat():PTAStat(NULL),TCTTime(0),MHPTime(0),FSMPTATime(0),AnnotationTime(0)

--- a/include/MTA/MTAStat.h
+++ b/include/MTA/MTAStat.h
@@ -25,7 +25,7 @@ class MTAStat : public PTAStat
 {
 
 public:
-    typedef SVFSet<const Instruction*> InstSet;
+    typedef Set<const Instruction*> InstSet;
 
     /// Constructor
     MTAStat():PTAStat(NULL),TCTTime(0),MHPTime(0),FSMPTATime(0),AnnotationTime(0)

--- a/include/MTA/PCG.h
+++ b/include/MTA/PCG.h
@@ -29,9 +29,9 @@ class PCG
 {
 
 public:
-    typedef SVFSet<const Function*> FunSet;
+    typedef Set<const Function*> FunSet;
     typedef std::vector<const Function*> FunVec;
-    typedef SVFSet<const Instruction*> CallInstSet;
+    typedef Set<const Instruction*> CallInstSet;
     typedef FIFOWorkList<const Function*> FunWorkList;
     typedef FIFOWorkList<const BasicBlock*> BBWorkList;
 

--- a/include/MTA/PCG.h
+++ b/include/MTA/PCG.h
@@ -29,9 +29,9 @@ class PCG
 {
 
 public:
-    typedef std::set<const Function*> FunSet;
+    typedef SVFSet<const Function*> FunSet;
     typedef std::vector<const Function*> FunVec;
-    typedef std::set<const Instruction*> CallInstSet;
+    typedef SVFSet<const Instruction*> CallInstSet;
     typedef FIFOWorkList<const Function*> FunWorkList;
     typedef FIFOWorkList<const BasicBlock*> BBWorkList;
 

--- a/include/MTA/TCT.h
+++ b/include/MTA/TCT.h
@@ -29,7 +29,7 @@ typedef GenericEdge<TCTNode> GenericTCTEdgeTy;
 class TCTEdge: public GenericTCTEdgeTy
 {
 public:
-    typedef std::set<const Instruction*> CallInstSet;
+    typedef SVFSet<const Instruction*> CallInstSet;
     enum CEDGEK
     {
         ThreadCreateEdge
@@ -118,14 +118,14 @@ class TCT: public GenericThreadCreateTreeTy
 public:
     typedef TCTEdge::ThreadCreateEdgeSet ThreadCreateEdgeSet;
     typedef ThreadCreateEdgeSet::iterator TCTNodeIter;
-    typedef std::set<const Function*> FunSet;
+    typedef SVFSet<const Function*> FunSet;
     typedef std::vector<const Instruction*> InstVec;
-    typedef std::set<const Instruction*> InstSet;
-    typedef std::set<const PTACallGraphNode*> PTACGNodeSet;
-    typedef std::map<const CxtThread,TCTNode*> CxtThreadToNodeMap;
-    typedef std::map<const CxtThread,CallStrCxt> CxtThreadToForkCxt;
-    typedef std::map<const CxtThread,const Function*> CxtThreadToFun;
-    typedef std::map<const Instruction*, const Loop*> InstToLoopMap;
+    typedef SVFSet<const Instruction*> InstSet;
+    typedef SVFSet<const PTACallGraphNode*> PTACGNodeSet;
+    typedef SVFMap<const CxtThread,TCTNode*> CxtThreadToNodeMap;
+    typedef SVFMap<const CxtThread,CallStrCxt> CxtThreadToForkCxt;
+    typedef SVFMap<const CxtThread,const Function*> CxtThreadToFun;
+    typedef SVFMap<const Instruction*, const Loop*> InstToLoopMap;
     typedef FIFOWorkList<CxtThreadProc> CxtThreadProcVec;
     typedef set<CxtThreadProc> CxtThreadProcSet;
     typedef SCCDetection<PTACallGraph*> ThreadCallGraphSCC;

--- a/include/MTA/TCT.h
+++ b/include/MTA/TCT.h
@@ -29,7 +29,7 @@ typedef GenericEdge<TCTNode> GenericTCTEdgeTy;
 class TCTEdge: public GenericTCTEdgeTy
 {
 public:
-    typedef SVFSet<const Instruction*> CallInstSet;
+    typedef Set<const Instruction*> CallInstSet;
     enum CEDGEK
     {
         ThreadCreateEdge
@@ -118,14 +118,14 @@ class TCT: public GenericThreadCreateTreeTy
 public:
     typedef TCTEdge::ThreadCreateEdgeSet ThreadCreateEdgeSet;
     typedef ThreadCreateEdgeSet::iterator TCTNodeIter;
-    typedef SVFSet<const Function*> FunSet;
+    typedef Set<const Function*> FunSet;
     typedef std::vector<const Instruction*> InstVec;
-    typedef SVFSet<const Instruction*> InstSet;
-    typedef SVFSet<const PTACallGraphNode*> PTACGNodeSet;
-    typedef SVFMap<const CxtThread,TCTNode*> CxtThreadToNodeMap;
-    typedef SVFMap<const CxtThread,CallStrCxt> CxtThreadToForkCxt;
-    typedef SVFMap<const CxtThread,const Function*> CxtThreadToFun;
-    typedef SVFMap<const Instruction*, const Loop*> InstToLoopMap;
+    typedef Set<const Instruction*> InstSet;
+    typedef Set<const PTACallGraphNode*> PTACGNodeSet;
+    typedef Map<const CxtThread,TCTNode*> CxtThreadToNodeMap;
+    typedef Map<const CxtThread,CallStrCxt> CxtThreadToForkCxt;
+    typedef Map<const CxtThread,const Function*> CxtThreadToFun;
+    typedef Map<const Instruction*, const Loop*> InstToLoopMap;
     typedef FIFOWorkList<CxtThreadProc> CxtThreadProcVec;
     typedef set<CxtThreadProc> CxtThreadProcSet;
     typedef SCCDetection<PTACallGraph*> ThreadCallGraphSCC;

--- a/include/MemoryModel/ConditionalPT.h
+++ b/include/MemoryModel/ConditionalPT.h
@@ -838,4 +838,31 @@ private:
 
 } // End namespace SVF
 
+namespace llvm {
+template <typename Cond> struct DenseMapInfo<SVF::CondVar<Cond>>
+{
+    static inline SVF::CondVar<Cond> getEmptyKey()
+    {
+        return SVF::CondVar<Cond>(Cond(), ~0);
+    }
+
+    static inline SVF::CondVar<Cond> getTombstoneKey()
+    {
+        return SVF::CondVar<Cond>(Cond(), ~1);
+    }
+
+    static unsigned getHashValue(const SVF::CondVar<Cond> &cv)
+    {
+        // TODO: evaluate hash, maybe generalise on Cond better.
+        return DenseMapInfo<SVF::NodeID>::getHashValue(cv.get_id())
+               + DenseMapInfo<unsigned>::getHashValue(cv.get_cond().getContexts().size())
+               + cv.get_cond().getContexts().empty() ? 0 : cv.get_cond().getContexts()[0];
+    }
+
+    static bool isEqual(const SVF::CondVar<Cond> &lhs, const SVF::CondVar<Cond> &rhs) {
+        return lhs == rhs;
+    }
+};
+}  // End namespace llvm
+
 #endif /* CONDVAR_H_ */

--- a/include/MemoryModel/ConditionalPT.h
+++ b/include/MemoryModel/ConditionalPT.h
@@ -130,11 +130,11 @@ private:
 template<class Element>
 class CondStdSet
 {
-    typedef SVFSet<Element> ElementSet;
+    typedef OrderedSet<Element> ElementSet;
 
 public:
-    typedef typename SVFSet<Element>::iterator iterator;
-    typedef typename SVFSet<Element>::const_iterator const_iterator;
+    typedef typename OrderedSet<Element>::iterator iterator;
+    typedef typename OrderedSet<Element>::const_iterator const_iterator;
 
     CondStdSet() {}
     ~CondStdSet() {}
@@ -300,7 +300,7 @@ template<class Cond>
 class CondPointsToSet
 {
 public:
-    typedef SVFMap<Cond, PointsTo> CondPts;
+    typedef Map<Cond, PointsTo> CondPts;
     typedef typename CondPts::iterator CondPtsIter;
     typedef typename CondPts::const_iterator CondPtsConstIter;
     typedef CondVar<Cond> SingleCondVar;
@@ -837,5 +837,26 @@ private:
 };
 
 } // End namespace SVF
+
+/// Specialise hash for CondVar
+template <typename Cond>
+struct std::hash<const SVF::CondVar<Cond>>
+{
+    size_t operator()(const SVF::CondVar<Cond> &cv) const
+    {
+        std::hash<Cond> h;
+        return h(cv.get_cond());
+    }
+};
+
+template <typename Cond>
+struct std::hash<SVF::CondVar<Cond>>
+{
+    size_t operator()(const SVF::CondVar<Cond> &cv) const
+    {
+        std::hash<Cond> h;
+        return h(cv.get_cond());
+    }
+};
 
 #endif /* CONDVAR_H_ */

--- a/include/MemoryModel/ConditionalPT.h
+++ b/include/MemoryModel/ConditionalPT.h
@@ -130,11 +130,11 @@ private:
 template<class Element>
 class CondStdSet
 {
-    typedef typename std::set<Element> ElementSet;
+    typedef typename SVFSet<Element> ElementSet;
 
 public:
-    typedef typename std::set<Element>::iterator iterator;
-    typedef typename std::set<Element>::const_iterator const_iterator;
+    typedef typename SVFSet<Element>::iterator iterator;
+    typedef typename SVFSet<Element>::const_iterator const_iterator;
 
     CondStdSet() {}
     ~CondStdSet() {}
@@ -300,7 +300,7 @@ template<class Cond>
 class CondPointsToSet
 {
 public:
-    typedef typename std::map<Cond, PointsTo> CondPts;
+    typedef typename SVFMap<Cond, PointsTo> CondPts;
     typedef typename CondPts::iterator CondPtsIter;
     typedef typename CondPts::const_iterator CondPtsConstIter;
     typedef CondVar<Cond> SingleCondVar;

--- a/include/MemoryModel/ConditionalPT.h
+++ b/include/MemoryModel/ConditionalPT.h
@@ -130,7 +130,7 @@ private:
 template<class Element>
 class CondStdSet
 {
-    typedef typename SVFSet<Element> ElementSet;
+    typedef SVFSet<Element> ElementSet;
 
 public:
     typedef typename SVFSet<Element>::iterator iterator;
@@ -300,7 +300,7 @@ template<class Cond>
 class CondPointsToSet
 {
 public:
-    typedef typename SVFMap<Cond, PointsTo> CondPts;
+    typedef SVFMap<Cond, PointsTo> CondPts;
     typedef typename CondPts::iterator CondPtsIter;
     typedef typename CondPts::const_iterator CondPtsConstIter;
     typedef CondVar<Cond> SingleCondVar;

--- a/include/MemoryModel/ConditionalPT.h
+++ b/include/MemoryModel/ConditionalPT.h
@@ -316,7 +316,7 @@ public:
     }
     //@}
 
-    /// Copy constructor  DenseMap constructor overloading
+    /// Copy constructor
     CondPointsToSet(const CondPointsToSet<Cond>& cptsSet)
 
     {

--- a/include/MemoryModel/ConditionalPT.h
+++ b/include/MemoryModel/ConditionalPT.h
@@ -838,31 +838,4 @@ private:
 
 } // End namespace SVF
 
-namespace llvm {
-template <typename Cond> struct DenseMapInfo<SVF::CondVar<Cond>>
-{
-    static inline SVF::CondVar<Cond> getEmptyKey()
-    {
-        return SVF::CondVar<Cond>(Cond(), ~0);
-    }
-
-    static inline SVF::CondVar<Cond> getTombstoneKey()
-    {
-        return SVF::CondVar<Cond>(Cond(), ~1);
-    }
-
-    static unsigned getHashValue(const SVF::CondVar<Cond> &cv)
-    {
-        // TODO: evaluate hash, maybe generalise on Cond better.
-        return DenseMapInfo<SVF::NodeID>::getHashValue(cv.get_id())
-               + DenseMapInfo<unsigned>::getHashValue(cv.get_cond().getContexts().size())
-               + cv.get_cond().getContexts().empty() ? 0 : cv.get_cond().getContexts()[0];
-    }
-
-    static bool isEqual(const SVF::CondVar<Cond> &lhs, const SVF::CondVar<Cond> &rhs) {
-        return lhs == rhs;
-    }
-};
-}  // End namespace llvm
-
 #endif /* CONDVAR_H_ */

--- a/include/MemoryModel/LocationSet.h
+++ b/include/MemoryModel/LocationSet.h
@@ -180,6 +180,13 @@ public:
             }
         }
     }
+
+    inline bool operator==(const LocationSet& rhs) const
+    {
+        return this->fldIdx == rhs.fldIdx
+               && this->byteOffset == rhs.byteOffset
+               && this->numStridePair == rhs.numStridePair;
+    }
     //@}
 
     /// Get methods
@@ -280,5 +287,12 @@ private:
 };
 
 } // End namespace SVF
+
+template <> struct std::hash<SVF::LocationSet> {
+    size_t operator()(const SVF::LocationSet &ls) const {
+        std::hash<std::pair<SVF::Size_t, SVF::Size_t>> h;
+        return h(std::make_pair(ls.getOffset(), ls.getByteOffset()));
+    }
+};
 
 #endif /* LOCATIONSET_H_ */

--- a/include/MemoryModel/MemModel.h
+++ b/include/MemoryModel/MemModel.h
@@ -61,9 +61,9 @@ private:
     /// flattened field offsets of of a struct
     std::vector<u32_t> foffset;
     /// Types of all fields of a struct
-    DenseMap<u32_t, const llvm::Type*> fldIdx2TypeMap;
+    SVFMap<u32_t, const llvm::Type*> fldIdx2TypeMap;
     /// Types of all fields of a struct
-    DenseMap<u32_t, const llvm::Type*> offset2TypeMap;
+    SVFMap<u32_t, const llvm::Type*> offset2TypeMap;
     /// All field infos after flattening a struct
     std::vector<FieldInfo> finfo;
 

--- a/include/MemoryModel/MemModel.h
+++ b/include/MemoryModel/MemModel.h
@@ -61,9 +61,9 @@ private:
     /// flattened field offsets of of a struct
     std::vector<u32_t> foffset;
     /// Types of all fields of a struct
-    SVFMap<u32_t, const llvm::Type*> fldIdx2TypeMap;
+    Map<u32_t, const llvm::Type*> fldIdx2TypeMap;
     /// Types of all fields of a struct
-    SVFMap<u32_t, const llvm::Type*> offset2TypeMap;
+    Map<u32_t, const llvm::Type*> offset2TypeMap;
     /// All field infos after flattening a struct
     std::vector<FieldInfo> finfo;
 

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -19,7 +19,7 @@ public:
     typedef PTData<Key, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
-    typedef std::map<const Key, Data> PtsMap;
+    typedef DenseMap<Key, Data> PtsMap;
     typedef typename PtsMap::iterator PtsMapIter;
     typedef typename PtsMap::const_iterator PtsMapConstIter;
     typedef typename Data::iterator iterator;

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -290,7 +290,7 @@ public:
     typedef typename BaseDFPTData::LocID LocID;
     typedef typename BaseMutPTData::PtsMap PtsMap;
     typedef typename BaseMutPTData::PtsMapConstIter PtsMapConstIter;
-    typedef DenseMap<LocID, PtsMap> DFPtsMap;	///< Data-flow point-to map
+    typedef SVFMap<LocID, PtsMap> DFPtsMap;	///< Data-flow point-to map
     typedef typename DFPtsMap::iterator DFPtsMapIter;
     typedef typename DFPtsMap::const_iterator DFPtsMapconstIter;
 
@@ -575,7 +575,7 @@ public:
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     typedef typename BaseDFPTData::LocID LocID;
-    typedef DenseMap<LocID, Data> UpdatedVarMap;	///< for propagating only newly added variable in IN/OUT set
+    typedef SVFMap<LocID, Data> UpdatedVarMap;	///< for propagating only newly added variable in IN/OUT set
     typedef typename UpdatedVarMap::iterator UpdatedVarMapIter;
     typedef typename UpdatedVarMap::const_iterator UpdatedVarconstIter;
     typedef typename Data::iterator DataIter;

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -10,22 +10,16 @@ namespace SVF
 template <typename Key, typename Datum, typename Data>
 class MutableDFPTData;
 
-template <typename Key, typename Datum, typename Data, typename CacheKey>
-class MutableDiffPTData;
-
 /// PTData implemented using points-to sets which are created once and updated continuously.
 template <typename Key, typename Datum, typename Data>
 class MutablePTData : public PTData<Key, Datum, Data>
 {
-    template <typename DFKey, typename DFDatum, typename DFData>
-    friend class MutableDFPTData;
-    template <typename DiffKey, typename DiffDatum, typename DiffData, typename CacheKey>
-    friend class MutableDiffPTData;
+    friend class MutableDFPTData<Key, Datum, Data>;
 public:
     typedef PTData<Key, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
-    typedef DenseMap<Key, std::unique_ptr<Data>> PtsMap;
+    typedef DenseMap<Key, Data> PtsMap;
     typedef typename PtsMap::iterator PtsMapIter;
     typedef typename PtsMap::const_iterator PtsMapConstIter;
     typedef typename Data::iterator iterator;
@@ -49,30 +43,30 @@ public:
 
     virtual inline const Data& getPts(const Key& var) override
     {
-        return getMutPts(var);
+        return ptsMap[var];
     }
 
     virtual inline const Data& getRevPts(const Key& var) override
     {
-        return getMutRevPts(var);
+        return revPtsMap[var];
     }
 
     virtual inline bool addPts(const Key &dstKey, const Datum& element) override
     {
-        addSingleRevPts(getMutRevPts(element), dstKey);
-        return addPts(getMutPts(dstKey), element);
+        addSingleRevPts(revPtsMap[element], dstKey);
+        return addPts(ptsMap[dstKey], element);
     }
 
     virtual inline bool unionPts(const Key& dstKey, const Key& srcKey) override
     {
-        addRevPts(getMutPts(srcKey), dstKey);
-        return unionPts(getMutPts(dstKey), getPts(srcKey));
+        addRevPts(ptsMap[srcKey], dstKey);
+        return unionPts(ptsMap[dstKey], getPts(srcKey));
     }
 
     virtual inline bool unionPts(const Key& dstKey, const Data& srcData) override
     {
         addRevPts(srcData,dstKey);
-        return unionPts(getMutPts(dstKey), srcData);
+        return unionPts(ptsMap[dstKey], srcData);
     }
 
     virtual inline void dumpPTData() override
@@ -82,12 +76,12 @@ public:
 
     virtual void clearPts(const Key& var, const Datum& element) override
     {
-        getMutPts(var).reset(element);
+        ptsMap[var].reset(element);
     }
 
     virtual void clearFullPts(const Key& var) override
     {
-        getMutPts(var).clear();
+        ptsMap[var].clear();
     }
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
@@ -104,35 +98,12 @@ public:
     ///@}
 
 protected:
-    inline Data& getMutPts(const Key& var)
-    {
-        return getOrMakePts(var, ptsMap);
-    }
-
-    inline Data& getMutRevPts(const Key& var)
-    {
-        return getOrMakePts(var, revPtsMap);
-    }
-
-    template <typename MapKey, typename MapType>
-    inline Data& getOrMakePts(const MapKey& var, MapType& map)
-    {
-        typename PtsMap::iterator foundPts = map.find(var);
-        if (foundPts == map.end())
-        {
-            Data *newPts = new Data();
-            map[var] = std::unique_ptr<Data>(newPts);
-            return *newPts;
-        }
-        else return *(foundPts->second);
-    }
-
     virtual inline void dumpPts(const PtsMap & ptsSet,raw_ostream & O = SVFUtil::outs()) const
     {
         for (PtsMapConstIter nodeIt = ptsSet.begin(); nodeIt != ptsSet.end(); nodeIt++)
         {
             const Key& var = nodeIt->first;
-            const Data & pts = *nodeIt->second;
+            const Data & pts = nodeIt->second;
             if (pts.empty())
                 continue;
             O << var << " ==> { ";
@@ -162,7 +133,7 @@ private:
     inline void addRevPts(const Data &ptsData, const Datum& tgr)
     {
         for(iterator it = ptsData.begin(), eit = ptsData.end(); it!=eit; ++it)
-            addSingleRevPts(getMutRevPts(*it), tgr);
+            addSingleRevPts(revPtsMap[*it], tgr);
     }
     ///@}
 
@@ -241,12 +212,12 @@ public:
 
     virtual inline Data &getDiffPts(Key &var) override
     {
-        return mutPTData.template getOrMakePts(var, diffPtsMap);
+        return diffPtsMap[var];
     }
 
     virtual inline Data &getPropaPts(Key &var) override
     {
-        return mutPTData.template getOrMakePts(var, propaPtsMap);
+        return propaPtsMap[var];
     }
 
     virtual inline bool computeDiffPts(Key &var, const Data &all) override
@@ -275,12 +246,12 @@ public:
 
     virtual inline Data& getCachePts(CacheKey &cache) override
     {
-        return mutPTData.template getOrMakePts<>(cache, cacheMap);
+        return cacheMap[cache];
     }
 
     virtual inline void addCachePts(CacheKey &cache, Data &data) override
     {
-        getCachePts(cache) |= data;
+        cacheMap[cache] |= data;
     }
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
@@ -379,13 +350,13 @@ public:
     virtual inline Data& getDFInPtsSet(LocID loc, const Key& var) override
     {
         PtsMap& inSet = dfInPtsMap[loc];
-        return mutPTData.template getOrMakePts<>(var, inSet);
+        return inSet[var];
     }
 
     virtual inline Data& getDFOutPtsSet(LocID loc, const Key& var) override
     {
         PtsMap& outSet = dfOutPtsMap[loc];
-        return mutPTData.template getOrMakePts<>(var, outSet);
+        return outSet[var];
     }
 
     /// Get internal flow-sensitive data structures.
@@ -472,15 +443,15 @@ public:
     ///@{
     virtual inline bool addPts(const Key &dstKey, const Key& srcKey) override
     {
-        return addPts(mutPTData.getMutPts(dstKey), srcKey);
+        return addPts(mutPTData.ptsMap[dstKey], srcKey);
     }
     virtual inline bool unionPts(const Key& dstKey, const Key& srcKey) override
     {
-        return unionPts(mutPTData.getMutPts(dstKey), getPts(srcKey));
+        return unionPts(mutPTData.ptsMap[dstKey], getPts(srcKey));
     }
     virtual inline bool unionPts(const Key& dstKey, const Data& srcData) override
     {
-        return unionPts(mutPTData.getMutPts(dstKey), srcData);
+        return unionPts(mutPTData.ptsMap[dstKey],srcData);
     }
     virtual void clearPts(const Key& var, const Datum& element) override
     {
@@ -572,7 +543,7 @@ public:
         for (PtsMapConstIter nodeIt = ptsSet.begin(); nodeIt != ptsSet.end(); nodeIt++)
         {
             const Key& var = nodeIt->first;
-            const Data & pts = *nodeIt->second;
+            const Data & pts = nodeIt->second;
             if (pts.empty())
                 continue;
             O << "<" << var << ",{";

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -19,7 +19,7 @@ public:
     typedef PTData<Key, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
-    typedef std::map<const Key, Data> PtsMap;
+    typedef SVFMap<const Key, Data> PtsMap;
     typedef typename PtsMap::iterator PtsMapIter;
     typedef typename PtsMap::const_iterator PtsMapConstIter;
     typedef typename Data::iterator iterator;

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -19,7 +19,7 @@ public:
     typedef PTData<Key, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
-    typedef DenseMap<Key, Data> PtsMap;
+    typedef std::map<const Key, Data> PtsMap;
     typedef typename PtsMap::iterator PtsMapIter;
     typedef typename PtsMap::const_iterator PtsMapConstIter;
     typedef typename Data::iterator iterator;

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -19,7 +19,7 @@ public:
     typedef PTData<Key, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
-    typedef SVFMap<const Key, Data> PtsMap;
+    typedef Map<Key, Data> PtsMap;
     typedef typename PtsMap::iterator PtsMapIter;
     typedef typename PtsMap::const_iterator PtsMapConstIter;
     typedef typename Data::iterator iterator;
@@ -290,7 +290,7 @@ public:
     typedef typename BaseDFPTData::LocID LocID;
     typedef typename BaseMutPTData::PtsMap PtsMap;
     typedef typename BaseMutPTData::PtsMapConstIter PtsMapConstIter;
-    typedef SVFMap<LocID, PtsMap> DFPtsMap;	///< Data-flow point-to map
+    typedef Map<LocID, PtsMap> DFPtsMap;	///< Data-flow point-to map
     typedef typename DFPtsMap::iterator DFPtsMapIter;
     typedef typename DFPtsMap::const_iterator DFPtsMapconstIter;
 
@@ -575,7 +575,7 @@ public:
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     typedef typename BaseDFPTData::LocID LocID;
-    typedef SVFMap<LocID, Data> UpdatedVarMap;	///< for propagating only newly added variable in IN/OUT set
+    typedef Map<LocID, Data> UpdatedVarMap;	///< for propagating only newly added variable in IN/OUT set
     typedef typename UpdatedVarMap::iterator UpdatedVarMapIter;
     typedef typename UpdatedVarMap::const_iterator UpdatedVarconstIter;
     typedef typename Data::iterator DataIter;

--- a/include/MemoryModel/PTAStat.h
+++ b/include/MemoryModel/PTAStat.h
@@ -124,9 +124,9 @@ public:
     /// Does not affect CLOCK_IN_MS.
     static bool markedClocksOnly;
 
-    typedef DenseMap<const char*,u32_t> NUMStatMap;
+    typedef SVFMap<const char*,u32_t> NUMStatMap;
 
-    typedef DenseMap<const char*,double> TIMEStatMap;
+    typedef SVFMap<const char*,double> TIMEStatMap;
 
     PTAStat(PointerAnalysis* p);
     virtual ~PTAStat() {}

--- a/include/MemoryModel/PTAStat.h
+++ b/include/MemoryModel/PTAStat.h
@@ -124,9 +124,9 @@ public:
     /// Does not affect CLOCK_IN_MS.
     static bool markedClocksOnly;
 
-    typedef SVFMap<const char*,u32_t> NUMStatMap;
+    typedef Map<const char*,u32_t> NUMStatMap;
 
-    typedef SVFMap<const char*,double> TIMEStatMap;
+    typedef Map<const char*,double> TIMEStatMap;
 
     PTAStat(PointerAnalysis* p);
     virtual ~PTAStat() {}

--- a/include/MemoryModel/PTAType.h
+++ b/include/MemoryModel/PTAType.h
@@ -89,7 +89,7 @@ class TypeSet
 {
 public:
 
-    typedef SVFSet<PTAType> TypeSetTy;
+    typedef OrderedSet<PTAType> TypeSetTy;
 
     typedef TypeSetTy::iterator iterator;
     typedef TypeSetTy::const_iterator const_iterator;
@@ -190,9 +190,9 @@ class TypeSystem
 {
 public:
 
-    typedef SVFMap<NodeID, TypeSet*> VarToTypeSetMapTy;
+    typedef Map<NodeID, TypeSet*> VarToTypeSetMapTy;
 
-    typedef SVFMap<PTAType, NodeBS> TypeToVarsMapTy;
+    typedef OrderedMap<PTAType, NodeBS> TypeToVarsMapTy;
 
     typedef typename VarToTypeSetMapTy::iterator iterator;
     typedef typename VarToTypeSetMapTy::const_iterator const_iterator;
@@ -359,7 +359,7 @@ private:
 
 private:
     VarToTypeSetMapTy VarToTypeSetMap;
-    SVFSet<PTAType> allPTATypes;
+    OrderedSet<PTAType> allPTATypes;
     TypeToVarsMapTy typeToVarsMap;
 };
 

--- a/include/MemoryModel/PTAType.h
+++ b/include/MemoryModel/PTAType.h
@@ -89,7 +89,7 @@ class TypeSet
 {
 public:
 
-    typedef std::set<PTAType> TypeSetTy;
+    typedef SVFSet<PTAType> TypeSetTy;
 
     typedef TypeSetTy::iterator iterator;
     typedef TypeSetTy::const_iterator const_iterator;
@@ -190,9 +190,9 @@ class TypeSystem
 {
 public:
 
-    typedef std::map<NodeID, TypeSet*> VarToTypeSetMapTy;
+    typedef SVFMap<NodeID, TypeSet*> VarToTypeSetMapTy;
 
-    typedef std::map<PTAType, NodeBS> TypeToVarsMapTy;
+    typedef SVFMap<PTAType, NodeBS> TypeToVarsMapTy;
 
     typedef typename VarToTypeSetMapTy::iterator iterator;
     typedef typename VarToTypeSetMapTy::const_iterator const_iterator;
@@ -359,7 +359,7 @@ private:
 
 private:
     VarToTypeSetMapTy VarToTypeSetMap;
-    std::set<PTAType> allPTATypes;
+    SVFSet<PTAType> allPTATypes;
     TypeToVarsMapTy typeToVarsMap;
 };
 

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -98,13 +98,13 @@ public:
     /// Indirect call edges type, map a callsite to a set of callees
     //@{
     typedef llvm::AliasAnalysis AliasAnalysis;
-    typedef DenseSet<const CallBlockNode*> CallSiteSet;
+    typedef SVFSet<const CallBlockNode*> CallSiteSet;
     typedef PAG::CallSiteToFunPtrMap CallSiteToFunPtrMap;
-    typedef DenseSet<const SVFFunction*> FunctionSet;
-    typedef DenseMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
+    typedef SVFSet<const SVFFunction*> FunctionSet;
+    typedef SVFMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
     typedef SCCDetection<PTACallGraph*> CallGraphSCC;
-    typedef DenseSet<const GlobalValue*> VTableSet;
-    typedef DenseSet<const SVFFunction*> VFunSet;
+    typedef SVFSet<const GlobalValue*> VTableSet;
+    typedef SVFSet<const SVFFunction*> VFunSet;
     //@}
 
     static const std::string aliasTestMayAlias;

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -98,13 +98,13 @@ public:
     /// Indirect call edges type, map a callsite to a set of callees
     //@{
     typedef llvm::AliasAnalysis AliasAnalysis;
-    typedef SVFSet<const CallBlockNode*> CallSiteSet;
+    typedef Set<const CallBlockNode*> CallSiteSet;
     typedef PAG::CallSiteToFunPtrMap CallSiteToFunPtrMap;
-    typedef SVFSet<const SVFFunction*> FunctionSet;
-    typedef SVFMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
+    typedef Set<const SVFFunction*> FunctionSet;
+    typedef Map<const CallBlockNode*, FunctionSet> CallEdgeMap;
     typedef SCCDetection<PTACallGraph*> CallGraphSCC;
-    typedef SVFSet<const GlobalValue*> VTableSet;
-    typedef SVFSet<const SVFFunction*> VFunSet;
+    typedef Set<const GlobalValue*> VTableSet;
+    typedef Set<const SVFFunction*> VFunSet;
     //@}
 
     static const std::string aliasTestMayAlias;

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -208,7 +208,7 @@ public:
         return svfMod;
     }
     /// Get all Valid Pointers for resolution
-    inline NodeSet& getAllValidPtrs()
+    inline OrderedNodeSet& getAllValidPtrs()
     {
         return pag->getAllValidPtrs();
     }

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -101,7 +101,7 @@ public:
     typedef Set<const CallBlockNode*> CallSiteSet;
     typedef PAG::CallSiteToFunPtrMap CallSiteToFunPtrMap;
     typedef Set<const SVFFunction*> FunctionSet;
-    typedef Map<const CallBlockNode*, FunctionSet> CallEdgeMap;
+    typedef OrderedMap<const CallBlockNode*, FunctionSet> CallEdgeMap;
     typedef SCCDetection<PTACallGraph*> CallGraphSCC;
     typedef Set<const GlobalValue*> VTableSet;
     typedef Set<const SVFFunction*> VFunSet;

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -222,8 +222,8 @@ public:
     typedef CondStdSet<CVar>  CPtSet;
     typedef PTData<CVar, CVar, CPtSet> PTDataTy;
     typedef MutablePTData<CVar, CVar, CPtSet> MutPTDataTy;
-    typedef SVFMap<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
-    typedef SVFMap<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
+    typedef Map<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
+    typedef Map<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
 
     /// Constructor
     CondPTAImpl(PAG* pag, PointerAnalysis::PTATY type) : PointerAnalysis(pag, type), normalized(false)

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -222,8 +222,8 @@ public:
     typedef CondStdSet<CVar>  CPtSet;
     typedef PTData<CVar, CVar, CPtSet> PTDataTy;
     typedef MutablePTData<CVar, CVar, CPtSet> MutPTDataTy;
-    typedef DenseMap<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
-    typedef DenseMap<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
+    typedef SVFMap<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
+    typedef SVFMap<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
 
     /// Constructor
     CondPTAImpl(PAG* pag, PointerAnalysis::PTATY type) : PointerAnalysis(pag, type), normalized(false)

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -536,7 +536,7 @@ public:
     /// Dump points-to information of top-level pointers
     void dumpTopLevelPtsTo()
     {
-        for (NodeSet::iterator nIter = this->getAllValidPtrs().begin(); nIter != this->getAllValidPtrs().end(); ++nIter)
+        for (OrderedNodeSet::iterator nIter = this->getAllValidPtrs().begin(); nIter != this->getAllValidPtrs().end(); ++nIter)
         {
             const PAGNode* node = this->getPAG()->getPAGNode(*nIter);
             if (this->getPAG()->isValidTopLevelPtr(node))

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -415,7 +415,7 @@ protected:
             const typename MutPTDataTy::PtsMap& ptsMap = getPtsMap();
             for(typename MutPTDataTy::PtsMap::const_iterator it = ptsMap.begin(), eit=ptsMap.end(); it!=eit; ++it)
             {
-                for(typename CPtSet::const_iterator cit = it->second.begin(), ecit=it->second.end(); cit!=ecit; ++cit)
+                for(typename CPtSet::const_iterator cit = it->second->begin(), ecit=it->second->end(); cit!=ecit; ++cit)
                 {
                     ptrToBVPtsMap[(it->first).get_id()].set(cit->get_id());
                     objToBVRevPtsMap[cit->get_id()].set((it->first).get_id());

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -415,7 +415,7 @@ protected:
             const typename MutPTDataTy::PtsMap& ptsMap = getPtsMap();
             for(typename MutPTDataTy::PtsMap::const_iterator it = ptsMap.begin(), eit=ptsMap.end(); it!=eit; ++it)
             {
-                for(typename CPtSet::const_iterator cit = it->second->begin(), ecit=it->second->end(); cit!=ecit; ++cit)
+                for(typename CPtSet::const_iterator cit = it->second.begin(), ecit=it->second.end(); cit!=ecit; ++cit)
                 {
                     ptrToBVPtsMap[(it->first).get_id()].set(cit->get_id());
                     objToBVRevPtsMap[cit->get_id()].set((it->first).get_id());

--- a/include/SABER/LeakChecker.h
+++ b/include/SABER/LeakChecker.h
@@ -43,7 +43,7 @@ class LeakChecker : public SrcSnkDDA
 {
 
 public:
-    typedef std::map<const SVFGNode*,const CallBlockNode*> SVFGNodeToCSIDMap;
+    typedef SVFMap<const SVFGNode*,const CallBlockNode*> SVFGNodeToCSIDMap;
     typedef FIFOWorkList<const CallBlockNode*> CSWorkList;
     typedef ProgSlice::VFWorkList WorkList;
     typedef NodeBS SVFGNodeBS;

--- a/include/SABER/LeakChecker.h
+++ b/include/SABER/LeakChecker.h
@@ -43,7 +43,7 @@ class LeakChecker : public SrcSnkDDA
 {
 
 public:
-    typedef SVFMap<const SVFGNode*,const CallBlockNode*> SVFGNodeToCSIDMap;
+    typedef Map<const SVFGNode*,const CallBlockNode*> SVFGNodeToCSIDMap;
     typedef FIFOWorkList<const CallBlockNode*> CSWorkList;
     typedef ProgSlice::VFWorkList WorkList;
     typedef NodeBS SVFGNodeBS;

--- a/include/SABER/ProgSlice.h
+++ b/include/SABER/ProgSlice.h
@@ -42,10 +42,10 @@ class ProgSlice
 {
 
 public:
-    typedef SVFSet<const SVFGNode*> SVFGNodeSet;
-    typedef SVFGNodeSet::iterator SVFGNodeSetIter;
+    typedef Set<const SVFGNode*> SVFGNodeSet;
+    typedef SVFGNodeSet::const_iterator SVFGNodeSetIter;
     typedef PathCondAllocator::Condition Condition;
-    typedef SVFMap<const SVFGNode*, Condition*> SVFGNodeToCondMap; 	///< map a SVFGNode to its condition during value-flow guard computation
+    typedef Map<const SVFGNode*, Condition*> SVFGNodeToCondMap; 	///< map a SVFGNode to its condition during value-flow guard computation
 
     typedef FIFOWorkList<const SVFGNode*> VFWorkList;		    ///< worklist for value-flow guard computation
     typedef FIFOWorkList<const BasicBlock*> CFWorkList;	///< worklist for control-flow guard computation

--- a/include/SABER/ProgSlice.h
+++ b/include/SABER/ProgSlice.h
@@ -42,10 +42,10 @@ class ProgSlice
 {
 
 public:
-    typedef std::set<const SVFGNode*> SVFGNodeSet;
+    typedef SVFSet<const SVFGNode*> SVFGNodeSet;
     typedef SVFGNodeSet::iterator SVFGNodeSetIter;
     typedef PathCondAllocator::Condition Condition;
-    typedef std::map<const SVFGNode*, Condition*> SVFGNodeToCondMap; 	///< map a SVFGNode to its condition during value-flow guard computation
+    typedef SVFMap<const SVFGNode*, Condition*> SVFGNodeToCondMap; 	///< map a SVFGNode to its condition during value-flow guard computation
 
     typedef FIFOWorkList<const SVFGNode*> VFWorkList;		    ///< worklist for value-flow guard computation
     typedef FIFOWorkList<const BasicBlock*> CFWorkList;	///< worklist for control-flow guard computation

--- a/include/SABER/SaberSVFGBuilder.h
+++ b/include/SABER/SaberSVFGBuilder.h
@@ -43,8 +43,8 @@ class SaberSVFGBuilder : public SVFGBuilder
 {
 
 public:
-    typedef SVFSet<const SVFGNode*> SVFGNodeSet;
-    typedef SVFMap<NodeID, NodeBS> NodeToPTSSMap;
+    typedef Set<const SVFGNode*> SVFGNodeSet;
+    typedef Map<NodeID, NodeBS> NodeToPTSSMap;
     typedef FIFOWorkList<NodeID> WorkList;
 
     /// Constructor

--- a/include/SABER/SaberSVFGBuilder.h
+++ b/include/SABER/SaberSVFGBuilder.h
@@ -43,8 +43,8 @@ class SaberSVFGBuilder : public SVFGBuilder
 {
 
 public:
-    typedef std::set<const SVFGNode*> SVFGNodeSet;
-    typedef std::map<NodeID, NodeBS> NodeToPTSSMap;
+    typedef SVFSet<const SVFGNode*> SVFGNodeSet;
+    typedef SVFMap<NodeID, NodeBS> NodeToPTSSMap;
     typedef FIFOWorkList<NodeID> WorkList;
 
     /// Constructor

--- a/include/SABER/SrcSnkDDA.h
+++ b/include/SABER/SrcSnkDDA.h
@@ -49,12 +49,12 @@ class SrcSnkDDA : public CFLSrcSnkSolver
 
 public:
     typedef ProgSlice::SVFGNodeSet SVFGNodeSet;
-    typedef std::map<const SVFGNode*,ProgSlice*> SVFGNodeToSliceMap;
+    typedef SVFMap<const SVFGNode*,ProgSlice*> SVFGNodeToSliceMap;
     typedef SVFGNodeSet::iterator SVFGNodeSetIter;
     typedef CxtDPItem DPIm;
-    typedef std::set<DPIm> DPImSet;							///< dpitem set
-    typedef std::map<const SVFGNode*, DPImSet> SVFGNodeToDPItemsMap; 	///< map a SVFGNode to its visited dpitems
-    typedef std::set<const CallBlockNode*> CallSiteSet;
+    typedef SVFSet<DPIm> DPImSet;							///< dpitem set
+    typedef SVFMap<const SVFGNode*, DPImSet> SVFGNodeToDPItemsMap; 	///< map a SVFGNode to its visited dpitems
+    typedef SVFSet<const CallBlockNode*> CallSiteSet;
     typedef NodeBS SVFGNodeBS;
     typedef ProgSlice::VFWorkList WorkList;
 

--- a/include/SABER/SrcSnkDDA.h
+++ b/include/SABER/SrcSnkDDA.h
@@ -49,12 +49,12 @@ class SrcSnkDDA : public CFLSrcSnkSolver
 
 public:
     typedef ProgSlice::SVFGNodeSet SVFGNodeSet;
-    typedef SVFMap<const SVFGNode*,ProgSlice*> SVFGNodeToSliceMap;
-    typedef SVFGNodeSet::iterator SVFGNodeSetIter;
+    typedef Map<const SVFGNode*,ProgSlice*> SVFGNodeToSliceMap;
+    typedef SVFGNodeSet::const_iterator SVFGNodeSetIter;
     typedef CxtDPItem DPIm;
-    typedef SVFSet<DPIm> DPImSet;							///< dpitem set
-    typedef SVFMap<const SVFGNode*, DPImSet> SVFGNodeToDPItemsMap; 	///< map a SVFGNode to its visited dpitems
-    typedef SVFSet<const CallBlockNode*> CallSiteSet;
+    typedef Set<DPIm> DPImSet;							///< dpitem set
+    typedef Map<const SVFGNode*, DPImSet> SVFGNodeToDPItemsMap; 	///< map a SVFGNode to its visited dpitems
+    typedef Set<const CallBlockNode*> CallSiteSet;
     typedef NodeBS SVFGNodeBS;
     typedef ProgSlice::VFWorkList WorkList;
 
@@ -253,7 +253,7 @@ protected:
     //@{
     inline bool forwardVisited(const SVFGNode* node, const DPIm& item)
     {
-        SVFGNodeToDPItemsMap::iterator it = nodeToDPItemsMap.find(node);
+        SVFGNodeToDPItemsMap::const_iterator it = nodeToDPItemsMap.find(node);
         if(it!=nodeToDPItemsMap.end())
             return it->second.find(item)!=it->second.end();
         else

--- a/include/SVF-FE/CHG.h
+++ b/include/SVF-FE/CHG.h
@@ -176,12 +176,12 @@ typedef GenericGraph<CHNode,CHEdge> GenericCHGraphTy;
 class CHGraph: public CommonCHGraph, public GenericCHGraphTy
 {
 public:
-    typedef SVFSet<const CHNode*> CHNodeSetTy;
+    typedef Set<const CHNode*> CHNodeSetTy;
     typedef FIFOWorkList<const CHNode*> WorkList;
-    typedef SVFMap<std::string, CHNodeSetTy> NameToCHNodesMap;
-    typedef SVFMap<CallSite, CHNodeSetTy> CallSiteToCHNodesMap;
-    typedef SVFMap<CallSite, VTableSet> CallSiteToVTableSetMap;
-    typedef SVFMap<CallSite, VFunSet> CallSiteToVFunSetMap;
+    typedef Map<std::string, CHNodeSetTy> NameToCHNodesMap;
+    typedef Map<CallSite, CHNodeSetTy> CallSiteToCHNodesMap;
+    typedef Map<CallSite, VTableSet> CallSiteToVTableSetMap;
+    typedef Map<CallSite, VFunSet> CallSiteToVFunSetMap;
 
     typedef enum
     {
@@ -220,7 +220,7 @@ public:
 
     inline s32_t getVirtualFunctionID(const SVFFunction* vfn) const
     {
-        SVFMap<const SVFFunction*, s32_t>::const_iterator it =
+        Map<const SVFFunction*, s32_t>::const_iterator it =
             virtualFunctionToIDMap.find(vfn);
         if (it != virtualFunctionToIDMap.end())
             return it->second;
@@ -229,7 +229,7 @@ public:
     }
     inline const SVFFunction* getVirtualFunctionBasedonID(s32_t id) const
     {
-        SVFMap<const SVFFunction*, s32_t>::const_iterator it, eit;
+        Map<const SVFFunction*, s32_t>::const_iterator it, eit;
         for (it = virtualFunctionToIDMap.begin(), eit =
                     virtualFunctionToIDMap.end(); it != eit; ++it)
         {
@@ -290,14 +290,14 @@ private:
     u32_t classNum;
     s32_t vfID;
     double buildingCHGTime;
-    SVFMap<const std::string, CHNode *> classNameToNodeMap;
+    Map<std::string, CHNode *> classNameToNodeMap;
     NameToCHNodesMap classNameToDescendantsMap;
     NameToCHNodesMap classNameToAncestorsMap;
     NameToCHNodesMap classNameToInstAndDescsMap;
     NameToCHNodesMap templateNameToInstancesMap;
     CallSiteToCHNodesMap csToClassesMap;
 
-    SVFMap<const SVFFunction*, s32_t> virtualFunctionToIDMap;
+    Map<const SVFFunction*, s32_t> virtualFunctionToIDMap;
     CallSiteToVTableSetMap csToCHAVtblsMap;
     CallSiteToVFunSetMap csToCHAVFnsMap;
 };

--- a/include/SVF-FE/CHG.h
+++ b/include/SVF-FE/CHG.h
@@ -176,12 +176,12 @@ typedef GenericGraph<CHNode,CHEdge> GenericCHGraphTy;
 class CHGraph: public CommonCHGraph, public GenericCHGraphTy
 {
 public:
-    typedef DenseSet<const CHNode*> CHNodeSetTy;
+    typedef SVFSet<const CHNode*> CHNodeSetTy;
     typedef FIFOWorkList<const CHNode*> WorkList;
     typedef std::map<std::string, CHNodeSetTy> NameToCHNodesMap;
-    typedef DenseMap<CallSite, CHNodeSetTy> CallSiteToCHNodesMap;
-    typedef DenseMap<CallSite, VTableSet> CallSiteToVTableSetMap;
-    typedef DenseMap<CallSite, VFunSet> CallSiteToVFunSetMap;
+    typedef SVFMap<CallSite, CHNodeSetTy> CallSiteToCHNodesMap;
+    typedef SVFMap<CallSite, VTableSet> CallSiteToVTableSetMap;
+    typedef SVFMap<CallSite, VFunSet> CallSiteToVFunSetMap;
 
     typedef enum
     {
@@ -220,7 +220,7 @@ public:
 
     inline s32_t getVirtualFunctionID(const SVFFunction* vfn) const
     {
-        DenseMap<const SVFFunction*, s32_t>::const_iterator it =
+        SVFMap<const SVFFunction*, s32_t>::const_iterator it =
             virtualFunctionToIDMap.find(vfn);
         if (it != virtualFunctionToIDMap.end())
             return it->second;
@@ -229,7 +229,7 @@ public:
     }
     inline const SVFFunction* getVirtualFunctionBasedonID(s32_t id) const
     {
-        DenseMap<const SVFFunction*, s32_t>::const_iterator it, eit;
+        SVFMap<const SVFFunction*, s32_t>::const_iterator it, eit;
         for (it = virtualFunctionToIDMap.begin(), eit =
                     virtualFunctionToIDMap.end(); it != eit; ++it)
         {
@@ -297,7 +297,7 @@ private:
     NameToCHNodesMap templateNameToInstancesMap;
     CallSiteToCHNodesMap csToClassesMap;
 
-    DenseMap<const SVFFunction*, s32_t> virtualFunctionToIDMap;
+    SVFMap<const SVFFunction*, s32_t> virtualFunctionToIDMap;
     CallSiteToVTableSetMap csToCHAVtblsMap;
     CallSiteToVFunSetMap csToCHAVFnsMap;
 };

--- a/include/SVF-FE/CHG.h
+++ b/include/SVF-FE/CHG.h
@@ -178,7 +178,7 @@ class CHGraph: public CommonCHGraph, public GenericCHGraphTy
 public:
     typedef SVFSet<const CHNode*> CHNodeSetTy;
     typedef FIFOWorkList<const CHNode*> WorkList;
-    typedef std::map<std::string, CHNodeSetTy> NameToCHNodesMap;
+    typedef SVFMap<std::string, CHNodeSetTy> NameToCHNodesMap;
     typedef SVFMap<CallSite, CHNodeSetTy> CallSiteToCHNodesMap;
     typedef SVFMap<CallSite, VTableSet> CallSiteToVTableSetMap;
     typedef SVFMap<CallSite, VFunSet> CallSiteToVFunSetMap;
@@ -290,7 +290,7 @@ private:
     u32_t classNum;
     s32_t vfID;
     double buildingCHGTime;
-    std::map<const std::string, CHNode *> classNameToNodeMap;
+    SVFMap<const std::string, CHNode *> classNameToNodeMap;
     NameToCHNodesMap classNameToDescendantsMap;
     NameToCHNodesMap classNameToAncestorsMap;
     NameToCHNodesMap classNameToInstAndDescsMap;

--- a/include/SVF-FE/CommonCHG.h
+++ b/include/SVF-FE/CommonCHG.h
@@ -14,8 +14,8 @@
 namespace SVF
 {
 
-typedef DenseSet<const GlobalValue*> VTableSet;
-typedef DenseSet<const SVFFunction*> VFunSet;
+typedef SVFSet<const GlobalValue*> VTableSet;
+typedef SVFSet<const SVFFunction*> VFunSet;
 
 /// Common base for class hierarchy graph. Only implements what PointerAnalysis needs.
 class CommonCHGraph

--- a/include/SVF-FE/CommonCHG.h
+++ b/include/SVF-FE/CommonCHG.h
@@ -14,8 +14,8 @@
 namespace SVF
 {
 
-typedef SVFSet<const GlobalValue*> VTableSet;
-typedef SVFSet<const SVFFunction*> VFunSet;
+typedef Set<const GlobalValue*> VTableSet;
+typedef Set<const SVFFunction*> VFunSet;
 
 /// Common base for class hierarchy graph. Only implements what PointerAnalysis needs.
 class CommonCHGraph

--- a/include/SVF-FE/DCHG.h
+++ b/include/SVF-FE/DCHG.h
@@ -156,7 +156,7 @@ public:
         typedefs.insert(diTypedef);
     }
 
-    const DenseSet<const DIDerivedType *> &getTypedefs(void) const
+    const SVFSet<const DIDerivedType *> &getTypedefs(void) const
     {
         return typedefs;
     }
@@ -192,7 +192,7 @@ private:
     /// Type of this node.
     const DIType *diType;
     /// Typedefs which map to this type.
-    DenseSet<const DIDerivedType *> typedefs;
+    SVFSet<const DIDerivedType *> typedefs;
     const GlobalValue* vtable;
     std::string typeName;
     size_t flags;
@@ -340,7 +340,7 @@ public:
     }
 
     /// Returns all the aggregates contained (transitively) in base.
-    const DenseSet<const DIType *> &getAggs(const DIType *base)
+    const SVFSet<const DIType *> &getAggs(const DIType *base)
     {
         base = getCanonicalType(base);
         assert(containingAggs.find(base) != containingAggs.end() && "DCHG: aggregates not gathered for base!");
@@ -355,25 +355,25 @@ protected:
     /// Whether this CHG is an extended CHG (first-field). Set by buildCHG.
     bool extended = false;
     /// Maps DITypes to their nodes.
-    DenseMap<const DIType *, DCHNode *> diTypeToNodeMap;
+    SVFMap<const DIType *, DCHNode *> diTypeToNodeMap;
     /// Maps VTables to the DIType associated with them.
-    DenseMap<const GlobalValue *, const DIType *> vtblToTypeMap;
+    SVFMap<const GlobalValue *, const DIType *> vtblToTypeMap;
     /// Maps types to all children (i.e. CHA).
-    DenseMap<const DIType *, NodeBS> chaMap;
+    SVFMap<const DIType *, NodeBS> chaMap;
     /// Maps types to all children but also considering first field.
-    DenseMap<const DIType *, NodeBS> chaFFMap;
+    SVFMap<const DIType *, NodeBS> chaFFMap;
     /// Maps types to a set with their vtable and all their children's.
-    DenseMap<const DIType *, VTableSet> vtblCHAMap;
+    SVFMap<const DIType *, VTableSet> vtblCHAMap;
     /// Maps callsites to a set of potential virtual functions based on CHA.
-    DenseMap<CallSite, VFunSet> csCHAMap;
+    SVFMap<CallSite, VFunSet> csCHAMap;
     /// Maps types to their canonical type (many-to-one).
-    DenseMap<const DIType *, const DIType *> canonicalTypeMap;
+    SVFMap<const DIType *, const DIType *> canonicalTypeMap;
     /// Set of all possible canonical types (i.e. values of canonicalTypeMap).
-    DenseSet<const DIType *> canonicalTypes;
+    SVFSet<const DIType *> canonicalTypes;
     /// Maps types to their flattened fields' types.
-    DenseMap<const DIType *, std::vector<const DIType *>> fieldTypes;
+    SVFMap<const DIType *, std::vector<const DIType *>> fieldTypes;
     /// Maps aggregate types to all the aggregate types it transitively contains.
-    DenseMap<const DIType *, DenseSet<const DIType *>> containingAggs;
+    SVFMap<const DIType *, SVFSet<const DIType *>> containingAggs;
 
 private:
     /// Construction helper to process DIBasicTypes.
@@ -426,7 +426,7 @@ private:
         type = getCanonicalType(type);
         if (hasNode(type))
         {
-            return diTypeToNodeMap.lookup(type);
+            return diTypeToNodeMap.at(type);
         }
 
         return nullptr;

--- a/include/SVF-FE/DCHG.h
+++ b/include/SVF-FE/DCHG.h
@@ -156,7 +156,7 @@ public:
         typedefs.insert(diTypedef);
     }
 
-    const SVFSet<const DIDerivedType *> &getTypedefs(void) const
+    const Set<const DIDerivedType *> &getTypedefs(void) const
     {
         return typedefs;
     }
@@ -192,7 +192,7 @@ private:
     /// Type of this node.
     const DIType *diType;
     /// Typedefs which map to this type.
-    SVFSet<const DIDerivedType *> typedefs;
+    Set<const DIDerivedType *> typedefs;
     const GlobalValue* vtable;
     std::string typeName;
     size_t flags;
@@ -340,7 +340,7 @@ public:
     }
 
     /// Returns all the aggregates contained (transitively) in base.
-    const SVFSet<const DIType *> &getAggs(const DIType *base)
+    const Set<const DIType *> &getAggs(const DIType *base)
     {
         base = getCanonicalType(base);
         assert(containingAggs.find(base) != containingAggs.end() && "DCHG: aggregates not gathered for base!");
@@ -355,25 +355,25 @@ protected:
     /// Whether this CHG is an extended CHG (first-field). Set by buildCHG.
     bool extended = false;
     /// Maps DITypes to their nodes.
-    SVFMap<const DIType *, DCHNode *> diTypeToNodeMap;
+    Map<const DIType *, DCHNode *> diTypeToNodeMap;
     /// Maps VTables to the DIType associated with them.
-    SVFMap<const GlobalValue *, const DIType *> vtblToTypeMap;
+    Map<const GlobalValue *, const DIType *> vtblToTypeMap;
     /// Maps types to all children (i.e. CHA).
-    SVFMap<const DIType *, NodeBS> chaMap;
+    Map<const DIType *, NodeBS> chaMap;
     /// Maps types to all children but also considering first field.
-    SVFMap<const DIType *, NodeBS> chaFFMap;
+    Map<const DIType *, NodeBS> chaFFMap;
     /// Maps types to a set with their vtable and all their children's.
-    SVFMap<const DIType *, VTableSet> vtblCHAMap;
+    Map<const DIType *, VTableSet> vtblCHAMap;
     /// Maps callsites to a set of potential virtual functions based on CHA.
-    SVFMap<CallSite, VFunSet> csCHAMap;
+    Map<CallSite, VFunSet> csCHAMap;
     /// Maps types to their canonical type (many-to-one).
-    SVFMap<const DIType *, const DIType *> canonicalTypeMap;
+    Map<const DIType *, const DIType *> canonicalTypeMap;
     /// Set of all possible canonical types (i.e. values of canonicalTypeMap).
-    SVFSet<const DIType *> canonicalTypes;
+    Set<const DIType *> canonicalTypes;
     /// Maps types to their flattened fields' types.
-    SVFMap<const DIType *, std::vector<const DIType *>> fieldTypes;
+    Map<const DIType *, std::vector<const DIType *>> fieldTypes;
     /// Maps aggregate types to all the aggregate types it transitively contains.
-    SVFMap<const DIType *, SVFSet<const DIType *>> containingAggs;
+    Map<const DIType *, Set<const DIType *>> containingAggs;
 
 private:
     /// Construction helper to process DIBasicTypes.

--- a/include/SVF-FE/DataFlowUtil.h
+++ b/include/SVF-FE/DataFlowUtil.h
@@ -120,9 +120,9 @@ public:
 
 class PTACFInfoBuilder{
 public:
-    typedef DenseMap<const Function*, DominatorTree*> FunToDTMap;  ///< map a function to its dominator tree
-    typedef DenseMap<const Function*, PostDominatorTree*> FunToPostDTMap;  ///< map a function to its post dominator tree
-    typedef DenseMap<const Function*, LoopInfo*> FunToLoopInfoMap;  ///< map a function to its loop info
+    typedef SVFMap<const Function*, DominatorTree*> FunToDTMap;  ///< map a function to its dominator tree
+    typedef SVFMap<const Function*, PostDominatorTree*> FunToPostDTMap;  ///< map a function to its post dominator tree
+    typedef SVFMap<const Function*, LoopInfo*> FunToLoopInfoMap;  ///< map a function to its loop info
 
     /// Constructor
      PTACFInfoBuilder();

--- a/include/SVF-FE/DataFlowUtil.h
+++ b/include/SVF-FE/DataFlowUtil.h
@@ -120,9 +120,9 @@ public:
 
 class PTACFInfoBuilder{
 public:
-    typedef SVFMap<const Function*, DominatorTree*> FunToDTMap;  ///< map a function to its dominator tree
-    typedef SVFMap<const Function*, PostDominatorTree*> FunToPostDTMap;  ///< map a function to its post dominator tree
-    typedef SVFMap<const Function*, LoopInfo*> FunToLoopInfoMap;  ///< map a function to its loop info
+    typedef Map<const Function*, DominatorTree*> FunToDTMap;  ///< map a function to its dominator tree
+    typedef Map<const Function*, PostDominatorTree*> FunToPostDTMap;  ///< map a function to its post dominator tree
+    typedef Map<const Function*, LoopInfo*> FunToLoopInfoMap;  ///< map a function to its loop info
 
     /// Constructor
      PTACFInfoBuilder();

--- a/include/SVF-FE/ICFGBuilder.h
+++ b/include/SVF-FE/ICFGBuilder.h
@@ -42,7 +42,7 @@ class ICFGBuilder
 public:
 
     typedef std::vector<const Instruction*> InstVec;
-    typedef SVFSet<const Instruction*> BBSet;
+    typedef Set<const Instruction*> BBSet;
 
 private:
     ICFG* icfg;

--- a/include/SVF-FE/ICFGBuilder.h
+++ b/include/SVF-FE/ICFGBuilder.h
@@ -42,7 +42,7 @@ class ICFGBuilder
 public:
 
     typedef std::vector<const Instruction*> InstVec;
-    typedef DenseSet<const Instruction*> BBSet;
+    typedef SVFSet<const Instruction*> BBSet;
 
 private:
     ICFG* icfg;

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -42,9 +42,9 @@ class LLVMModuleSet
 public:
 
     typedef std::vector<const SVFFunction*> FunctionSetType;
-    typedef DenseMap<const SVFFunction*, const SVFFunction*> FunDeclToDefMapTy;
-    typedef DenseMap<const SVFFunction*, FunctionSetType> FunDefToDeclsMapTy;
-    typedef DenseMap<const GlobalVariable*, GlobalVariable*> GlobalDefToRepMapTy;
+    typedef SVFMap<const SVFFunction*, const SVFFunction*> FunDeclToDefMapTy;
+    typedef SVFMap<const SVFFunction*, FunctionSetType> FunDefToDeclsMapTy;
+    typedef SVFMap<const GlobalVariable*, GlobalVariable*> GlobalDefToRepMapTy;
 
 private:
     static LLVMModuleSet *llvmModuleSet;

--- a/include/SVF-FE/LLVMModule.h
+++ b/include/SVF-FE/LLVMModule.h
@@ -42,9 +42,9 @@ class LLVMModuleSet
 public:
 
     typedef std::vector<const SVFFunction*> FunctionSetType;
-    typedef SVFMap<const SVFFunction*, const SVFFunction*> FunDeclToDefMapTy;
-    typedef SVFMap<const SVFFunction*, FunctionSetType> FunDefToDeclsMapTy;
-    typedef SVFMap<const GlobalVariable*, GlobalVariable*> GlobalDefToRepMapTy;
+    typedef Map<const SVFFunction*, const SVFFunction*> FunDeclToDefMapTy;
+    typedef Map<const SVFFunction*, FunctionSetType> FunDefToDeclsMapTy;
+    typedef Map<const GlobalVariable*, GlobalVariable*> GlobalDefToRepMapTy;
 
 private:
     static LLVMModuleSet *llvmModuleSet;

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -47,18 +47,18 @@ public:
     //{@
     /// llvm value to sym id map
     /// local (%) and global (@) identifiers are pointer types which have a value node id.
-    typedef Map<const Value *, SymID> ValueToIDMapTy;
+    typedef OrderedMap<const Value *, SymID> ValueToIDMapTy;
     /// sym id to memory object map
-    typedef Map<SymID,MemObj*> IDToMemMapTy;
+    typedef OrderedMap<SymID,MemObj*> IDToMemMapTy;
     /// function to sym id map
-    typedef Map<const Function *, SymID> FunToIDMapTy;
+    typedef OrderedMap<const Function *, SymID> FunToIDMapTy;
     /// sym id to sym type map
-    typedef Map<SymID,SYMTYPE> IDToSymTyMapTy;
+    typedef OrderedMap<SymID,SYMTYPE> IDToSymTyMapTy;
     /// struct type to struct info map
-    typedef Map<const Type*, StInfo*> TypeToFieldInfoMap;
+    typedef OrderedMap<const Type*, StInfo*> TypeToFieldInfoMap;
     typedef Set<CallSite> CallSiteSet;
-    typedef Map<const Instruction*,CallSiteID> CallSiteToIDMapTy;
-    typedef Map<CallSiteID,const Instruction*> IDToCallSiteMapTy;
+    typedef OrderedMap<const Instruction*,CallSiteID> CallSiteToIDMapTy;
+    typedef OrderedMap<CallSiteID,const Instruction*> IDToCallSiteMapTy;
 
     //@}
 

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -47,18 +47,18 @@ public:
     //{@
     /// llvm value to sym id map
     /// local (%) and global (@) identifiers are pointer types which have a value node id.
-    typedef SVFMap<const Value *, SymID> ValueToIDMapTy;
+    typedef Map<const Value *, SymID> ValueToIDMapTy;
     /// sym id to memory object map
-    typedef SVFMap<SymID,MemObj*> IDToMemMapTy;
+    typedef Map<SymID,MemObj*> IDToMemMapTy;
     /// function to sym id map
-    typedef SVFMap<const Function *, SymID> FunToIDMapTy;
+    typedef Map<const Function *, SymID> FunToIDMapTy;
     /// sym id to sym type map
-    typedef SVFMap<SymID,SYMTYPE> IDToSymTyMapTy;
+    typedef Map<SymID,SYMTYPE> IDToSymTyMapTy;
     /// struct type to struct info map
-    typedef SVFMap<const Type*, StInfo*> TypeToFieldInfoMap;
-    typedef SVFSet<CallSite> CallSiteSet;
-    typedef SVFMap<const Instruction*,CallSiteID> CallSiteToIDMapTy;
-    typedef SVFMap<CallSiteID,const Instruction*> IDToCallSiteMapTy;
+    typedef Map<const Type*, StInfo*> TypeToFieldInfoMap;
+    typedef Set<CallSite> CallSiteSet;
+    typedef Map<const Instruction*,CallSiteID> CallSiteToIDMapTy;
+    typedef Map<CallSiteID,const Instruction*> IDToCallSiteMapTy;
 
     //@}
 

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -47,18 +47,18 @@ public:
     //{@
     /// llvm value to sym id map
     /// local (%) and global (@) identifiers are pointer types which have a value node id.
-    typedef DenseMap<const Value *, SymID> ValueToIDMapTy;
+    typedef SVFMap<const Value *, SymID> ValueToIDMapTy;
     /// sym id to memory object map
-    typedef DenseMap<SymID,MemObj*> IDToMemMapTy;
+    typedef SVFMap<SymID,MemObj*> IDToMemMapTy;
     /// function to sym id map
-    typedef DenseMap<const Function *, SymID> FunToIDMapTy;
+    typedef SVFMap<const Function *, SymID> FunToIDMapTy;
     /// sym id to sym type map
-    typedef DenseMap<SymID,SYMTYPE> IDToSymTyMapTy;
+    typedef SVFMap<SymID,SYMTYPE> IDToSymTyMapTy;
     /// struct type to struct info map
-    typedef DenseMap<const Type*, StInfo*> TypeToFieldInfoMap;
-    typedef DenseSet<CallSite> CallSiteSet;
-    typedef DenseMap<const Instruction*,CallSiteID> CallSiteToIDMapTy;
-    typedef DenseMap<CallSiteID,const Instruction*> IDToCallSiteMapTy;
+    typedef SVFMap<const Type*, StInfo*> TypeToFieldInfoMap;
+    typedef SVFSet<CallSite> CallSiteSet;
+    typedef SVFMap<const Instruction*,CallSiteID> CallSiteToIDMapTy;
+    typedef SVFMap<CallSiteID,const Instruction*> IDToCallSiteMapTy;
 
     //@}
 

--- a/include/Util/BasicTypes.h
+++ b/include/Util/BasicTypes.h
@@ -208,21 +208,6 @@ typedef llvm::DINodeArray DINodeArray;
 typedef llvm::DITypeRefArray DITypeRefArray;
 namespace dwarf = llvm::dwarf;
 
-/// LLVM containers
-template <typename T>
-using DenseMapInfo = llvm::DenseMapInfo<T>;
-
-template <typename KeyT, typename ValueT>
-using DenseMapPair = llvm::detail::DenseMapPair<KeyT, ValueT>;
-
-template <typename KeyT, typename ValueT,
-          typename KeyInfoT = DenseMapInfo<KeyT>,
-          typename BucketT = DenseMapPair<KeyT, ValueT>>
-using DenseMap = llvm::DenseMap<KeyT, ValueT, KeyInfoT, BucketT>;
-
-template <typename ValueT, typename ValueInfoT = DenseMapInfo<ValueT>>
-using DenseSet = llvm::DenseSet<ValueT, ValueInfoT>;
-
 class SVFFunction : public SVFValue
 {
 private:
@@ -298,5 +283,13 @@ public:
 };
 
 } // End namespace SVF
+
+/// Specialise hash for CallSites.
+template <> struct std::hash<SVF::CallSite> {
+    size_t operator()(const SVF::CallSite &cs) const {
+        std::hash<SVF::Instruction *> h;
+        return h(cs.getInstruction());
+    }
+};
 
 #endif /* BASICTYPES_H_ */

--- a/include/Util/DPItem.h
+++ b/include/Util/DPItem.h
@@ -773,4 +773,59 @@ public:
 
 } // End namespace SVF
 
+/// Specialise hash for CxtDPItem.
+template <>
+struct std::hash<SVF::CxtDPItem>
+{
+    size_t operator()(const SVF::CxtDPItem &cdpi) const
+    {
+        std::hash<std::pair<SVF::NodeID, SVF::ContextCond>> h;
+        return h(std::make_pair(cdpi.getCurNodeID(), cdpi.getContexts()));
+    }
+};
+
+/// Specialise hash for StmtDPItem.
+template <typename LocCond>
+struct std::hash<SVF::StmtDPItem<LocCond>>
+{
+    size_t operator()(const SVF::StmtDPItem<LocCond> &sdpi) const
+    {
+        std::hash<std::pair<SVF::NodeID, const LocCond *>> h;
+        return h(std::make_pair(sdpi.getCurNodeID(), sdpi.getLoc()));
+    }
+};
+
+/// Specialise hash for CxtStmtDPItem.
+template<class LocCond>
+struct std::hash<SVF::CxtStmtDPItem<LocCond>>
+{
+    size_t operator()(const SVF::CxtStmtDPItem<LocCond> &csdpi) const
+    {
+        std::hash<std::pair<SVF::NodeID, std::pair<const LocCond *, SVF::ContextCond>>> h;
+        return h(std::make_pair(csdpi.getCurNodeID(),
+                                std::make_pair(csdpi.getLoc(), csdpi.getCond())));
+    }
+};
+
+/// Specialise hash for ContextCond.
+template <>
+struct std::hash<const SVF::ContextCond>
+{
+    size_t operator()(const SVF::ContextCond &cc) const
+    {
+        std::hash<SVF::CallStrCxt> h;
+        return h(cc.getContexts());
+    }
+};
+
+template <>
+struct std::hash<SVF::ContextCond>
+{
+    size_t operator()(const SVF::ContextCond &cc) const
+    {
+        std::hash<SVF::CallStrCxt> h;
+        return h(cc.getContexts());
+    }
+};
+
 #endif /* DPITEM_H_ */

--- a/include/Util/ExtAPI.h
+++ b/include/Util/ExtAPI.h
@@ -94,7 +94,7 @@ private:
     //  (hash_map and map are much slower).
     llvm::StringMap<extf_t> info;
     //A cache of is_ext results for all SVFFunction*'s (hash_map is fastest).
-    SVFMap<const SVFFunction*, bool> isext_cache;
+    Map<const SVFFunction*, bool> isext_cache;
 
     void init();                          //fill in the map (see ExtAPI.cpp)
 
@@ -208,7 +208,7 @@ public:
     {
         assert(F);
         //Check the cache first; everything below is slower.
-        SVFMap<const SVFFunction*, bool>::iterator i_iec= isext_cache.find(F);
+        Map<const SVFFunction*, bool>::iterator i_iec= isext_cache.find(F);
         if(i_iec != isext_cache.end())
             return i_iec->second;
 

--- a/include/Util/ExtAPI.h
+++ b/include/Util/ExtAPI.h
@@ -94,7 +94,7 @@ private:
     //  (hash_map and map are much slower).
     llvm::StringMap<extf_t> info;
     //A cache of is_ext results for all SVFFunction*'s (hash_map is fastest).
-    DenseMap<const SVFFunction*, bool> isext_cache;
+    SVFMap<const SVFFunction*, bool> isext_cache;
 
     void init();                          //fill in the map (see ExtAPI.cpp)
 
@@ -208,7 +208,7 @@ public:
     {
         assert(F);
         //Check the cache first; everything below is slower.
-        DenseMap<const SVFFunction*, bool>::iterator i_iec= isext_cache.find(F);
+        SVFMap<const SVFFunction*, bool>::iterator i_iec= isext_cache.find(F);
         if(i_iec != isext_cache.end())
             return i_iec->second;
 

--- a/include/Util/PathCondAllocator.h
+++ b/include/Util/PathCondAllocator.h
@@ -48,15 +48,15 @@ public:
     static u32_t totalCondNum;
 
     typedef DdNode Condition;
-    typedef std::map<u32_t,Condition*> CondPosMap;		///< map a branch to its Condition
-    typedef std::map<const BasicBlock*, CondPosMap > BBCondMap;	// map bb to a Condition
-    typedef std::map<const Condition*, const Instruction* > CondToTermInstMap;	// map a condition to its branch instruction
-    typedef std::set<const BasicBlock*> BasicBlockSet;
-    typedef std::map<const Function*,  BasicBlockSet> FunToExitBBsMap;  ///< map a function to all its basic blocks calling program exit
-    typedef std::map<const BasicBlock*, Condition*> BBToCondMap;	///< map a basic block to its condition during control-flow guard computation
+    typedef SVFMap<u32_t,Condition*> CondPosMap;		///< map a branch to its Condition
+    typedef SVFMap<const BasicBlock*, CondPosMap > BBCondMap;	// map bb to a Condition
+    typedef SVFMap<const Condition*, const Instruction* > CondToTermInstMap;	// map a condition to its branch instruction
+    typedef SVFSet<const BasicBlock*> BasicBlockSet;
+    typedef SVFMap<const Function*,  BasicBlockSet> FunToExitBBsMap;  ///< map a function to all its basic blocks calling program exit
+    typedef SVFMap<const BasicBlock*, Condition*> BBToCondMap;	///< map a basic block to its condition during control-flow guard computation
     typedef FIFOWorkList<const BasicBlock*> CFWorkList;	///< worklist for control-flow guard computation
 
-    typedef std::map<u32_t,Condition*> IndexToConditionMap;
+    typedef SVFMap<u32_t,Condition*> IndexToConditionMap;
 
     /// Constructor
     PathCondAllocator()

--- a/include/Util/PathCondAllocator.h
+++ b/include/Util/PathCondAllocator.h
@@ -48,15 +48,15 @@ public:
     static u32_t totalCondNum;
 
     typedef DdNode Condition;
-    typedef SVFMap<u32_t,Condition*> CondPosMap;		///< map a branch to its Condition
-    typedef SVFMap<const BasicBlock*, CondPosMap > BBCondMap;	// map bb to a Condition
-    typedef SVFMap<const Condition*, const Instruction* > CondToTermInstMap;	// map a condition to its branch instruction
-    typedef SVFSet<const BasicBlock*> BasicBlockSet;
-    typedef SVFMap<const Function*,  BasicBlockSet> FunToExitBBsMap;  ///< map a function to all its basic blocks calling program exit
-    typedef SVFMap<const BasicBlock*, Condition*> BBToCondMap;	///< map a basic block to its condition during control-flow guard computation
+    typedef Map<u32_t,Condition*> CondPosMap;		///< map a branch to its Condition
+    typedef Map<const BasicBlock*, CondPosMap > BBCondMap;	// map bb to a Condition
+    typedef Map<const Condition*, const Instruction* > CondToTermInstMap;	// map a condition to its branch instruction
+    typedef Set<const BasicBlock*> BasicBlockSet;
+    typedef Map<const Function*,  BasicBlockSet> FunToExitBBsMap;  ///< map a function to all its basic blocks calling program exit
+    typedef Map<const BasicBlock*, Condition*> BBToCondMap;	///< map a basic block to its condition during control-flow guard computation
     typedef FIFOWorkList<const BasicBlock*> CFWorkList;	///< worklist for control-flow guard computation
 
-    typedef SVFMap<u32_t,Condition*> IndexToConditionMap;
+    typedef Map<u32_t,Condition*> IndexToConditionMap;
 
     /// Constructor
     PathCondAllocator()

--- a/include/Util/SCC.h
+++ b/include/Util/SCC.h
@@ -113,8 +113,8 @@ public:
         NodeBS _subNodes; /// nodes in the scc represented by this node
     };
 
-    typedef SVFMap<NodeID,GNodeSCCInfo > GNODESCCInfoMap;
-    typedef SVFMap<NodeID, NodeID> NodeToNodeMap;
+    typedef Map<NodeID,GNodeSCCInfo > GNODESCCInfoMap;
+    typedef Map<NodeID, NodeID> NodeToNodeMap;
 
     SCCDetection(const GraphType &GT)
         : _graph(GT),

--- a/include/Util/SCC.h
+++ b/include/Util/SCC.h
@@ -113,8 +113,8 @@ public:
         NodeBS _subNodes; /// nodes in the scc represented by this node
     };
 
-    typedef DenseMap<NodeID,GNodeSCCInfo > GNODESCCInfoMap;
-    typedef DenseMap<NodeID, NodeID> NodeToNodeMap;
+    typedef SVFMap<NodeID,GNodeSCCInfo > GNODESCCInfoMap;
+    typedef SVFMap<NodeID, NodeID> NodeToNodeMap;
 
     SCCDetection(const GraphType &GT)
         : _graph(GT),

--- a/include/Util/SVFBasicTypes.h
+++ b/include/Util/SVFBasicTypes.h
@@ -63,11 +63,12 @@ typedef llvm::SparseBitVector<> NodeBS;
 typedef NodeBS PointsTo;
 typedef PointsTo AliasSet;
 
-template <typename Key>
-using SVFSet = std::set<Key>;
+template<typename Key, typename Compare = std::less<Key>, typename Allocator = std::allocator<Key>>
+using SVFSet = std::set<Key, Compare, Allocator>;
 
-template <typename Key, typename Value>
-using SVFMap = std::map<Key, Value>;
+template<typename Key, typename Value, typename Compare = std::less<Key>,
+         typename Allocator = std::allocator<std::pair<const Key, Value>>>
+using SVFMap = std::map<Key, Value, Compare, Allocator>;
 
 typedef std::pair<NodeID, NodeID> NodePair;
 typedef SVFSet<NodeID> NodeSet;

--- a/include/Util/SVFBasicTypes.h
+++ b/include/Util/SVFBasicTypes.h
@@ -70,6 +70,13 @@ template<typename Key, typename Value, typename Compare = std::less<Key>,
          typename Allocator = std::allocator<std::pair<const Key, Value>>>
 using SVFMap = std::map<Key, Value, Compare, Allocator>;
 
+template<typename Key, typename Compare = std::less<Key>, typename Allocator = std::allocator<Key>>
+using OrderedSet = std::set<Key, Compare, Allocator>;
+
+template<typename Key, typename Value, typename Compare = std::less<Key>,
+         typename Allocator = std::allocator<std::pair<const Key, Value>>>
+using OrderedMap = std::map<Key, Value, Compare, Allocator>;
+
 typedef std::pair<NodeID, NodeID> NodePair;
 typedef SVFSet<NodeID> NodeSet;
 typedef SVFSet<NodePair> NodePairSet;

--- a/include/Util/SVFModule.h
+++ b/include/Util/SVFModule.h
@@ -42,7 +42,7 @@ public:
     typedef std::vector<Function*> LLVMFunctionSetType;
     typedef std::vector<GlobalVariable*> GlobalSetType;
     typedef std::vector<GlobalAlias*> AliasSetType;
-    typedef DenseMap<const Function*,const SVFFunction*> LLVMFun2SVFFunMap;
+    typedef SVFMap<const Function*,const SVFFunction*> LLVMFun2SVFFunMap;
 
     /// Iterators type def
     typedef FunctionSetType::iterator iterator;

--- a/include/Util/SVFModule.h
+++ b/include/Util/SVFModule.h
@@ -42,7 +42,7 @@ public:
     typedef std::vector<Function*> LLVMFunctionSetType;
     typedef std::vector<GlobalVariable*> GlobalSetType;
     typedef std::vector<GlobalAlias*> AliasSetType;
-    typedef SVFMap<const Function*,const SVFFunction*> LLVMFun2SVFFunMap;
+    typedef Map<const Function*,const SVFFunction*> LLVMFun2SVFFunMap;
 
     /// Iterators type def
     typedef FunctionSetType::iterator iterator;

--- a/include/Util/TypeBasedHeapCloning.h
+++ b/include/Util/TypeBasedHeapCloning.h
@@ -149,21 +149,21 @@ private:
     PAG *ppag = nullptr;
 
     /// Object -> its type.
-    DenseMap<NodeID, const DIType *> objToType;
+    SVFMap<NodeID, const DIType *> objToType;
     /// Object -> allocation site.
     /// The value NodeID depends on the pointer analysis (could be
     /// an SVFG node or PAG node for example).
-    DenseMap<NodeID, NodeID> objToAllocation;
+    SVFMap<NodeID, NodeID> objToAllocation;
     /// (Original) object -> set of its clones.
-    DenseMap<NodeID, NodeBS> objToClones;
+    SVFMap<NodeID, NodeBS> objToClones;
     /// (Clone) object -> original object (opposite of objToclones).
-    DenseMap<NodeID, NodeID> cloneToOriginalObj;
+    SVFMap<NodeID, NodeID> cloneToOriginalObj;
     /// Maps nodes (a location like a PAG node or SVFG node) to their filter set.
-    DenseMap<NodeID, PointsTo> locToFilterSet;
+    SVFMap<NodeID, PointsTo> locToFilterSet;
     /// Maps objects to the GEP nodes beneath them.
-    DenseMap<NodeID, NodeBS> objToGeps;
+    SVFMap<NodeID, NodeBS> objToGeps;
     /// Maps memory objects to their GEP objects. (memobj -> (fieldidx -> geps))
-    DenseMap<const MemObj *, DenseMap<unsigned, NodeBS>> memObjToGeps;
+    SVFMap<const MemObj *, SVFMap<unsigned, NodeBS>> memObjToGeps;
 
     /// Test whether object is a GEP object. For convenience.
     bool isGep(const PAGNode *n) const;

--- a/include/Util/TypeBasedHeapCloning.h
+++ b/include/Util/TypeBasedHeapCloning.h
@@ -149,21 +149,21 @@ private:
     PAG *ppag = nullptr;
 
     /// Object -> its type.
-    SVFMap<NodeID, const DIType *> objToType;
+    Map<NodeID, const DIType *> objToType;
     /// Object -> allocation site.
     /// The value NodeID depends on the pointer analysis (could be
     /// an SVFG node or PAG node for example).
-    SVFMap<NodeID, NodeID> objToAllocation;
+    Map<NodeID, NodeID> objToAllocation;
     /// (Original) object -> set of its clones.
-    SVFMap<NodeID, NodeBS> objToClones;
+    Map<NodeID, NodeBS> objToClones;
     /// (Clone) object -> original object (opposite of objToclones).
-    SVFMap<NodeID, NodeID> cloneToOriginalObj;
+    Map<NodeID, NodeID> cloneToOriginalObj;
     /// Maps nodes (a location like a PAG node or SVFG node) to their filter set.
-    SVFMap<NodeID, PointsTo> locToFilterSet;
+    Map<NodeID, PointsTo> locToFilterSet;
     /// Maps objects to the GEP nodes beneath them.
-    SVFMap<NodeID, NodeBS> objToGeps;
+    Map<NodeID, NodeBS> objToGeps;
     /// Maps memory objects to their GEP objects. (memobj -> (fieldidx -> geps))
-    SVFMap<const MemObj *, SVFMap<unsigned, NodeBS>> memObjToGeps;
+    Map<const MemObj *, Map<unsigned, NodeBS>> memObjToGeps;
 
     /// Test whether object is a GEP object. For convenience.
     bool isGep(const PAGNode *n) const;

--- a/include/Util/WorkList.h
+++ b/include/Util/WorkList.h
@@ -36,6 +36,8 @@
 #ifndef WORKLIST_H_
 #define WORKLIST_H_
 
+#include "Util/BasicTypes.h"
+
 #include <assert.h>
 #include <cstdlib>
 #include <vector>

--- a/include/Util/WorkList.h
+++ b/include/Util/WorkList.h
@@ -48,7 +48,7 @@ namespace SVF
 /**
  * Worklist with "first come first go" order.
  * New nodes pushed at back and popped from front.
- * Elements in the list are unique as they're recorded by std::set.
+ * Elements in the list are unique as they're recorded by SVFSet.
  */
 template<class Data>
 class List
@@ -68,7 +68,7 @@ class List
         ListNode* next;
     };
 
-    typedef std::set<Data> DataSet;
+    typedef SVFSet<Data> DataSet;
     typedef ListNode Node;
 
 public:
@@ -129,12 +129,12 @@ private:
 /**
  * Worklist with "first in first out" order.
  * New nodes will be pushed at back and popped from front.
- * Elements in the list are unique as they're recorded by std::set.
+ * Elements in the list are unique as they're recorded by SVFSet.
  */
 template<class Data>
 class FIFOWorkList
 {
-    typedef std::set<Data> DataSet;
+    typedef SVFSet<Data> DataSet;
     typedef std::deque<Data> DataDeque;
 public:
     FIFOWorkList() {}
@@ -195,12 +195,12 @@ private:
 /**
  * Worlist with "first in last out" order.
  * New nodes will be pushed at back and popped from back.
- * Elements in the list are unique as they're recorded by std::set.
+ * Elements in the list are unique as they're recorded by SVFSet.
  */
 template<class Data>
 class FILOWorkList
 {
-    typedef std::set<Data> DataSet;
+    typedef SVFSet<Data> DataSet;
     typedef std::vector<Data> DataVector;
 public:
     FILOWorkList() {}

--- a/include/Util/WorkList.h
+++ b/include/Util/WorkList.h
@@ -50,7 +50,7 @@ namespace SVF
 /**
  * Worklist with "first come first go" order.
  * New nodes pushed at back and popped from front.
- * Elements in the list are unique as they're recorded by SVFSet.
+ * Elements in the list are unique as they're recorded by Set.
  */
 template<class Data>
 class List
@@ -70,7 +70,7 @@ class List
         ListNode* next;
     };
 
-    typedef SVFSet<Data> DataSet;
+    typedef Set<Data> DataSet;
     typedef ListNode Node;
 
 public:
@@ -131,12 +131,12 @@ private:
 /**
  * Worklist with "first in first out" order.
  * New nodes will be pushed at back and popped from front.
- * Elements in the list are unique as they're recorded by SVFSet.
+ * Elements in the list are unique as they're recorded by Set.
  */
 template<class Data>
 class FIFOWorkList
 {
-    typedef SVFSet<Data> DataSet;
+    typedef Set<Data> DataSet;
     typedef std::deque<Data> DataDeque;
 public:
     FIFOWorkList() {}
@@ -197,12 +197,12 @@ private:
 /**
  * Worlist with "first in last out" order.
  * New nodes will be pushed at back and popped from back.
- * Elements in the list are unique as they're recorded by SVFSet.
+ * Elements in the list are unique as they're recorded by Set.
  */
 template<class Data>
 class FILOWorkList
 {
-    typedef SVFSet<Data> DataSet;
+    typedef Set<Data> DataSet;
     typedef std::vector<Data> DataVector;
 public:
     FILOWorkList() {}

--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -53,7 +53,7 @@ class Andersen:  public WPAConstraintSolver, public BVDataPTAImpl
 
 public:
     typedef SCCDetection<ConstraintGraph*> CGSCC;
-    typedef Map<CallSite, NodeID> CallSite2DummyValPN;
+    typedef OrderedMap<CallSite, NodeID> CallSite2DummyValPN;
 
     /// Pass ID
     static char ID;

--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -53,7 +53,7 @@ class Andersen:  public WPAConstraintSolver, public BVDataPTAImpl
 
 public:
     typedef SCCDetection<ConstraintGraph*> CGSCC;
-    typedef SVFMap<CallSite, NodeID> CallSite2DummyValPN;
+    typedef Map<CallSite, NodeID> CallSite2DummyValPN;
 
     /// Pass ID
     static char ID;
@@ -425,7 +425,7 @@ class AndersenWaveDiffWithType : public AndersenWaveDiff
 
 private:
 
-    typedef SVFMap<NodeID, SVFSet<const GepCGEdge*>> TypeMismatchedObjToEdgeTy;
+    typedef Map<NodeID, Set<const GepCGEdge*>> TypeMismatchedObjToEdgeTy;
 
     TypeMismatchedObjToEdgeTy typeMismatchedObjToEdges;
 
@@ -434,12 +434,12 @@ private:
         TypeMismatchedObjToEdgeTy::iterator it = typeMismatchedObjToEdges.find(obj);
         if (it != typeMismatchedObjToEdges.end())
         {
-            SVFSet<const GepCGEdge*> &edges = it->second;
+            Set<const GepCGEdge*> &edges = it->second;
             edges.insert(gepEdge);
         }
         else
         {
-            SVFSet<const GepCGEdge*> edges;
+            Set<const GepCGEdge*> edges;
             edges.insert(gepEdge);
             typeMismatchedObjToEdges[obj] = edges;
         }

--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -53,7 +53,7 @@ class Andersen:  public WPAConstraintSolver, public BVDataPTAImpl
 
 public:
     typedef SCCDetection<ConstraintGraph*> CGSCC;
-    typedef DenseMap<CallSite, NodeID> CallSite2DummyValPN;
+    typedef SVFMap<CallSite, NodeID> CallSite2DummyValPN;
 
     /// Pass ID
     static char ID;
@@ -425,7 +425,7 @@ class AndersenWaveDiffWithType : public AndersenWaveDiff
 
 private:
 
-    typedef DenseMap<NodeID, DenseSet<const GepCGEdge*>> TypeMismatchedObjToEdgeTy;
+    typedef SVFMap<NodeID, SVFSet<const GepCGEdge*>> TypeMismatchedObjToEdgeTy;
 
     TypeMismatchedObjToEdgeTy typeMismatchedObjToEdges;
 
@@ -434,12 +434,12 @@ private:
         TypeMismatchedObjToEdgeTy::iterator it = typeMismatchedObjToEdges.find(obj);
         if (it != typeMismatchedObjToEdges.end())
         {
-            DenseSet<const GepCGEdge*> &edges = it->second;
+            SVFSet<const GepCGEdge*> &edges = it->second;
             edges.insert(gepEdge);
         }
         else
         {
-            DenseSet<const GepCGEdge*> edges;
+            SVFSet<const GepCGEdge*> edges;
             edges.insert(gepEdge);
             typeMismatchedObjToEdges[obj] = edges;
         }
@@ -561,7 +561,7 @@ protected:
     //@{
     bool isMetEdge (ConstraintEdge* edge) const
     {
-        EdgeSet::iterator it = metEdges.find(edge->getEdgeID());
+        EdgeSet::const_iterator it = metEdges.find(edge->getEdgeID());
         return it != metEdges.end();
     };
     void addMetEdge(ConstraintEdge* edge)

--- a/include/WPA/AndersenSFR.h
+++ b/include/WPA/AndersenSFR.h
@@ -43,7 +43,7 @@ namespace SVF
 class AndersenSCD : public Andersen
 {
 public:
-    typedef SVFMap<NodeID, NodeID> NodeToNodeMap;
+    typedef Map<NodeID, NodeID> NodeToNodeMap;
 
 protected:
     static AndersenSCD* scdAndersen;
@@ -101,9 +101,9 @@ protected:
 class AndersenSFR : public AndersenSCD
 {
 public:
-    typedef SVFMap<NodeID, NodeBS> NodeStrides;
-    typedef SVFMap<NodeID, NodeSet> FieldReps;
-    typedef SVFMap<NodeID, pair<NodeID, NodeSet>> SFRTrait;
+    typedef Map<NodeID, NodeBS> NodeStrides;
+    typedef Map<NodeID, NodeSet> FieldReps;
+    typedef Map<NodeID, pair<NodeID, NodeSet>> SFRTrait;
 
 private:
     static AndersenSFR* sfrAndersen;

--- a/include/WPA/AndersenSFR.h
+++ b/include/WPA/AndersenSFR.h
@@ -43,7 +43,7 @@ namespace SVF
 class AndersenSCD : public Andersen
 {
 public:
-    typedef DenseMap<NodeID, NodeID> NodeToNodeMap;
+    typedef SVFMap<NodeID, NodeID> NodeToNodeMap;
 
 protected:
     static AndersenSCD* scdAndersen;
@@ -101,9 +101,9 @@ protected:
 class AndersenSFR : public AndersenSCD
 {
 public:
-    typedef DenseMap<NodeID, NodeBS> NodeStrides;
-    typedef DenseMap<NodeID, NodeSet> FieldReps;
-    typedef DenseMap<NodeID, pair<NodeID, NodeSet>> SFRTrait;
+    typedef SVFMap<NodeID, NodeBS> NodeStrides;
+    typedef SVFMap<NodeID, NodeSet> FieldReps;
+    typedef SVFMap<NodeID, pair<NodeID, NodeSet>> SFRTrait;
 
 private:
     static AndersenSFR* sfrAndersen;

--- a/include/WPA/CSC.h
+++ b/include/WPA/CSC.h
@@ -49,7 +49,7 @@ typedef SCCDetection<ConstraintGraph *> CGSCC;
 class CSC
 {
 public:
-    typedef SVFMap<NodeID, NodeID> IdToIdMap;
+    typedef Map<NodeID, NodeID> IdToIdMap;
     typedef FILOWorkList<NodeID> WorkStack;
     typedef typename IdToIdMap::iterator iterator;
 

--- a/include/WPA/CSC.h
+++ b/include/WPA/CSC.h
@@ -49,7 +49,7 @@ typedef SCCDetection<ConstraintGraph *> CGSCC;
 class CSC
 {
 public:
-    typedef DenseMap<NodeID, NodeID> IdToIdMap;
+    typedef SVFMap<NodeID, NodeID> IdToIdMap;
     typedef FILOWorkList<NodeID> WorkStack;
     typedef typename IdToIdMap::iterator iterator;
 

--- a/include/WPA/FlowSensitive.h
+++ b/include/WPA/FlowSensitive.h
@@ -243,7 +243,7 @@ protected:
     virtual void printCTirAliasStats(void);
 
     /// Fills may/noAliases for the location/pointer pairs in cmp.
-    virtual void countAliases(SVFSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases);
+    virtual void countAliases(Set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases);
 
     SVFG* svfg;
     ///Get points-to set for a node from data flow IN/OUT set at a statement.

--- a/include/WPA/FlowSensitive.h
+++ b/include/WPA/FlowSensitive.h
@@ -243,7 +243,7 @@ protected:
     virtual void printCTirAliasStats(void);
 
     /// Fills may/noAliases for the location/pointer pairs in cmp.
-    virtual void countAliases(DenseSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases);
+    virtual void countAliases(SVFSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases);
 
     SVFG* svfg;
     ///Get points-to set for a node from data flow IN/OUT set at a statement.

--- a/include/WPA/FlowSensitiveTBHC.h
+++ b/include/WPA/FlowSensitiveTBHC.h
@@ -93,7 +93,7 @@ public:
 protected:
     virtual void backPropagate(NodeID clone) override;
 
-    virtual void countAliases(SVFSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases) override;
+    virtual void countAliases(Set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases) override;
 
 private:
     /// Determines whether each GEP is for a load or not. Builds gepIsLoad map.
@@ -111,7 +111,7 @@ private:
     bool allReuse;
 
     /// Maps GEP objects to the SVFG nodes that retrieved them with getGepObjClones.
-    SVFMap<NodeID, NodeBS> gepToSVFGRetrievers;
+    Map<NodeID, NodeBS> gepToSVFGRetrievers;
     /// Maps whether a (SVFG) GEP node is a load or not.
     NodeBS loadGeps;
 };

--- a/include/WPA/FlowSensitiveTBHC.h
+++ b/include/WPA/FlowSensitiveTBHC.h
@@ -93,7 +93,7 @@ public:
 protected:
     virtual void backPropagate(NodeID clone) override;
 
-    virtual void countAliases(DenseSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases) override;
+    virtual void countAliases(SVFSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases) override;
 
 private:
     /// Determines whether each GEP is for a load or not. Builds gepIsLoad map.
@@ -111,7 +111,7 @@ private:
     bool allReuse;
 
     /// Maps GEP objects to the SVFG nodes that retrieved them with getGepObjClones.
-    DenseMap<NodeID, NodeBS> gepToSVFGRetrievers;
+    SVFMap<NodeID, NodeBS> gepToSVFGRetrievers;
     /// Maps whether a (SVFG) GEP node is a load or not.
     NodeBS loadGeps;
 };

--- a/include/WPA/TypeAnalysis.h
+++ b/include/WPA/TypeAnalysis.h
@@ -78,7 +78,7 @@ public:
     //@}
 
 private:
-    std::set<CallSite> virtualCallSites;
+    SVFSet<CallSite> virtualCallSites;
 };
 
 } // End namespace SVF

--- a/include/WPA/TypeAnalysis.h
+++ b/include/WPA/TypeAnalysis.h
@@ -78,7 +78,7 @@ public:
     //@}
 
 private:
-    SVFSet<CallSite> virtualCallSites;
+    Set<CallSite> virtualCallSites;
 };
 
 } // End namespace SVF

--- a/lib/DDA/DDAClient.cpp
+++ b/lib/DDA/DDAClient.cpp
@@ -141,8 +141,8 @@ void FunptrDDAClient::performStat(PointerAnalysis* pta)
         if(ddaPts.count() >= anderPts.count() || ddaPts.empty())
             continue;
 
-        DenseSet<const SVFFunction*> ander_vfns;
-        DenseSet<const SVFFunction*> dda_vfns;
+        SVFSet<const SVFFunction*> ander_vfns;
+        SVFSet<const SVFFunction*> dda_vfns;
         ander->getVFnsFromPts(cbn,anderPts, ander_vfns);
         pta->getVFnsFromPts(cbn,ddaPts, dda_vfns);
 

--- a/lib/DDA/DDAClient.cpp
+++ b/lib/DDA/DDAClient.cpp
@@ -141,8 +141,8 @@ void FunptrDDAClient::performStat(PointerAnalysis* pta)
         if(ddaPts.count() >= anderPts.count() || ddaPts.empty())
             continue;
 
-        SVFSet<const SVFFunction*> ander_vfns;
-        SVFSet<const SVFFunction*> dda_vfns;
+        Set<const SVFFunction*> ander_vfns;
+        Set<const SVFFunction*> dda_vfns;
         ander->getVFnsFromPts(cbn,anderPts, ander_vfns);
         pta->getVFnsFromPts(cbn,ddaPts, dda_vfns);
 

--- a/lib/DDA/DDAClient.cpp
+++ b/lib/DDA/DDAClient.cpp
@@ -58,7 +58,7 @@ void DDAClient::answerQueries(PointerAnalysis* pta)
     collectCandidateQueries(pta->getPAG());
 
     u32_t count = 0;
-    for (NodeSet::iterator nIter = candidateQueries.begin();
+    for (OrderedNodeSet::iterator nIter = candidateQueries.begin();
             nIter != candidateQueries.end(); ++nIter,++count)
     {
         PAGNode* node = pta->getPAG()->getPAGNode(*nIter);
@@ -78,7 +78,7 @@ void DDAClient::answerQueries(PointerAnalysis* pta)
     stat->setMemUsageAfter(vmrss, vmsize);
 }
 
-NodeSet& FunptrDDAClient::collectCandidateQueries(PAG* p)
+OrderedNodeSet& FunptrDDAClient::collectCandidateQueries(PAG* p)
 {
     setPAG(p);
     for(PAG::CallSiteToFunPtrMap::const_iterator it = pag->getIndirectCallsites().begin(),
@@ -176,7 +176,7 @@ void FunptrDDAClient::performStat(PointerAnalysis* pta)
 
 
 /// Only collect function pointers as query candidates.
-NodeSet& AliasDDAClient::collectCandidateQueries(PAG* pag)
+OrderedNodeSet& AliasDDAClient::collectCandidateQueries(PAG* pag)
 {
     setPAG(pag);
     PAGEdge::PAGEdgeSetTy& loads = pag->getEdgeSet(PAGEdge::Load);

--- a/lib/DDA/DDAPass.cpp
+++ b/lib/DDA/DDAPass.cpp
@@ -241,7 +241,7 @@ void DDAPass::collectCxtInsenEdgeForRecur(PointerAnalysis* pta, const SVFG* svfg
 void DDAPass::collectCxtInsenEdgeForVFCycle(PointerAnalysis* pta, const SVFG* svfg,const SVFGSCC* svfgSCC, SVFGEdgeSet& insensitveEdges)
 {
 
-    std::set<NodePair> insensitvefunPairs;
+    SVFSet<NodePair> insensitvefunPairs;
 
     for (SVFG::SVFGNodeIDToNodeMapTy::const_iterator it = svfg->begin(),eit = svfg->end(); it != eit; ++it)
     {

--- a/lib/DDA/DDAPass.cpp
+++ b/lib/DDA/DDAPass.cpp
@@ -241,7 +241,7 @@ void DDAPass::collectCxtInsenEdgeForRecur(PointerAnalysis* pta, const SVFG* svfg
 void DDAPass::collectCxtInsenEdgeForVFCycle(PointerAnalysis* pta, const SVFG* svfg,const SVFGSCC* svfgSCC, SVFGEdgeSet& insensitveEdges)
 {
 
-    SVFSet<NodePair> insensitvefunPairs;
+    Set<NodePair> insensitvefunPairs;
 
     for (SVFG::SVFGNodeIDToNodeMapTy::const_iterator it = svfg->begin(),eit = svfg->end(); it != eit; ++it)
     {

--- a/lib/DDA/DDAPass.cpp
+++ b/lib/DDA/DDAPass.cpp
@@ -347,7 +347,7 @@ AliasResult DDAPass::alias(const Value* V1, const Value* V2)
 void DDAPass::printQueryPTS()
 {
     const NodeSet& candidates = _client->getCandidateQueries();
-    for (NodeSet::iterator it = candidates.begin(), eit = candidates.end(); it != eit; ++it)
+    for (NodeSet::const_iterator it = candidates.begin(), eit = candidates.end(); it != eit; ++it)
     {
         const PointsTo& pts = _pta->getPts(*it);
         _pta->dumpPts(*it,pts);

--- a/lib/DDA/DDAPass.cpp
+++ b/lib/DDA/DDAPass.cpp
@@ -241,7 +241,7 @@ void DDAPass::collectCxtInsenEdgeForRecur(PointerAnalysis* pta, const SVFG* svfg
 void DDAPass::collectCxtInsenEdgeForVFCycle(PointerAnalysis* pta, const SVFG* svfg,const SVFGSCC* svfgSCC, SVFGEdgeSet& insensitveEdges)
 {
 
-    Set<NodePair> insensitvefunPairs;
+    OrderedSet<NodePair> insensitvefunPairs;
 
     for (SVFG::SVFGNodeIDToNodeMapTy::const_iterator it = svfg->begin(),eit = svfg->end(); it != eit; ++it)
     {
@@ -346,8 +346,8 @@ AliasResult DDAPass::alias(const Value* V1, const Value* V2)
  */
 void DDAPass::printQueryPTS()
 {
-    const NodeSet& candidates = _client->getCandidateQueries();
-    for (NodeSet::const_iterator it = candidates.begin(), eit = candidates.end(); it != eit; ++it)
+    const OrderedNodeSet& candidates = _client->getCandidateQueries();
+    for (OrderedNodeSet::const_iterator it = candidates.begin(), eit = candidates.end(); it != eit; ++it)
     {
         const PointsTo& pts = _pta->getPts(*it);
         _pta->dumpPts(*it,pts);

--- a/lib/Graphs/ExternalPAG.cpp
+++ b/lib/Graphs/ExternalPAG.cpp
@@ -28,9 +28,9 @@ llvm::cl::list<std::string> DumpPAGFunctions("dump-function-pags",
         llvm::cl::CommaSeparated);
 
 
-DenseMap<const SVFFunction*, DenseMap<int, PAGNode *>>
+SVFMap<const SVFFunction*, SVFMap<int, PAGNode *>>
         ExternalPAG::functionToExternalPAGEntries;
-DenseMap<const SVFFunction*, PAGNode *> ExternalPAG::functionToExternalPAGReturns;
+SVFMap<const SVFFunction*, PAGNode *> ExternalPAG::functionToExternalPAGReturns;
 
 std::vector<std::pair<std::string, std::string>>
         ExternalPAG::parseExternalPAGs(llvm::cl::list<std::string> &extpagsArgs)
@@ -78,7 +78,7 @@ bool ExternalPAG::connectCallsiteToExternalPAG(CallSite *cs)
     const SVFFunction* svfFun = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(function);
     if (!hasExternalPAG(svfFun)) return false;
 
-    DenseMap<int, PAGNode*> argNodes =
+    SVFMap<int, PAGNode*> argNodes =
         functionToExternalPAGEntries[svfFun];
     PAGNode *retNode = functionToExternalPAGReturns[svfFun];
 
@@ -257,9 +257,9 @@ void ExternalPAG::dumpFunctions(std::vector<std::string> functions)
     PAG *pag = PAG::getPAG();
 
     // Naive: first map functions to entries in PAG, then dump them.
-    DenseMap<const SVFFunction*, std::vector<PAGNode *>> functionToPAGNodes;
+    SVFMap<const SVFFunction*, std::vector<PAGNode *>> functionToPAGNodes;
 
-    DenseSet<PAGNode *> callDsts;
+    SVFSet<PAGNode *> callDsts;
     for (PAG::iterator it = pag->begin(); it != pag->end(); ++it)
     {
         PAGNode *currNode = it->second;
@@ -303,8 +303,8 @@ void ExternalPAG::dumpFunctions(std::vector<std::string> functions)
         std::string functionName = it->first->getName();
 
         // The final nodes and edges we will print.
-        DenseSet<PAGNode *> nodes;
-        DenseSet<PAGEdge *> edges;
+        SVFSet<PAGNode *> nodes;
+        SVFSet<PAGEdge *> edges;
         // The search stack.
         std::stack<PAGNode *> todoNodes;
         // The arguments to the function.
@@ -394,7 +394,7 @@ bool ExternalPAG::addExternalPAG(const SVFFunction* function)
     //        : to map function names to the return node.
 
     // To create the new edges.
-    DenseMap<NodeID, PAGNode *> extToNewNodes;
+    SVFMap<NodeID, PAGNode *> extToNewNodes;
 
     // Add the value nodes.
     for (auto extNodeIt = this->getValueNodes().begin();
@@ -478,7 +478,7 @@ bool ExternalPAG::addExternalPAG(const SVFFunction* function)
     }
 
     // Record the arg nodes.
-    DenseMap<int, PAGNode *> argNodes;
+    SVFMap<int, PAGNode *> argNodes;
     for (auto argNodeIt = this->getArgNodes().begin();
             argNodeIt != this->getArgNodes().end(); ++argNodeIt)
     {

--- a/lib/Graphs/ExternalPAG.cpp
+++ b/lib/Graphs/ExternalPAG.cpp
@@ -28,9 +28,9 @@ llvm::cl::list<std::string> DumpPAGFunctions("dump-function-pags",
         llvm::cl::CommaSeparated);
 
 
-SVFMap<const SVFFunction*, SVFMap<int, PAGNode *>>
+Map<const SVFFunction*, Map<int, PAGNode *>>
         ExternalPAG::functionToExternalPAGEntries;
-SVFMap<const SVFFunction*, PAGNode *> ExternalPAG::functionToExternalPAGReturns;
+Map<const SVFFunction*, PAGNode *> ExternalPAG::functionToExternalPAGReturns;
 
 std::vector<std::pair<std::string, std::string>>
         ExternalPAG::parseExternalPAGs(llvm::cl::list<std::string> &extpagsArgs)
@@ -78,7 +78,7 @@ bool ExternalPAG::connectCallsiteToExternalPAG(CallSite *cs)
     const SVFFunction* svfFun = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(function);
     if (!hasExternalPAG(svfFun)) return false;
 
-    SVFMap<int, PAGNode*> argNodes =
+    Map<int, PAGNode*> argNodes =
         functionToExternalPAGEntries[svfFun];
     PAGNode *retNode = functionToExternalPAGReturns[svfFun];
 
@@ -257,9 +257,9 @@ void ExternalPAG::dumpFunctions(std::vector<std::string> functions)
     PAG *pag = PAG::getPAG();
 
     // Naive: first map functions to entries in PAG, then dump them.
-    SVFMap<const SVFFunction*, std::vector<PAGNode *>> functionToPAGNodes;
+    Map<const SVFFunction*, std::vector<PAGNode *>> functionToPAGNodes;
 
-    SVFSet<PAGNode *> callDsts;
+    Set<PAGNode *> callDsts;
     for (PAG::iterator it = pag->begin(); it != pag->end(); ++it)
     {
         PAGNode *currNode = it->second;
@@ -303,8 +303,8 @@ void ExternalPAG::dumpFunctions(std::vector<std::string> functions)
         std::string functionName = it->first->getName();
 
         // The final nodes and edges we will print.
-        SVFSet<PAGNode *> nodes;
-        SVFSet<PAGEdge *> edges;
+        Set<PAGNode *> nodes;
+        Set<PAGEdge *> edges;
         // The search stack.
         std::stack<PAGNode *> todoNodes;
         // The arguments to the function.
@@ -394,7 +394,7 @@ bool ExternalPAG::addExternalPAG(const SVFFunction* function)
     //        : to map function names to the return node.
 
     // To create the new edges.
-    SVFMap<NodeID, PAGNode *> extToNewNodes;
+    Map<NodeID, PAGNode *> extToNewNodes;
 
     // Add the value nodes.
     for (auto extNodeIt = this->getValueNodes().begin();
@@ -478,7 +478,7 @@ bool ExternalPAG::addExternalPAG(const SVFFunction* function)
     }
 
     // Record the arg nodes.
-    SVFMap<int, PAGNode *> argNodes;
+    Map<int, PAGNode *> argNodes;
     for (auto argNodeIt = this->getArgNodes().begin();
             argNodeIt != this->getArgNodes().end(); ++argNodeIt)
     {

--- a/lib/Graphs/PTACallGraph.cpp
+++ b/lib/Graphs/PTACallGraph.cpp
@@ -210,12 +210,12 @@ void PTACallGraph::getAllCallSitesInvokingCallee(const SVFFunction* callee, PTAC
     for(PTACallGraphNode::iterator it = callGraphNode->InEdgeBegin(), eit = callGraphNode->InEdgeEnd();
             it!=eit; ++it)
     {
-        for(PTACallGraphEdge::CallInstSet::iterator cit = (*it)->directCallsBegin(),
+        for(PTACallGraphEdge::CallInstSet::const_iterator cit = (*it)->directCallsBegin(),
                 ecit = (*it)->directCallsEnd(); cit!=ecit; ++cit)
         {
             csSet.insert((*cit));
         }
-        for(PTACallGraphEdge::CallInstSet::iterator cit = (*it)->indirectCallsBegin(),
+        for(PTACallGraphEdge::CallInstSet::const_iterator cit = (*it)->indirectCallsBegin(),
                 ecit = (*it)->indirectCallsEnd(); cit!=ecit; ++cit)
         {
             csSet.insert((*cit));
@@ -232,7 +232,7 @@ void PTACallGraph::getDirCallSitesInvokingCallee(const SVFFunction* callee, PTAC
     for(PTACallGraphNode::iterator it = callGraphNode->InEdgeBegin(), eit = callGraphNode->InEdgeEnd();
             it!=eit; ++it)
     {
-        for(PTACallGraphEdge::CallInstSet::iterator cit = (*it)->directCallsBegin(),
+        for(PTACallGraphEdge::CallInstSet::const_iterator cit = (*it)->directCallsBegin(),
                 ecit = (*it)->directCallsEnd(); cit!=ecit; ++cit)
         {
             csSet.insert((*cit));
@@ -249,7 +249,7 @@ void PTACallGraph::getIndCallSitesInvokingCallee(const SVFFunction* callee, PTAC
     for(PTACallGraphNode::iterator it = callGraphNode->InEdgeBegin(), eit = callGraphNode->InEdgeEnd();
             it!=eit; ++it)
     {
-        for(PTACallGraphEdge::CallInstSet::iterator cit = (*it)->indirectCallsBegin(),
+        for(PTACallGraphEdge::CallInstSet::const_iterator cit = (*it)->indirectCallsBegin(),
                 ecit = (*it)->indirectCallsEnd(); cit!=ecit; ++cit)
         {
             csSet.insert((*cit));

--- a/lib/Graphs/SVFGStat.cpp
+++ b/lib/Graphs/SVFGStat.cpp
@@ -392,7 +392,7 @@ void SVFGStat::performSCCStat(SVFGEdgeSet insensitiveCalRetEdges)
     SVFGSCC* svfgSCC = new SVFGSCC(graph);
     svfgSCC->find();
 
-    DenseNodeSet sccRepNodeSet;
+    NodeSet sccRepNodeSet;
     SVFG::SVFGNodeIDToNodeMapTy::iterator it = graph->begin();
     SVFG::SVFGNodeIDToNodeMapTy::iterator eit = graph->end();
     for (; it != eit; ++it)

--- a/lib/Graphs/ThreadCallGraph.cpp
+++ b/lib/Graphs/ThreadCallGraph.cpp
@@ -68,7 +68,7 @@ void ThreadCallGraph::updateCallGraph(PointerAnalysis* pta)
     }
 
     // Fork sites
-    for (CallSiteSet::iterator it = forksitesBegin(), eit = forksitesEnd(); it != eit; ++it)
+    for (CallSiteSet::const_iterator it = forksitesBegin(), eit = forksitesEnd(); it != eit; ++it)
     {
         const Value* forkedval = tdAPI->getForkedFun((*it)->getCallSite());
         if(SVFUtil::dyn_cast<Function>(forkedval)==NULL)
@@ -92,7 +92,7 @@ void ThreadCallGraph::updateCallGraph(PointerAnalysis* pta)
     }
 
     // parallel_for sites
-    for (CallSiteSet::iterator it = parForSitesBegin(), eit = parForSitesEnd(); it != eit; ++it)
+    for (CallSiteSet::const_iterator it = parForSitesBegin(), eit = parForSitesEnd(); it != eit; ++it)
     {
         const Value* forkedval = tdAPI->getTaskFuncAtHareParForSite((*it)->getCallSite());
         if(SVFUtil::dyn_cast<Function>(forkedval)==NULL)
@@ -123,12 +123,12 @@ void ThreadCallGraph::updateCallGraph(PointerAnalysis* pta)
 void ThreadCallGraph::updateJoinEdge(PointerAnalysis* pta)
 {
 
-    for (CallSiteSet::iterator it = joinsitesBegin(), eit = joinsitesEnd(); it != eit; ++it)
+    for (CallSiteSet::const_iterator it = joinsitesBegin(), eit = joinsitesEnd(); it != eit; ++it)
     {
         const Value* jointhread = tdAPI->getJoinedThread((*it)->getCallSite());
         // find its corresponding fork sites first
         CallSiteSet forkset;
-        for (CallSiteSet::iterator it = forksitesBegin(), eit = forksitesEnd(); it != eit; ++it)
+        for (CallSiteSet::const_iterator it = forksitesBegin(), eit = forksitesEnd(); it != eit; ++it)
         {
             const Value* forkthread = tdAPI->getForkedThread((*it)->getCallSite());
             if (pta->alias(jointhread, forkthread))

--- a/lib/MSSA/MemRegion.cpp
+++ b/lib/MSSA/MemRegion.cpp
@@ -106,8 +106,8 @@ void MRGenerator::collectGlobals()
         {
             if (obj->getMemObj()->isGlobalObj())
             {
-                allGlobals.set(nIter->getFirst());
-                allGlobals |= CollectPtsChain(nIter->getFirst());
+                allGlobals.set(nIter->first);
+                allGlobals |= CollectPtsChain(nIter->first);
             }
         }
     }

--- a/lib/MTA/FSMPTA.cpp
+++ b/lib/MTA/FSMPTA.cpp
@@ -140,7 +140,7 @@ void MTASVFGBuilder::performRemovingMHPEdges()
         assert (n1->hasOutgoingEdge() && "n1 doesn't have out edge");
         assert (n2->hasIncomingEdge() && "n2 doesn't have in edge");
 
-        std::set<SVFGEdge*> removededges;
+        SVFSet<SVFGEdge*> removededges;
         for (SVFGEdge::SVFGEdgeSetTy::iterator iter = n1->OutEdgeBegin(); iter != n1->OutEdgeEnd(); ++iter)
         {
             SVFGEdge* edge = *iter;

--- a/lib/MTA/FSMPTA.cpp
+++ b/lib/MTA/FSMPTA.cpp
@@ -140,7 +140,7 @@ void MTASVFGBuilder::performRemovingMHPEdges()
         assert (n1->hasOutgoingEdge() && "n1 doesn't have out edge");
         assert (n2->hasIncomingEdge() && "n2 doesn't have in edge");
 
-        SVFSet<SVFGEdge*> removededges;
+        Set<SVFGEdge*> removededges;
         for (SVFGEdge::SVFGEdgeSetTy::iterator iter = n1->OutEdgeBegin(); iter != n1->OutEdgeEnd(); ++iter)
         {
             SVFGEdge* edge = *iter;

--- a/lib/MTA/MHP.cpp
+++ b/lib/MTA/MHP.cpp
@@ -706,8 +706,8 @@ void MHP::printInterleaving()
  */
 void ForkJoinAnalysis::collectSCEVInfo()
 {
-    typedef SVFSet<const Instruction*> CallInstSet;
-    typedef SVFMap<const Function*, CallInstSet > FunToFJSites;
+    typedef Set<const Instruction*> CallInstSet;
+    typedef Map<const Function*, CallInstSet > FunToFJSites;
     FunToFJSites funToFJSites;
 
     for(ThreadCallGraph::CallSiteSet::iterator it = tct->getThreadCallGraph()->forksitesBegin(),

--- a/lib/MTA/MHP.cpp
+++ b/lib/MTA/MHP.cpp
@@ -706,8 +706,8 @@ void MHP::printInterleaving()
  */
 void ForkJoinAnalysis::collectSCEVInfo()
 {
-    typedef std::set<const Instruction*> CallInstSet;
-    typedef std::map<const Function*, CallInstSet > FunToFJSites;
+    typedef SVFSet<const Instruction*> CallInstSet;
+    typedef SVFMap<const Function*, CallInstSet > FunToFJSites;
     FunToFJSites funToFJSites;
 
     for(ThreadCallGraph::CallSiteSet::iterator it = tct->getThreadCallGraph()->forksitesBegin(),

--- a/lib/MTA/MTA.cpp
+++ b/lib/MTA/MTA.cpp
@@ -170,7 +170,7 @@ void MTA::detect(SVFModule* module)
     LoadSet loads;
     StoreSet stores;
 
-    SVFSet<const Instruction*> needcheckinst;
+    Set<const Instruction*> needcheckinst;
     // Add symbols for all of the functions and the instructions in them.
     for (SVFModule::iterator F = module->begin(), E = module->end(); F != E; ++F)
     {

--- a/lib/MTA/MTA.cpp
+++ b/lib/MTA/MTA.cpp
@@ -170,7 +170,7 @@ void MTA::detect(SVFModule* module)
     LoadSet loads;
     StoreSet stores;
 
-    std::set<const Instruction*> needcheckinst;
+    SVFSet<const Instruction*> needcheckinst;
     // Add symbols for all of the functions and the instructions in them.
     for (SVFModule::iterator F = module->begin(), E = module->end(); F != E; ++F)
     {

--- a/lib/MTA/MTAResultValidator.cpp
+++ b/lib/MTA/MTAResultValidator.cpp
@@ -314,13 +314,13 @@ bool MTAResultValidator::validateCxtThread()
         }
     }
 
-    std::set<int> visitedvthd;
+    SVFSet<int> visitedvthd;
 
     for (NodeID i = 0; i < tct->getTCTNodeNum(); i++)
     {
         const CxtThread rthd = tct->getTCTNode(i)->getCxtThread();
         bool matched = false;
-        for (std::map<NodeID, CallStrCxt>::iterator j = vthdToCxt.begin(), ej = vthdToCxt.end(); j != ej; j++)
+        for (SVFMap<NodeID, CallStrCxt>::iterator j = vthdToCxt.begin(), ej = vthdToCxt.end(); j != ej; j++)
         {
             NodeID vthdid = (*j).first;
             if (matchCxt(rthd.getContext(), vthdToCxt[vthdid]))
@@ -358,7 +358,7 @@ bool MTAResultValidator::validateCxtThread()
         if (PrintValidRes)
         {
             outs() << "\nValidate CxtThread: Some given CxtThreads cannot be found !!!\n";
-            for (std::map<NodeID, CallStrCxt>::iterator j = vthdToCxt.begin(), ej = vthdToCxt.end(); j != ej; j++)
+            for (SVFMap<NodeID, CallStrCxt>::iterator j = vthdToCxt.begin(), ej = vthdToCxt.end(); j != ej; j++)
             {
                 NodeID vthdid = (*j).first;
                 if (visitedvthd.find(vthdid) == visitedvthd.end())
@@ -391,7 +391,7 @@ bool MTAResultValidator::validateTCT()
             }
         }
 
-        for (std::set<NodeID>::iterator j = rthdToChildren[i].begin(), ej = rthdToChildren[i].end(); j != ej; j++)
+        for (SVFSet<NodeID>::iterator j = rthdToChildren[i].begin(), ej = rthdToChildren[i].end(); j != ej; j++)
         {
             NodeID gid = *j;
             if (!tct->hasGraphEdge(pnode, tct->getTCTNode(gid), TCTEdge::ThreadCreateEdge))
@@ -404,7 +404,7 @@ bool MTAResultValidator::validateTCT()
         {
             outs() << "Validate TCT: Wrong at TID " << rthdTovthd[i] << "\n";
             outs() << "Given children: \t";
-            for (std::set<NodeID>::iterator j = rthdToChildren[i].begin(), ej = rthdToChildren[i].end(); j != ej; j++)
+            for (SVFSet<NodeID>::iterator j = rthdToChildren[i].begin(), ej = rthdToChildren[i].end(); j != ej; j++)
             {
                 NodeID gid = *j;
                 outs() << rthdTovthd[gid] << ", ";

--- a/lib/MTA/MTAResultValidator.cpp
+++ b/lib/MTA/MTAResultValidator.cpp
@@ -314,13 +314,13 @@ bool MTAResultValidator::validateCxtThread()
         }
     }
 
-    SVFSet<int> visitedvthd;
+    Set<int> visitedvthd;
 
     for (NodeID i = 0; i < tct->getTCTNodeNum(); i++)
     {
         const CxtThread rthd = tct->getTCTNode(i)->getCxtThread();
         bool matched = false;
-        for (SVFMap<NodeID, CallStrCxt>::iterator j = vthdToCxt.begin(), ej = vthdToCxt.end(); j != ej; j++)
+        for (Map<NodeID, CallStrCxt>::iterator j = vthdToCxt.begin(), ej = vthdToCxt.end(); j != ej; j++)
         {
             NodeID vthdid = (*j).first;
             if (matchCxt(rthd.getContext(), vthdToCxt[vthdid]))
@@ -358,7 +358,7 @@ bool MTAResultValidator::validateCxtThread()
         if (PrintValidRes)
         {
             outs() << "\nValidate CxtThread: Some given CxtThreads cannot be found !!!\n";
-            for (SVFMap<NodeID, CallStrCxt>::iterator j = vthdToCxt.begin(), ej = vthdToCxt.end(); j != ej; j++)
+            for (Map<NodeID, CallStrCxt>::iterator j = vthdToCxt.begin(), ej = vthdToCxt.end(); j != ej; j++)
             {
                 NodeID vthdid = (*j).first;
                 if (visitedvthd.find(vthdid) == visitedvthd.end())
@@ -391,7 +391,7 @@ bool MTAResultValidator::validateTCT()
             }
         }
 
-        for (SVFSet<NodeID>::iterator j = rthdToChildren[i].begin(), ej = rthdToChildren[i].end(); j != ej; j++)
+        for (Set<NodeID>::iterator j = rthdToChildren[i].begin(), ej = rthdToChildren[i].end(); j != ej; j++)
         {
             NodeID gid = *j;
             if (!tct->hasGraphEdge(pnode, tct->getTCTNode(gid), TCTEdge::ThreadCreateEdge))
@@ -404,7 +404,7 @@ bool MTAResultValidator::validateTCT()
         {
             outs() << "Validate TCT: Wrong at TID " << rthdTovthd[i] << "\n";
             outs() << "Given children: \t";
-            for (SVFSet<NodeID>::iterator j = rthdToChildren[i].begin(), ej = rthdToChildren[i].end(); j != ej; j++)
+            for (Set<NodeID>::iterator j = rthdToChildren[i].begin(), ej = rthdToChildren[i].end(); j != ej; j++)
             {
                 NodeID gid = *j;
                 outs() << rthdTovthd[gid] << ", ";

--- a/lib/MTA/PCG.cpp
+++ b/lib/MTA/PCG.cpp
@@ -191,7 +191,7 @@ void PCG::identifyFollowers()
     {
         const Instruction* inst = *sit;
         BBWorkList bb_worklist;
-        SVFSet<const BasicBlock*> visitedBBs;
+        Set<const BasicBlock*> visitedBBs;
         bb_worklist.push(inst->getParent());
         while (!bb_worklist.empty())
         {

--- a/lib/MTA/PCG.cpp
+++ b/lib/MTA/PCG.cpp
@@ -191,7 +191,7 @@ void PCG::identifyFollowers()
     {
         const Instruction* inst = *sit;
         BBWorkList bb_worklist;
-        std::set<const BasicBlock*> visitedBBs;
+        SVFSet<const BasicBlock*> visitedBBs;
         bb_worklist.push(inst->getParent());
         while (!bb_worklist.empty())
         {

--- a/lib/MTA/TCT.cpp
+++ b/lib/MTA/TCT.cpp
@@ -71,7 +71,7 @@ bool TCT::isInRecursion(const Instruction* inst) const
 {
     const Function* f = inst->getParent()->getParent();
     FIFOWorkList<const Function*> worklist;
-    std::set<const Function*> visits;
+    SVFSet<const Function*> visits;
     worklist.push(f);
 
     while(!worklist.empty())

--- a/lib/MTA/TCT.cpp
+++ b/lib/MTA/TCT.cpp
@@ -71,7 +71,7 @@ bool TCT::isInRecursion(const Instruction* inst) const
 {
     const Function* f = inst->getParent()->getParent();
     FIFOWorkList<const Function*> worklist;
-    SVFSet<const Function*> visits;
+    Set<const Function*> visits;
     worklist.push(f);
 
     while(!worklist.empty())

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -545,7 +545,7 @@ void PointerAnalysis::getVFnsFromPts(const CallBlockNode* cs, const PointsTo &ta
 
     if (chgraph->csHasVtblsBasedonCHA(SVFUtil::getLLVMCallSite(cs->getCallSite())))
     {
-        SVFSet<const GlobalValue*> vtbls;
+        Set<const GlobalValue*> vtbls;
         const VTableSet &chaVtbls = chgraph->getCSVtblsBasedonCHA(SVFUtil::getLLVMCallSite(cs->getCallSite()));
         for (PointsTo::iterator it = target.begin(), eit = target.end(); it != eit; ++it)
         {

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -545,7 +545,7 @@ void PointerAnalysis::getVFnsFromPts(const CallBlockNode* cs, const PointsTo &ta
 
     if (chgraph->csHasVtblsBasedonCHA(SVFUtil::getLLVMCallSite(cs->getCallSite())))
     {
-        DenseSet<const GlobalValue*> vtbls;
+        SVFSet<const GlobalValue*> vtbls;
         const VTableSet &chaVtbls = chgraph->getCSVtblsBasedonCHA(SVFUtil::getLLVMCallSite(cs->getCallSite()));
         for (PointsTo::iterator it = target.begin(), eit = target.end(); it != eit; ++it)
         {

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -328,7 +328,7 @@ void PointerAnalysis::validateTests()
 
 void PointerAnalysis::dumpAllTypes()
 {
-    for (NodeSet::iterator nIter = this->getAllValidPtrs().begin();
+    for (OrderedNodeSet::iterator nIter = this->getAllValidPtrs().begin();
             nIter != this->getAllValidPtrs().end(); ++nIter)
     {
         const PAGNode* node = getPAG()->getPAGNode(*nIter);

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -240,7 +240,7 @@ void BVDataPTAImpl::dumpTopLevelPtsTo()
  */
 void BVDataPTAImpl::dumpAllPts()
 {
-    DenseNodeSet pagNodes;
+    NodeSet pagNodes;
     for(PAG::iterator it = pag->begin(), eit = pag->end(); it!=eit; it++)
     {
         pagNodes.insert(it->first);

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -207,7 +207,7 @@ bool BVDataPTAImpl::readFromFile(const string& filename)
  */
 void BVDataPTAImpl::dumpTopLevelPtsTo()
 {
-    for (NodeSet::iterator nIter = this->getAllValidPtrs().begin();
+    for (OrderedNodeSet::iterator nIter = this->getAllValidPtrs().begin();
             nIter != this->getAllValidPtrs().end(); ++nIter)
     {
         const PAGNode* node = getPAG()->getPAGNode(*nIter);

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -240,7 +240,7 @@ void BVDataPTAImpl::dumpTopLevelPtsTo()
  */
 void BVDataPTAImpl::dumpAllPts()
 {
-    NodeSet pagNodes;
+    OrderedNodeSet pagNodes;
     for(PAG::iterator it = pag->begin(), eit = pag->end(); it!=eit; it++)
     {
         pagNodes.insert(it->first);

--- a/lib/SABER/ProgSlice.cpp
+++ b/lib/SABER/ProgSlice.cpp
@@ -199,7 +199,7 @@ std::string ProgSlice::evalFinalCond() const
     std::string str;
     raw_string_ostream rawstr(str);
     NodeBS elems = pathAllocator->exactCondElem(finalCond);
-    SVFSet<std::string> locations;
+    Set<std::string> locations;
     for(NodeBS::iterator it = elems.begin(), eit = elems.end(); it!=eit; ++it)
     {
         Condition* atom = pathAllocator->getCond(*it);
@@ -207,7 +207,7 @@ std::string ProgSlice::evalFinalCond() const
         locations.insert(getSourceLoc(tinst));
     }
     /// print leak path after eliminating duplicated element
-    for(SVFSet<std::string>::iterator iter = locations.begin(), eiter = locations.end();
+    for(Set<std::string>::iterator iter = locations.begin(), eiter = locations.end();
             iter!=eiter; ++iter)
     {
         rawstr << "\t\t  --> (" << *iter << ") \n";

--- a/lib/SABER/ProgSlice.cpp
+++ b/lib/SABER/ProgSlice.cpp
@@ -199,7 +199,7 @@ std::string ProgSlice::evalFinalCond() const
     std::string str;
     raw_string_ostream rawstr(str);
     NodeBS elems = pathAllocator->exactCondElem(finalCond);
-    std::set<std::string> locations;
+    SVFSet<std::string> locations;
     for(NodeBS::iterator it = elems.begin(), eit = elems.end(); it!=eit; ++it)
     {
         Condition* atom = pathAllocator->getCond(*it);
@@ -207,7 +207,7 @@ std::string ProgSlice::evalFinalCond() const
         locations.insert(getSourceLoc(tinst));
     }
     /// print leak path after eliminating duplicated element
-    for(std::set<std::string>::iterator iter = locations.begin(), eiter = locations.end();
+    for(SVFSet<std::string>::iterator iter = locations.begin(), eiter = locations.end();
             iter!=eiter; ++iter)
     {
         rawstr << "\t\t  --> (" << *iter << ") \n";

--- a/lib/SABER/SaberAnnotator.cpp
+++ b/lib/SABER/SaberAnnotator.cpp
@@ -54,7 +54,7 @@ void SaberAnnotator::annotateSource()
  */
 void SaberAnnotator::annotateSinks()
 {
-    for(ProgSlice::SVFGNodeSet::iterator it = _curSlice->getSinks().begin(),
+    for(ProgSlice::SVFGNodeSet::const_iterator it = _curSlice->getSinks().begin(),
             eit = _curSlice->getSinks().end(); it!=eit; ++it)
     {
         if(const ActualParmSVFGNode* ap = SVFUtil::dyn_cast<ActualParmSVFGNode>(*it))

--- a/lib/SVF-FE/DCHG.cpp
+++ b/lib/SVF-FE/DCHG.cpp
@@ -220,7 +220,7 @@ void DCHGraph::buildVTables(const Module &module)
 const NodeBS &DCHGraph::cha(const DIType *type, bool firstField)
 {
     type = getCanonicalType(type);
-    DenseMap<const DIType *, NodeBS> &cacheMap = firstField ? chaFFMap : chaMap;
+    SVFMap<const DIType *, NodeBS> &cacheMap = firstField ? chaFFMap : chaMap;
 
     // Check if we've already computed.
     if (cacheMap.find(type) != cacheMap.end())
@@ -1138,7 +1138,7 @@ void DCHGraph::print(void)
     SVFUtil::outs() << thickLine;
     unsigned numStructs = 0;
     unsigned largestStruct = 0;
-    DenseNodeSet nodes;
+    NodeSet nodes;
     for (DCHGraph::const_iterator it = begin(); it != end(); ++it)
     {
         nodes.insert(it->first);
@@ -1230,7 +1230,7 @@ void DCHGraph::print(void)
 
         currIndent += singleIndent;
 
-        const DenseSet<const DIDerivedType *> &typedefs = node->getTypedefs();
+        const SVFSet<const DIDerivedType *> &typedefs = node->getTypedefs();
         for (const DIDerivedType *tdef : typedefs)
         {
             std::string typedefName = "void";

--- a/lib/SVF-FE/DCHG.cpp
+++ b/lib/SVF-FE/DCHG.cpp
@@ -220,7 +220,7 @@ void DCHGraph::buildVTables(const Module &module)
 const NodeBS &DCHGraph::cha(const DIType *type, bool firstField)
 {
     type = getCanonicalType(type);
-    SVFMap<const DIType *, NodeBS> &cacheMap = firstField ? chaFFMap : chaMap;
+    Map<const DIType *, NodeBS> &cacheMap = firstField ? chaFFMap : chaMap;
 
     // Check if we've already computed.
     if (cacheMap.find(type) != cacheMap.end())
@@ -1230,7 +1230,7 @@ void DCHGraph::print(void)
 
         currIndent += singleIndent;
 
-        const SVFSet<const DIDerivedType *> &typedefs = node->getTypedefs();
+        const Set<const DIDerivedType *> &typedefs = node->getTypedefs();
         for (const DIDerivedType *tdef : typedefs)
         {
             std::string typedefName = "void";

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -249,9 +249,9 @@ void LLVMModuleSet::addSVFMain()
 void LLVMModuleSet::buildFunToFunMap()
 {
     SVFSet<Function*> funDecls, funDefs;
-    std::set<string> declNames, defNames, intersectNames;
-    typedef std::map<string, Function*> NameToFunDefMapTy;
-    typedef std::map<string, SVFSet<Function*>> NameToFunDeclsMapTy;
+    SVFSet<string> declNames, defNames, intersectNames;
+    typedef SVFMap<string, Function*> NameToFunDefMapTy;
+    typedef SVFMap<string, SVFSet<Function*>> NameToFunDeclsMapTy;
 
     for (SVFModule::LLVMFunctionSetType::iterator it = svfModule->llvmFunBegin(),
             eit = svfModule->llvmFunEnd(); it != eit; ++it)
@@ -269,7 +269,7 @@ void LLVMModuleSet::buildFunToFunMap()
         }
     }
     // Find the intersectNames
-    std::set<string>::iterator declIter, defIter;
+    SVFSet<string>::iterator declIter, defIter;
     declIter = declNames.begin();
     defIter = defNames.begin();
     while (declIter != declNames.end() && defIter != defNames.end())
@@ -360,7 +360,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
 void LLVMModuleSet::buildGlobalDefToRepMap()
 {
-    typedef std::map<string, SVFSet<GlobalVariable*>> NameToGlobalsMapTy;
+    typedef SVFMap<string, SVFSet<GlobalVariable*>> NameToGlobalsMapTy;
     NameToGlobalsMapTy nameToGlobalsMap;
     for (SVFModule::global_iterator it = svfModule->global_begin(),
             eit = svfModule->global_end(); it != eit; ++it)

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -248,10 +248,10 @@ void LLVMModuleSet::addSVFMain()
 
 void LLVMModuleSet::buildFunToFunMap()
 {
-    SVFSet<Function*> funDecls, funDefs;
-    SVFSet<string> declNames, defNames, intersectNames;
-    typedef SVFMap<string, Function*> NameToFunDefMapTy;
-    typedef SVFMap<string, SVFSet<Function*>> NameToFunDeclsMapTy;
+    Set<Function*> funDecls, funDefs;
+    Set<string> declNames, defNames, intersectNames;
+    typedef Map<string, Function*> NameToFunDefMapTy;
+    typedef Map<string, Set<Function*>> NameToFunDeclsMapTy;
 
     for (SVFModule::LLVMFunctionSetType::iterator it = svfModule->llvmFunBegin(),
             eit = svfModule->llvmFunEnd(); it != eit; ++it)
@@ -269,7 +269,7 @@ void LLVMModuleSet::buildFunToFunMap()
         }
     }
     // Find the intersectNames
-    SVFSet<string>::iterator declIter, defIter;
+    Set<string>::iterator declIter, defIter;
     declIter = declNames.begin();
     defIter = defNames.begin();
     while (declIter != declNames.end() && defIter != defNames.end())
@@ -291,7 +291,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
     ///// name to def map
     NameToFunDefMapTy nameToFunDefMap;
-    for (SVFSet<Function*>::iterator it = funDefs.begin(),
+    for (Set<Function*>::iterator it = funDefs.begin(),
             eit = funDefs.end(); it != eit; ++it)
     {
         Function *fdef = *it;
@@ -303,7 +303,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
     ///// name to decls map
     NameToFunDeclsMapTy nameToFunDeclsMap;
-    for (SVFSet<Function*>::iterator it = funDecls.begin(),
+    for (Set<Function*>::iterator it = funDecls.begin(),
             eit = funDecls.end(); it != eit; ++it)
     {
         Function *fdecl = *it;
@@ -313,19 +313,19 @@ void LLVMModuleSet::buildFunToFunMap()
         NameToFunDeclsMapTy::iterator mit = nameToFunDeclsMap.find(funName);
         if (mit == nameToFunDeclsMap.end())
         {
-            SVFSet<Function*> decls;
+            Set<Function*> decls;
             decls.insert(fdecl);
             nameToFunDeclsMap[funName] = decls;
         }
         else
         {
-            SVFSet<Function*> &decls = mit->second;
+            Set<Function*> &decls = mit->second;
             decls.insert(fdecl);
         }
     }
 
     /// Fun decl --> def
-    for (SVFSet<Function*>::iterator it = funDecls.begin(),
+    for (Set<Function*>::iterator it = funDecls.begin(),
             eit = funDecls.end(); it != eit; ++it)
     {
         const Function *fdecl = *it;
@@ -339,7 +339,7 @@ void LLVMModuleSet::buildFunToFunMap()
     }
 
     /// Fun def --> decls
-    for (SVFSet<Function*>::iterator it = funDefs.begin(),
+    for (Set<Function*>::iterator it = funDefs.begin(),
             eit = funDefs.end(); it != eit; ++it)
     {
         const Function *fdef = *it;
@@ -350,7 +350,7 @@ void LLVMModuleSet::buildFunToFunMap()
         if (mit == nameToFunDeclsMap.end())
             continue;
         std::vector<const SVFFunction*>& decls = FunDefToDeclsMap[svfModule->getSVFFunction(fdef)];
-        for (SVFSet<Function*>::iterator sit = mit->second.begin(),
+        for (Set<Function*>::iterator sit = mit->second.begin(),
                 seit = mit->second.end(); sit != seit; ++sit)
         {
             decls.push_back(svfModule->getSVFFunction(*sit));
@@ -360,7 +360,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
 void LLVMModuleSet::buildGlobalDefToRepMap()
 {
-    typedef SVFMap<string, SVFSet<GlobalVariable*>> NameToGlobalsMapTy;
+    typedef Map<string, Set<GlobalVariable*>> NameToGlobalsMapTy;
     NameToGlobalsMapTy nameToGlobalsMap;
     for (SVFModule::global_iterator it = svfModule->global_begin(),
             eit = svfModule->global_end(); it != eit; ++it)
@@ -372,13 +372,13 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
         NameToGlobalsMapTy::iterator mit = nameToGlobalsMap.find(name);
         if (mit == nameToGlobalsMap.end())
         {
-            SVFSet<GlobalVariable*> globals;
+            Set<GlobalVariable*> globals;
             globals.insert(global);
             nameToGlobalsMap[name] = globals;
         }
         else
         {
-            SVFSet<GlobalVariable*> &globals = mit->second;
+            Set<GlobalVariable*> &globals = mit->second;
             globals.insert(global);
         }
     }
@@ -386,9 +386,9 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
     for (NameToGlobalsMapTy::iterator it = nameToGlobalsMap.begin(),
             eit = nameToGlobalsMap.end(); it != eit; ++it)
     {
-        SVFSet<GlobalVariable*> &globals = it->second;
+        Set<GlobalVariable*> &globals = it->second;
         GlobalVariable *rep = *(globals.begin());
-        SVFSet<GlobalVariable*>::iterator repit = globals.begin();
+        Set<GlobalVariable*>::iterator repit = globals.begin();
         while (repit != globals.end())
         {
             GlobalVariable *cur = *repit;
@@ -399,7 +399,7 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
             }
             repit++;
         }
-        for (SVFSet<GlobalVariable*>::iterator sit = globals.begin(),
+        for (Set<GlobalVariable*>::iterator sit = globals.begin(),
                 seit = globals.end(); sit != seit; ++sit)
         {
             GlobalVariable *cur = *sit;

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -248,10 +248,10 @@ void LLVMModuleSet::addSVFMain()
 
 void LLVMModuleSet::buildFunToFunMap()
 {
-    DenseSet<Function*> funDecls, funDefs;
+    SVFSet<Function*> funDecls, funDefs;
     std::set<string> declNames, defNames, intersectNames;
     typedef std::map<string, Function*> NameToFunDefMapTy;
-    typedef std::map<string, DenseSet<Function*>> NameToFunDeclsMapTy;
+    typedef std::map<string, SVFSet<Function*>> NameToFunDeclsMapTy;
 
     for (SVFModule::LLVMFunctionSetType::iterator it = svfModule->llvmFunBegin(),
             eit = svfModule->llvmFunEnd(); it != eit; ++it)
@@ -291,7 +291,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
     ///// name to def map
     NameToFunDefMapTy nameToFunDefMap;
-    for (DenseSet<Function*>::iterator it = funDefs.begin(),
+    for (SVFSet<Function*>::iterator it = funDefs.begin(),
             eit = funDefs.end(); it != eit; ++it)
     {
         Function *fdef = *it;
@@ -303,7 +303,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
     ///// name to decls map
     NameToFunDeclsMapTy nameToFunDeclsMap;
-    for (DenseSet<Function*>::iterator it = funDecls.begin(),
+    for (SVFSet<Function*>::iterator it = funDecls.begin(),
             eit = funDecls.end(); it != eit; ++it)
     {
         Function *fdecl = *it;
@@ -313,19 +313,19 @@ void LLVMModuleSet::buildFunToFunMap()
         NameToFunDeclsMapTy::iterator mit = nameToFunDeclsMap.find(funName);
         if (mit == nameToFunDeclsMap.end())
         {
-            DenseSet<Function*> decls;
+            SVFSet<Function*> decls;
             decls.insert(fdecl);
             nameToFunDeclsMap[funName] = decls;
         }
         else
         {
-            DenseSet<Function*> &decls = mit->second;
+            SVFSet<Function*> &decls = mit->second;
             decls.insert(fdecl);
         }
     }
 
     /// Fun decl --> def
-    for (DenseSet<Function*>::iterator it = funDecls.begin(),
+    for (SVFSet<Function*>::iterator it = funDecls.begin(),
             eit = funDecls.end(); it != eit; ++it)
     {
         const Function *fdecl = *it;
@@ -339,7 +339,7 @@ void LLVMModuleSet::buildFunToFunMap()
     }
 
     /// Fun def --> decls
-    for (DenseSet<Function*>::iterator it = funDefs.begin(),
+    for (SVFSet<Function*>::iterator it = funDefs.begin(),
             eit = funDefs.end(); it != eit; ++it)
     {
         const Function *fdef = *it;
@@ -350,7 +350,7 @@ void LLVMModuleSet::buildFunToFunMap()
         if (mit == nameToFunDeclsMap.end())
             continue;
         std::vector<const SVFFunction*>& decls = FunDefToDeclsMap[svfModule->getSVFFunction(fdef)];
-        for (DenseSet<Function*>::iterator sit = mit->second.begin(),
+        for (SVFSet<Function*>::iterator sit = mit->second.begin(),
                 seit = mit->second.end(); sit != seit; ++sit)
         {
             decls.push_back(svfModule->getSVFFunction(*sit));
@@ -360,7 +360,7 @@ void LLVMModuleSet::buildFunToFunMap()
 
 void LLVMModuleSet::buildGlobalDefToRepMap()
 {
-    typedef std::map<string, DenseSet<GlobalVariable*>> NameToGlobalsMapTy;
+    typedef std::map<string, SVFSet<GlobalVariable*>> NameToGlobalsMapTy;
     NameToGlobalsMapTy nameToGlobalsMap;
     for (SVFModule::global_iterator it = svfModule->global_begin(),
             eit = svfModule->global_end(); it != eit; ++it)
@@ -372,13 +372,13 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
         NameToGlobalsMapTy::iterator mit = nameToGlobalsMap.find(name);
         if (mit == nameToGlobalsMap.end())
         {
-            DenseSet<GlobalVariable*> globals;
+            SVFSet<GlobalVariable*> globals;
             globals.insert(global);
             nameToGlobalsMap[name] = globals;
         }
         else
         {
-            DenseSet<GlobalVariable*> &globals = mit->second;
+            SVFSet<GlobalVariable*> &globals = mit->second;
             globals.insert(global);
         }
     }
@@ -386,9 +386,9 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
     for (NameToGlobalsMapTy::iterator it = nameToGlobalsMap.begin(),
             eit = nameToGlobalsMap.end(); it != eit; ++it)
     {
-        DenseSet<GlobalVariable*> &globals = it->second;
+        SVFSet<GlobalVariable*> &globals = it->second;
         GlobalVariable *rep = *(globals.begin());
-        DenseSet<GlobalVariable*>::iterator repit = globals.begin();
+        SVFSet<GlobalVariable*>::iterator repit = globals.begin();
         while (repit != globals.end())
         {
             GlobalVariable *cur = *repit;
@@ -399,7 +399,7 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
             }
             repit++;
         }
-        for (DenseSet<GlobalVariable*>::iterator sit = globals.begin(),
+        for (SVFSet<GlobalVariable*>::iterator sit = globals.begin(),
                 seit = globals.end(); sit != seit; ++sit)
         {
             GlobalVariable *cur = *sit;

--- a/lib/SVF-FE/LLVMUtil.cpp
+++ b/lib/SVF-FE/LLVMUtil.cpp
@@ -59,7 +59,7 @@ bool SVFUtil::isObject(const Value * ref)
  */
 void SVFUtil::getFunReachableBBs (const Function * fun, DominatorTree* dt, std::vector<const BasicBlock*> &reachableBBs)
 {
-    std::set<const BasicBlock*> visited;
+    SVFSet<const BasicBlock*> visited;
     std::vector<const BasicBlock*> bbVec;
     bbVec.push_back(&fun->getEntryBlock());
     while(!bbVec.empty())
@@ -90,7 +90,7 @@ bool SVFUtil::functionDoesNotRet (const Function * fun)
 {
 
     std::vector<const BasicBlock*> bbVec;
-    std::set<const BasicBlock*> visited;
+    SVFSet<const BasicBlock*> visited;
     bbVec.push_back(&fun->getEntryBlock());
     while(!bbVec.empty())
     {

--- a/lib/SVF-FE/LLVMUtil.cpp
+++ b/lib/SVF-FE/LLVMUtil.cpp
@@ -59,7 +59,7 @@ bool SVFUtil::isObject(const Value * ref)
  */
 void SVFUtil::getFunReachableBBs (const Function * fun, DominatorTree* dt, std::vector<const BasicBlock*> &reachableBBs)
 {
-    SVFSet<const BasicBlock*> visited;
+    Set<const BasicBlock*> visited;
     std::vector<const BasicBlock*> bbVec;
     bbVec.push_back(&fun->getEntryBlock());
     while(!bbVec.empty())
@@ -90,7 +90,7 @@ bool SVFUtil::functionDoesNotRet (const Function * fun)
 {
 
     std::vector<const BasicBlock*> bbVec;
-    SVFSet<const BasicBlock*> visited;
+    Set<const BasicBlock*> visited;
     bbVec.push_back(&fun->getEntryBlock());
     while(!bbVec.empty())
     {

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -113,7 +113,7 @@ SymbolTableInfo* SymbolTableInfo::Symbolnfo()
  */
 void SymbolTableInfo::collectTypeInfo(const Type* ty)
 {
-    assert(typeToFieldInfo.find_as(ty) == typeToFieldInfo.end() && "this type has been collected before");
+    assert(typeToFieldInfo.find(ty) == typeToFieldInfo.end() && "this type has been collected before");
 
     if (const ArrayType* aty = SVFUtil::dyn_cast<ArrayType>(ty))
         collectArrayInfo(aty);

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -137,7 +137,7 @@ void PTAStat::performStat()
     u32_t numOfConstant = 0;
     u32_t fiObjNumber = 0;
     u32_t fsObjNumber = 0;
-    SVFSet<SymID> memObjSet;
+    Set<SymID> memObjSet;
     for(PAG::iterator it = pag->begin(), eit = pag->end(); it!=eit; ++it)
     {
         PAGNode* node = it->second;

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -137,7 +137,7 @@ void PTAStat::performStat()
     u32_t numOfConstant = 0;
     u32_t fiObjNumber = 0;
     u32_t fsObjNumber = 0;
-    DenseSet<SymID> memObjSet;
+    SVFSet<SymID> memObjSet;
     for(PAG::iterator it = pag->begin(), eit = pag->end(); it!=eit; ++it)
     {
         PAGNode* node = it->second;
@@ -235,7 +235,7 @@ void PTAStat::callgraphStat()
     unsigned totalEdge = 0;
     unsigned edgeInCycle = 0;
 
-    DenseNodeSet sccRepNodeSet;
+    NodeSet sccRepNodeSet;
     PTACallGraph::iterator it = graph->begin();
     PTACallGraph::iterator eit = graph->end();
     for (; it != eit; ++it)

--- a/lib/Util/PathCondAllocator.cpp
+++ b/lib/Util/PathCondAllocator.cpp
@@ -254,7 +254,7 @@ PathCondAllocator::Condition* PathCondAllocator::evaluateLoopExitBranch(const Ba
     {
         const Loop *loop = loopInfo->getLoopFor(bb);
         SmallBBVector exitbbs;
-        SVFSet<BasicBlock*> filteredbbs;
+        Set<BasicBlock*> filteredbbs;
         loop->getExitBlocks(exitbbs);
         /// exclude exit bb which calls program exit
         while(!exitbbs.empty())
@@ -267,7 +267,7 @@ PathCondAllocator::Condition* PathCondAllocator::evaluateLoopExitBranch(const Ba
         /// if the dst dominate all other loop exit bbs, then dst can certainly be reached
         bool allPDT = true;
         PostDominatorTree* pdt = getPostDT(fun);
-        for(SVFSet<BasicBlock*>::iterator it = filteredbbs.begin(), eit = filteredbbs.end(); it!=eit; ++it)
+        for(Set<BasicBlock*>::const_iterator it = filteredbbs.begin(), eit = filteredbbs.end(); it!=eit; ++it)
         {
             if(pdt->dominates(dst,*it) == false)
                 allPDT =false;
@@ -382,7 +382,7 @@ bool PathCondAllocator::isBBCallsProgExit(const BasicBlock* bb)
     if(it!=funToExitBBsMap.end())
     {
         PostDominatorTree* pdt = getPostDT(fun);
-        for(BasicBlockSet::iterator bit = it->second.begin(), ebit= it->second.end(); bit!=ebit; bit++)
+        for(BasicBlockSet::const_iterator bit = it->second.begin(), ebit= it->second.end(); bit!=ebit; bit++)
         {
             if(pdt->dominates(*bit,bb))
                 return true;
@@ -515,10 +515,10 @@ void PathCondAllocator::printPathCond()
 
     outs() << "print path condition\n";
 
-    for(BBCondMap::iterator it = bbConds.begin(), eit = bbConds.end(); it!=eit; ++it)
+    for(BBCondMap::const_iterator it = bbConds.begin(), eit = bbConds.end(); it!=eit; ++it)
     {
         const BasicBlock* bb = it->first;
-        for(CondPosMap::iterator cit = it->second.begin(), ecit = it->second.end(); cit!=ecit; ++cit)
+        for(CondPosMap::const_iterator cit = it->second.begin(), ecit = it->second.end(); cit!=ecit; ++cit)
         {
             u32_t i=0;
             for (const BasicBlock *succ: successors(bb))

--- a/lib/Util/PathCondAllocator.cpp
+++ b/lib/Util/PathCondAllocator.cpp
@@ -254,7 +254,7 @@ PathCondAllocator::Condition* PathCondAllocator::evaluateLoopExitBranch(const Ba
     {
         const Loop *loop = loopInfo->getLoopFor(bb);
         SmallBBVector exitbbs;
-        std::set<BasicBlock*> filteredbbs;
+        SVFSet<BasicBlock*> filteredbbs;
         loop->getExitBlocks(exitbbs);
         /// exclude exit bb which calls program exit
         while(!exitbbs.empty())
@@ -267,7 +267,7 @@ PathCondAllocator::Condition* PathCondAllocator::evaluateLoopExitBranch(const Ba
         /// if the dst dominate all other loop exit bbs, then dst can certainly be reached
         bool allPDT = true;
         PostDominatorTree* pdt = getPostDT(fun);
-        for(std::set<BasicBlock*>::iterator it = filteredbbs.begin(), eit = filteredbbs.end(); it!=eit; ++it)
+        for(SVFSet<BasicBlock*>::iterator it = filteredbbs.begin(), eit = filteredbbs.end(); it!=eit; ++it)
         {
             if(pdt->dominates(dst,*it) == false)
                 allPDT =false;

--- a/lib/Util/TypeBasedHeapCloning.cpp
+++ b/lib/Util/TypeBasedHeapCloning.cpp
@@ -302,8 +302,8 @@ bool TypeBasedHeapCloning::init(NodeID loc, NodeID p, const DIType *tildet, bool
             }
         }
 
-        const SVFSet<const DIType *> &aggs = dchg->isAgg(tp)
-                                             ? dchg->getAggs(tp) : SVFSet<const DIType *>();
+        const Set<const DIType *> &aggs = dchg->isAgg(tp)
+                                             ? dchg->getAggs(tp) : Set<const DIType *>();
 
         NodeID prop;
         bool filter = false;

--- a/lib/Util/TypeBasedHeapCloning.cpp
+++ b/lib/Util/TypeBasedHeapCloning.cpp
@@ -35,7 +35,7 @@ void TypeBasedHeapCloning::setPAG(PAG *pag)
 
 bool TypeBasedHeapCloning::isBlkObjOrConstantObj(NodeID o) const
 {
-    if (isClone(o)) o = cloneToOriginalObj.lookup(o);
+    if (isClone(o)) o = cloneToOriginalObj.at(o);
     return SVFUtil::isa<ObjPN>(ppag->getPAGNode(o)) && ppag->isBlkObjOrConstantObj(o);
 }
 
@@ -58,7 +58,7 @@ void TypeBasedHeapCloning::setType(NodeID o, const DIType *t)
 const DIType *TypeBasedHeapCloning::getType(NodeID o) const
 {
     assert(objToType.find(o) != objToType.end() && "TBHC: object has no type?");
-    return objToType.lookup(o);
+    return objToType.at(o);
 }
 
 void TypeBasedHeapCloning::setAllocationSite(NodeID o, NodeID site)
@@ -69,7 +69,7 @@ void TypeBasedHeapCloning::setAllocationSite(NodeID o, NodeID site)
 NodeID TypeBasedHeapCloning::getAllocationSite(NodeID o) const
 {
     assert(objToAllocation.find(o) != objToAllocation.end() && "TBHC: object has no allocation site?");
-    return objToAllocation.lookup(o);
+    return objToAllocation.at(o);
 }
 
 const NodeBS TypeBasedHeapCloning::getObjsWithClones(void)
@@ -104,7 +104,7 @@ NodeID TypeBasedHeapCloning::getOriginalObj(NodeID c) const
     {
         assert(cloneToOriginalObj.find(c) != cloneToOriginalObj.end()
                && "TBHC: original object not set for clone?");
-        return cloneToOriginalObj.lookup(c);
+        return cloneToOriginalObj.at(c);
     }
 
     return c;
@@ -302,8 +302,8 @@ bool TypeBasedHeapCloning::init(NodeID loc, NodeID p, const DIType *tildet, bool
             }
         }
 
-        const DenseSet<const DIType *> &aggs = dchg->isAgg(tp)
-                                               ? dchg->getAggs(tp) : DenseSet<const DIType *>();
+        const SVFSet<const DIType *> &aggs = dchg->isAgg(tp)
+                                             ? dchg->getAggs(tp) : SVFSet<const DIType *>();
 
         NodeID prop;
         bool filter = false;

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -724,7 +724,7 @@ void Andersen::updateNodeRepAndSubs(NodeID nodeId, NodeID newRepId)
  */
 void Andersen::dumpTopLevelPtsTo()
 {
-    for (NodeSet::iterator nIter = this->getAllValidPtrs().begin();
+    for (OrderedNodeSet::iterator nIter = this->getAllValidPtrs().begin();
             nIter != this->getAllValidPtrs().end(); ++nIter)
     {
         const PAGNode* node = getPAG()->getPAGNode(*nIter);

--- a/lib/WPA/AndersenSFR.cpp
+++ b/lib/WPA/AndersenSFR.cpp
@@ -139,7 +139,7 @@ void AndersenSFR::fieldExpand(NodeSet& initials, Size_t offset, NodeBS& strides,
             else
                 assert(false && "Not an object node!!");
 
-            std::set<Size_t> offsets;
+            SVFSet<Size_t> offsets;
             offsets.insert(offset);
 
             // calculate offsets

--- a/lib/WPA/AndersenSFR.cpp
+++ b/lib/WPA/AndersenSFR.cpp
@@ -139,7 +139,7 @@ void AndersenSFR::fieldExpand(NodeSet& initials, Size_t offset, NodeBS& strides,
             else
                 assert(false && "Not an object node!!");
 
-            SVFSet<Size_t> offsets;
+            Set<Size_t> offsets;
             offsets.insert(offset);
 
             // calculate offsets

--- a/lib/WPA/AndersenStat.cpp
+++ b/lib/WPA/AndersenStat.cpp
@@ -61,7 +61,7 @@ void AndersenStat::collectCycleInfo(ConstraintGraph* consCG)
     _NumOfCycles = 0;
     _NumOfPWCCycles = 0;
     _NumOfNodesInCycles = 0;
-    DenseNodeSet repNodes;
+    NodeSet repNodes;
     repNodes.clear();
     for(ConstraintGraph::iterator it = consCG->begin(), eit = consCG->end(); it!=eit; ++it)
     {

--- a/lib/WPA/AndersenWaveDiffWithType.cpp
+++ b/lib/WPA/AndersenWaveDiffWithType.cpp
@@ -51,13 +51,13 @@ void AndersenWaveDiffWithType::processTypeMismatchedGep(NodeID obj, const Type *
     TypeMismatchedObjToEdgeTy::iterator it = typeMismatchedObjToEdges.find(obj);
     if (it == typeMismatchedObjToEdges.end())
         return;
-    SVFSet<const GepCGEdge*> &edges = it->second;
-    SVFSet<const GepCGEdge*> processed;
+    Set<const GepCGEdge*> &edges = it->second;
+    Set<const GepCGEdge*> processed;
 
     PTAType ptaTy(type);
     NodeBS &nodesOfType = typeSystem->getVarsForType(ptaTy);
 
-    for (SVFSet<const GepCGEdge*>::iterator nit = edges.begin(), neit = edges.end(); nit != neit; ++nit)
+    for (Set<const GepCGEdge*>::iterator nit = edges.begin(), neit = edges.end(); nit != neit; ++nit)
     {
         if (const NormalGepCGEdge *normalGepEdge = SVFUtil::dyn_cast<NormalGepCGEdge>(*nit))
         {
@@ -70,7 +70,7 @@ void AndersenWaveDiffWithType::processTypeMismatchedGep(NodeID obj, const Type *
         }
     }
 
-    for (SVFSet<const GepCGEdge*>::iterator nit = processed.begin(), neit = processed.end(); nit != neit; ++nit)
+    for (Set<const GepCGEdge*>::iterator nit = processed.begin(), neit = processed.end(); nit != neit; ++nit)
         edges.erase(*nit);
 }
 
@@ -129,7 +129,7 @@ void AndersenWaveDiffWithType::mergeTypeOfNodes(const NodeBS &nodes)
 {
 
     /// collect types in a cycle
-    SVFSet<PTAType> typesInSCC;
+    OrderedSet<PTAType> typesInSCC;
     for (NodeBS::iterator it = nodes.begin(), eit = nodes.end(); it != eit; ++it)
     {
         if (typeSystem->hasTypeSet(*it))
@@ -146,7 +146,7 @@ void AndersenWaveDiffWithType::mergeTypeOfNodes(const NodeBS &nodes)
     /// merge types of nodes in a cycle
     for (NodeBS::iterator it = nodes.begin(), eit = nodes.end(); it != eit; ++it)
     {
-        for (SVFSet<PTAType>::iterator tyit = typesInSCC.begin(), tyeit = typesInSCC.end(); tyit != tyeit; ++tyit)
+        for (OrderedSet<PTAType>::iterator tyit = typesInSCC.begin(), tyeit = typesInSCC.end(); tyit != tyeit; ++tyit)
         {
             const PTAType &ptaTy = *tyit;
             if (typeSystem->addTypeForVar(*it, ptaTy))

--- a/lib/WPA/AndersenWaveDiffWithType.cpp
+++ b/lib/WPA/AndersenWaveDiffWithType.cpp
@@ -51,13 +51,13 @@ void AndersenWaveDiffWithType::processTypeMismatchedGep(NodeID obj, const Type *
     TypeMismatchedObjToEdgeTy::iterator it = typeMismatchedObjToEdges.find(obj);
     if (it == typeMismatchedObjToEdges.end())
         return;
-    DenseSet<const GepCGEdge*> &edges = it->second;
-    DenseSet<const GepCGEdge*> processed;
+    SVFSet<const GepCGEdge*> &edges = it->second;
+    SVFSet<const GepCGEdge*> processed;
 
     PTAType ptaTy(type);
     NodeBS &nodesOfType = typeSystem->getVarsForType(ptaTy);
 
-    for (DenseSet<const GepCGEdge*>::iterator nit = edges.begin(), neit = edges.end(); nit != neit; ++nit)
+    for (SVFSet<const GepCGEdge*>::iterator nit = edges.begin(), neit = edges.end(); nit != neit; ++nit)
     {
         if (const NormalGepCGEdge *normalGepEdge = SVFUtil::dyn_cast<NormalGepCGEdge>(*nit))
         {
@@ -70,7 +70,7 @@ void AndersenWaveDiffWithType::processTypeMismatchedGep(NodeID obj, const Type *
         }
     }
 
-    for (DenseSet<const GepCGEdge*>::iterator nit = processed.begin(), neit = processed.end(); nit != neit; ++nit)
+    for (SVFSet<const GepCGEdge*>::iterator nit = processed.begin(), neit = processed.end(); nit != neit; ++nit)
         edges.erase(*nit);
 }
 

--- a/lib/WPA/AndersenWaveDiffWithType.cpp
+++ b/lib/WPA/AndersenWaveDiffWithType.cpp
@@ -129,7 +129,7 @@ void AndersenWaveDiffWithType::mergeTypeOfNodes(const NodeBS &nodes)
 {
 
     /// collect types in a cycle
-    std::set<PTAType> typesInSCC;
+    SVFSet<PTAType> typesInSCC;
     for (NodeBS::iterator it = nodes.begin(), eit = nodes.end(); it != eit; ++it)
     {
         if (typeSystem->hasTypeSet(*it))
@@ -146,7 +146,7 @@ void AndersenWaveDiffWithType::mergeTypeOfNodes(const NodeBS &nodes)
     /// merge types of nodes in a cycle
     for (NodeBS::iterator it = nodes.begin(), eit = nodes.end(); it != eit; ++it)
     {
-        for (std::set<PTAType>::iterator tyit = typesInSCC.begin(), tyeit = typesInSCC.end(); tyit != tyeit; ++tyit)
+        for (SVFSet<PTAType>::iterator tyit = typesInSCC.begin(), tyeit = typesInSCC.end(); tyit != tyeit; ++tyit)
         {
             const PTAType &ptaTy = *tyit;
             if (typeSystem->addTypeForVar(*it, ptaTy))

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -701,7 +701,7 @@ void FlowSensitive::printCTirAliasStats(void)
     assert(dchg && "eval-ctir-aliases needs DCHG.");
 
     // < SVFG node ID (loc), PAG node of interest (top-level pointer) >.
-    DenseSet<std::pair<NodeID, NodeID>> cmpLocs;
+    SVFSet<std::pair<NodeID, NodeID>> cmpLocs;
     for (SVFG::iterator npair = svfg->begin(); npair != svfg->end(); ++npair)
     {
         NodeID loc = npair->first;
@@ -760,7 +760,7 @@ void FlowSensitive::printCTirAliasStats(void)
                  << "  " << "NO  % : " << 100 * ((double)noAliases/(double)(total)) << "\n";
 }
 
-void FlowSensitive::countAliases(DenseSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
+void FlowSensitive::countAliases(SVFSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
 {
     for (std::pair<NodeID, NodeID> locPA : cmp)
     {

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -701,7 +701,7 @@ void FlowSensitive::printCTirAliasStats(void)
     assert(dchg && "eval-ctir-aliases needs DCHG.");
 
     // < SVFG node ID (loc), PAG node of interest (top-level pointer) >.
-    SVFSet<std::pair<NodeID, NodeID>> cmpLocs;
+    Set<std::pair<NodeID, NodeID>> cmpLocs;
     for (SVFG::iterator npair = svfg->begin(); npair != svfg->end(); ++npair)
     {
         NodeID loc = npair->first;
@@ -760,7 +760,7 @@ void FlowSensitive::printCTirAliasStats(void)
                  << "  " << "NO  % : " << 100 * ((double)noAliases/(double)(total)) << "\n";
 }
 
-void FlowSensitive::countAliases(SVFSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
+void FlowSensitive::countAliases(Set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
 {
     for (std::pair<NodeID, NodeID> locPA : cmp)
     {

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -98,7 +98,7 @@ void FlowSensitiveStat::performStat()
 
     u32_t fiObjNumber = 0;
     u32_t fsObjNumber = 0;
-    DenseSet<SymID> nodeSet;
+    SVFSet<SymID> nodeSet;
     for (PAG::const_iterator nodeIt = pag->begin(), nodeEit = pag->end(); nodeIt != nodeEit; nodeIt++)
     {
         NodeID nodeId = nodeIt->first;

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -385,9 +385,9 @@ void FlowSensitiveStat::statInOutPtsSize(const DFInOutMap& data, ENUM_INOUT inOr
         PtsMap::const_iterator ptsEit = cptsMap.end();
         for (; ptsIt != ptsEit; ++ptsIt)
         {
-            if (ptsIt->second.empty()) continue;
+            if (ptsIt->second->empty()) continue;
 
-            u32_t ptsNum = ptsIt->second.count();	/// points-to target number
+            u32_t ptsNum = ptsIt->second->count();	/// points-to target number
 
             // Only node with non-empty points-to set are counted.
             _NumOfVarHaveINOUTPts[inOrOut]++;

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -385,9 +385,9 @@ void FlowSensitiveStat::statInOutPtsSize(const DFInOutMap& data, ENUM_INOUT inOr
         PtsMap::const_iterator ptsEit = cptsMap.end();
         for (; ptsIt != ptsEit; ++ptsIt)
         {
-            if (ptsIt->second->empty()) continue;
+            if (ptsIt->second.empty()) continue;
 
-            u32_t ptsNum = ptsIt->second->count();	/// points-to target number
+            u32_t ptsNum = ptsIt->second.count();	/// points-to target number
 
             // Only node with non-empty points-to set are counted.
             _NumOfVarHaveINOUTPts[inOrOut]++;

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -98,7 +98,7 @@ void FlowSensitiveStat::performStat()
 
     u32_t fiObjNumber = 0;
     u32_t fsObjNumber = 0;
-    SVFSet<SymID> nodeSet;
+    Set<SymID> nodeSet;
     for (PAG::const_iterator nodeIt = pag->begin(), nodeEit = pag->end(); nodeIt != nodeEit; nodeIt++)
     {
         NodeID nodeId = nodeIt->first;

--- a/lib/WPA/FlowSensitiveTBHC.cpp
+++ b/lib/WPA/FlowSensitiveTBHC.cpp
@@ -657,9 +657,9 @@ void FlowSensitiveTBHC::expandFIObjs(const PointsTo& pts, PointsTo& expandedPts)
     }
 }
 
-void FlowSensitiveTBHC::countAliases(SVFSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
+void FlowSensitiveTBHC::countAliases(Set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
 {
-    SVFMap<std::pair<NodeID, NodeID>, PointsTo> filteredPts;
+    Map<std::pair<NodeID, NodeID>, PointsTo> filteredPts;
     for (std::pair<NodeID, NodeID> locP : cmp)
     {
         const PointsTo &filterSet = getFilterSet(locP.first);

--- a/lib/WPA/FlowSensitiveTBHC.cpp
+++ b/lib/WPA/FlowSensitiveTBHC.cpp
@@ -657,9 +657,9 @@ void FlowSensitiveTBHC::expandFIObjs(const PointsTo& pts, PointsTo& expandedPts)
     }
 }
 
-void FlowSensitiveTBHC::countAliases(DenseSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
+void FlowSensitiveTBHC::countAliases(SVFSet<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
 {
-    DenseMap<std::pair<NodeID, NodeID>, PointsTo> filteredPts;
+    SVFMap<std::pair<NodeID, NodeID>, PointsTo> filteredPts;
     for (std::pair<NodeID, NodeID> locP : cmp)
     {
         const PointsTo &filterSet = getFilterSet(locP.first);

--- a/tools/Example/svf-ex.cpp
+++ b/tools/Example/svf-ex.cpp
@@ -80,7 +80,7 @@ void traverseOnICFG(ICFG* icfg, const Instruction* inst)
 {
     ICFGNode* iNode = icfg->getBlockICFGNode(inst);
     FIFOWorkList<const ICFGNode*> worklist;
-    std::set<const ICFGNode*> visited;
+    SVFSet<const ICFGNode*> visited;
     worklist.push(iNode);
 
     /// Traverse along VFG
@@ -111,7 +111,7 @@ void traverseOnVFG(const SVFG* vfg, Value* val)
     PAGNode* pNode = pag->getPAGNode(pag->getValueNode(val));
     const VFGNode* vNode = vfg->getDefSVFGNode(pNode);
     FIFOWorkList<const VFGNode*> worklist;
-    std::set<const VFGNode*> visited;
+    SVFSet<const VFGNode*> visited;
     worklist.push(vNode);
 
     /// Traverse along VFG
@@ -132,7 +132,7 @@ void traverseOnVFG(const SVFG* vfg, Value* val)
     }
 
     /// Collect all LLVM Values
-    for(std::set<const VFGNode*>::const_iterator it = visited.begin(), eit = visited.end(); it!=eit; ++it)
+    for(SVFSet<const VFGNode*>::const_iterator it = visited.begin(), eit = visited.end(); it!=eit; ++it)
     {
         const VFGNode* node = *it;
         /// can only query VFGNode involving top-level pointers (starting with % or @ in LLVM IR)

--- a/tools/Example/svf-ex.cpp
+++ b/tools/Example/svf-ex.cpp
@@ -80,7 +80,7 @@ void traverseOnICFG(ICFG* icfg, const Instruction* inst)
 {
     ICFGNode* iNode = icfg->getBlockICFGNode(inst);
     FIFOWorkList<const ICFGNode*> worklist;
-    SVFSet<const ICFGNode*> visited;
+    Set<const ICFGNode*> visited;
     worklist.push(iNode);
 
     /// Traverse along VFG
@@ -111,7 +111,7 @@ void traverseOnVFG(const SVFG* vfg, Value* val)
     PAGNode* pNode = pag->getPAGNode(pag->getValueNode(val));
     const VFGNode* vNode = vfg->getDefSVFGNode(pNode);
     FIFOWorkList<const VFGNode*> worklist;
-    SVFSet<const VFGNode*> visited;
+    Set<const VFGNode*> visited;
     worklist.push(vNode);
 
     /// Traverse along VFG
@@ -132,7 +132,7 @@ void traverseOnVFG(const SVFG* vfg, Value* val)
     }
 
     /// Collect all LLVM Values
-    for(SVFSet<const VFGNode*>::const_iterator it = visited.begin(), eit = visited.end(); it!=eit; ++it)
+    for(Set<const VFGNode*>::const_iterator it = visited.begin(), eit = visited.end(); it!=eit; ++it)
     {
         const VFGNode* node = *it;
         /// can only query VFGNode involving top-level pointers (starting with % or @ in LLVM IR)


### PR DESCRIPTION
As title. Required specifying CondVar for DenseMapInfo. The hash could be improved, but it shouldn't be too bad.

Some Andersen's stats, in seconds:
mutt  39.4 -> 32.3
mruby 9.77 -> 6.194

Edit: Also, I decided to implement the empty and tombstone keys like LLVM does, with ~0 and ~1. It think with such a NodeID, no analysis can scale...
https://llvm.org/doxygen/DenseMapInfo_8h_source.html#118