### PR TITLE
Addendum to PTData refactor

### DIFF
--- a/include/MemoryModel/AbstractPointsToDS.h
+++ b/include/MemoryModel/AbstractPointsToDS.h
@@ -37,6 +37,8 @@ template <typename Key, typename Datum, typename Data>
 class PTData
 {
 public:
+    typedef Set<Key> KeySet;
+
     /// Types of a points-to data structures.
     enum PTDataTy
     {
@@ -64,8 +66,8 @@ public:
 
     /// Get points-to set of var.
     virtual const Data& getPts(const Key& var) = 0;
-    /// Get reverse points-to set of var.
-    virtual const Data& getRevPts(const Key& var) = 0;
+    /// Get reverse points-to set of datum.
+    virtual const KeySet& getRevPts(const Datum& datum) = 0;
 
     /// Adds element to the points-to set associated with var.
     virtual bool addPts(const Key& var, const Datum& element) = 0;

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -18,8 +18,10 @@ class MutablePTData : public PTData<Key, Datum, Data>
 public:
     typedef PTData<Key, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
+    typedef typename BasePTData::KeySet KeySet;
 
     typedef Map<Key, Data> PtsMap;
+    typedef Map<Datum, KeySet> RevPtsMap;
     typedef typename PtsMap::iterator PtsMapIter;
     typedef typename PtsMap::const_iterator PtsMapConstIter;
     typedef typename Data::iterator iterator;
@@ -46,9 +48,9 @@ public:
         return ptsMap[var];
     }
 
-    virtual inline const Data& getRevPts(const Key& var) override
+    virtual inline const KeySet& getRevPts(const Key& datum) override
     {
-        return revPtsMap[var];
+        return revPtsMap[datum];
     }
 
     virtual inline bool addPts(const Key &dstKey, const Datum& element) override
@@ -126,11 +128,11 @@ private:
     {
         return d.test_and_set(e);
     }
-    inline void addSingleRevPts(Data &revData, const Datum& tgr)
+    inline void addSingleRevPts(KeySet &revData, const Key& tgr)
     {
-        addPts(revData,tgr);
+        revData.insert(tgr);
     }
-    inline void addRevPts(const Data &ptsData, const Datum& tgr)
+    inline void addRevPts(const Data &ptsData, const Key& tgr)
     {
         for(iterator it = ptsData.begin(), eit = ptsData.end(); it!=eit; ++it)
             addSingleRevPts(revPtsMap[*it], tgr);
@@ -139,7 +141,7 @@ private:
 
 protected:
     PtsMap ptsMap;
-    PtsMap revPtsMap;
+    RevPtsMap revPtsMap;
 };
 
 /// DiffPTData implemented with points-to sets which are updated continuously.
@@ -151,6 +153,7 @@ public:
     typedef PTData<Key, Datum, Data> BasePTData;
     typedef DiffPTData<Key, Datum, Data, CacheKey> BaseDiffPTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
+    typedef typename BasePTData::KeySet KeySet;
 
     typedef typename MutablePTData<Key, Datum, Data>::PtsMap PtsMap;
     typedef typename MutablePTData<CacheKey, Datum, Data>::PtsMap CachePtsMap;
@@ -175,9 +178,9 @@ public:
         return mutPTData.getPts(var);
     }
 
-    virtual inline const Data& getRevPts(const Key& var) override
+    virtual inline const KeySet& getRevPts(const Datum& datum) override
     {
-        return mutPTData.getRevPts(var);
+        return mutPTData.getRevPts(datum);
     }
 
     virtual inline bool addPts(const Key &dstKey, const Datum& element) override
@@ -286,6 +289,7 @@ public:
     typedef MutablePTData<Key, Datum, Data> BaseMutPTData;
     typedef DFPTData<Key, Datum, Data> BaseDFPTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
+    typedef typename BasePTData::KeySet KeySet;
 
     typedef typename BaseDFPTData::LocID LocID;
     typedef typename BaseMutPTData::PtsMap PtsMap;
@@ -314,9 +318,9 @@ public:
         return mutPTData.getPts(var);
     }
 
-    virtual inline const Data& getRevPts(const Key& var) override
+    virtual inline const KeySet& getRevPts(const Datum& datum) override
     {
-        return mutPTData.getRevPts(var);
+        return mutPTData.getRevPts(datum);
     }
 
     virtual inline bool hasDFInSet(LocID loc) const override

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -244,7 +244,7 @@ public:
 
     /// Given an object, get all the nodes having whose pointsto contains the object.
     /// Similar to getPts, this also needs to be implemented in child classes.
-    virtual const PointsTo& getRevPts(NodeID nodeId) = 0;
+    virtual const NodeSet& getRevPts(NodeID nodeId) = 0;
 
     /// Clear points-to data
     virtual void clearPts()

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -77,7 +77,7 @@ public:
     {
         return ptD->getPts(id);
     }
-    virtual inline const PointsTo& getRevPts(NodeID nodeId)
+    virtual inline const NodeSet& getRevPts(NodeID nodeId)
     {
         return ptD->getRevPts(nodeId);
     }
@@ -223,6 +223,7 @@ public:
     typedef PTData<CVar, CVar, CPtSet> PTDataTy;
     typedef MutablePTData<CVar, CVar, CPtSet> MutPTDataTy;
     typedef Map<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
+    typedef Map<NodeID, NodeSet> PtrToNSMap;
     typedef Map<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
 
     /// Constructor
@@ -284,7 +285,7 @@ public:
     {
         return ptD->getPts(id);
     }
-    virtual inline const CPtSet& getRevPts(CVar nodeId)
+    virtual inline const Set<CVar>& getRevPts(CVar nodeId)
     {
         return ptD->getRevPts(nodeId);
     }
@@ -418,7 +419,7 @@ protected:
                 for(typename CPtSet::const_iterator cit = it->second.begin(), ecit=it->second.end(); cit!=ecit; ++cit)
                 {
                     ptrToBVPtsMap[(it->first).get_id()].set(cit->get_id());
-                    objToBVRevPtsMap[cit->get_id()].set((it->first).get_id());
+                    objToNSRevPtsMap[cit->get_id()].insert((it->first).get_id());
                     ptrToCPtsMap[(it->first).get_id()].set(*cit);
                 }
             }
@@ -435,7 +436,7 @@ protected:
     /// Normal points-to representation (without conditions)
     PtrToBVPtsMap ptrToBVPtsMap;
     /// Normal points-to representation (without conditions)
-    PtrToBVPtsMap objToBVRevPtsMap;
+    PtrToNSMap objToNSRevPtsMap;
     /// Conditional points-to representation (with conditions)
     PtrToCPtsMap ptrToCPtsMap;
 public:
@@ -465,10 +466,10 @@ public:
         return ptrToCPtsMap[ptr];
     }
     /// Given an object return all pointers points to this object
-    virtual inline PointsTo& getRevPts(NodeID obj)
+    virtual inline NodeSet& getRevPts(NodeID obj)
     {
         assert(normalized && "Pts of all context-var have to be merged/normalized. Want to use getPts(CVar cvar)??");
-        return objToBVRevPtsMap[obj];
+        return objToNSRevPtsMap[obj];
     }
 
     /// Interface expose to users of our pointer analysis, given Location infos

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -454,8 +454,8 @@ bool Andersen::collapseField(NodeID nodeId)
         if (fieldId != baseId)
         {
             // use the reverse pts of this field node to find all pointers point to it
-            const PointsTo & revPts = getRevPts(fieldId);
-            for (PointsTo::iterator ptdIt = revPts.begin(), ptdEit = revPts.end();
+            const NodeSet &revPts = getRevPts(fieldId);
+            for (NodeSet::const_iterator ptdIt = revPts.begin(), ptdEit = revPts.end();
                     ptdIt != ptdEit; ptdIt++)
             {
                 // change the points-to target from field to base node


### PR DESCRIPTION
Reverse points-to sets need to account for the fact that we separated key and datum. A reverse set is saying... given this **Datum**, these are **Keys** (i.e. a set of Keys, not a Data), that contain that datum in their associated **Data**. Thus it is `Map<Datum, KeySet>`. I used `Set` for the `KeySet` and suprisingly for large Andersen runs... it is faster.

For example, on my machine, (avg. TL PTS size in parentheses),
```
lynx: 74s to 57s (150.492)
bash: 29s to 20s (239.593)
astyle: 24.7s to 19.4s (211.37)
mruby: 6.466s to 6.614s (20.2511)
```

Overall, perhaps `SparseBitVector` can be reconsidered to `unordered_set` or even a plain `BitVector`*. Memory usage is obviously also an important factor to consider, though, and I didn't test that.

\* The BCs I've worked on have always had less than 10000 objects giving a maximum BC memory usage of less then 1.5 kilobytes (discounting BitVector's internal maintenance). With a dynamically sized bit vector, this is obviously much smaller. Also with a dynamically sized bit vector, a cheap pre-analysis can predict which objects are likely to be stored together and hence give them similar values so we don't have bit vectors with huge gaps (e.g. instead of a bit vector storing node IDs 5 and 2560 and 7000, we can rename them to, 8, 9, 10, for example). The difficulty is considering all relations when renaming but I can't help but think something analogous can be found in another field. Whatever... maybe that's another paper. :)