### PR TITLE
Add back LocMemModel support

### DIFF
--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -420,6 +420,8 @@ public:
     void collectTypeInfo(const Type* T);
     /// Given an offset from a Gep Instruction, return it modulus offset by considering memory layout
     virtual LocationSet getModulusOffset(const MemObj* obj, const LocationSet& ls);
+    /// Get the LocationSet offset the SymbolTableInfo is interested in (field offset or byte offset)
+    virtual Size_t getLocationSetOffset(const LocationSet& ls);
 
     /// Debug method
     void printFlattenFields(const Type* type);
@@ -469,15 +471,11 @@ public:
     virtual bool computeGepOffset(const User *V, LocationSet& ls);
     /// Given an offset from a Gep Instruction, return it modulus offset by considering memory layout
     virtual LocationSet getModulusOffset(const MemObj* obj, const LocationSet& ls);
+    /// Get the LocationSet offset the SymbolTableInfo is interested in (field offset or byte offset)
+    virtual Size_t getLocationSetOffset(const LocationSet& ls);
 
     /// Verify struct size construction
     void verifyStructSize(StInfo *stInfo, u32_t structSize);
-
-protected:
-    /// Collect the struct info
-    virtual void collectStructInfo(const StructType *T);
-    /// Collect the array info
-    virtual void collectArrayInfo(const ArrayType *T);
 };
 
 

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -608,7 +608,7 @@ NodeID PAG::getGepObjNode(const MemObj* obj, const LocationSet& ls)
     NodeID base = getObjectNode(obj);
 
     // Base and first field are the same memory location.
-    if (FirstFieldEqBase && ls.getOffset() == 0) return base;
+    if (FirstFieldEqBase && SymbolTableInfo::Symbolnfo()->getLocationSetOffset(ls) == 0) return base;
 
     /// if this obj is field-insensitive, just return the field-insensitive node.
     if (obj->isFieldInsensitive())
@@ -643,7 +643,7 @@ NodeID PAG::addGepObjNode(const MemObj* obj, const LocationSet& ls)
                                             getNodeNumAfterPAGBuild() > StInfo::getMaxFieldLimit() ?
                                             getNodeNumAfterPAGBuild() : StInfo::getMaxFieldLimit()
                                         )));
-    NodeID gepId = (ls.getOffset() + 1) * gepMultiplier + base;
+    NodeID gepId = (SymbolTableInfo::Symbolnfo()->getLocationSetOffset(ls) + 1) * gepMultiplier + base;
     GepObjNodeMap[std::make_pair(base, ls)] = gepId;
     GepObjPN *node = new GepObjPN(obj, gepId, ls);
     memToFieldsMap[base].set(gepId);

--- a/lib/MemoryModel/LocationSet.cpp
+++ b/lib/MemoryModel/LocationSet.cpp
@@ -31,6 +31,7 @@
 
 #include "MemoryModel/LocationSet.h"
 #include "MemoryModel/MemModel.h"
+#include "SVF-FE/SymbolTableInfo.h"
 
 using namespace SVF;
 
@@ -118,7 +119,7 @@ PointsTo LocationSet::computeAllLocations() const
 {
 
     PointsTo result;
-    result.set(getOffset());
+    result.set(SymbolTableInfo::Symbolnfo()->getLocationSetOffset(*this));
 
     if (isConstantOffset() == false)
     {
@@ -134,7 +135,7 @@ PointsTo LocationSet::computeAllLocations() const
         do
         {
             u32_t i = 0;
-            NodeID ofst = getOffset();
+            NodeID ofst = SymbolTableInfo::Symbolnfo()->getLocationSetOffset(*this);
             while (i < lhsVec.size())
             {
                 ofst += (lhsVec[i].second * indices[i]);

--- a/lib/MemoryModel/MemModel.cpp
+++ b/lib/MemoryModel/MemModel.cpp
@@ -306,21 +306,13 @@ bool LocSymTableInfo::computeGepOffset(const User *V, LocationSet& ls)
 {
 
     assert(V);
-    int baseIndex = -1;
     int index = 0;
+
     for (bridge_gep_iterator gi = bridge_gep_begin(*V), ge = bridge_gep_end(*V);
             gi != ge; ++gi, ++index)
     {
+
         if(SVFUtil::isa<ConstantInt>(gi.getOperand()) == false)
-            baseIndex = index;
-    }
-
-    index = 0;
-    for (bridge_gep_iterator gi = bridge_gep_begin(*V), ge = bridge_gep_end(*V);
-            gi != ge; ++gi, ++index)
-    {
-
-        if (index <= baseIndex)
         {
             /// variant offset
             // Handling pointer types

--- a/lib/MemoryModel/MemModel.cpp
+++ b/lib/MemoryModel/MemModel.cpp
@@ -345,6 +345,12 @@ bool LocSymTableInfo::computeGepOffset(const User *V, LocationSet& ls)
                 Size_t num = at->getNumElements();
                 ls.addElemNumStridePair(std::make_pair(num, sz));
             }
+            else if (const StructType *ST = SVFUtil::dyn_cast<StructType>(*gi) )
+            {
+                // Handling struct here
+                Size_t sz = getTypeSizeInBytes(ST);
+                ls.addElemNumStridePair(std::make_pair(1, sz));
+            }
             else
                 assert(false && "what other types?");
         }

--- a/lib/MemoryModel/MemModel.cpp
+++ b/lib/MemoryModel/MemModel.cpp
@@ -395,98 +395,6 @@ bool LocSymTableInfo::computeGepOffset(const User *V, LocationSet& ls)
 }
 
 /*!
- * Collect array information
- */
-void LocSymTableInfo::collectArrayInfo(const llvm::ArrayType*)
-{
-    /*
-    StInfo *stinfo = new StInfo();
-    typeToFieldInfo[ty] = stinfo;
-
-    /// If this is an array type, calculate the outmost array
-    /// information and append them to the inner elements' type
-    /// information later.
-    u64_t out_num = ty->getNumElements();
-    const Type* elemTy = ty->getElementType();
-    u32_t out_stride = getTypeSizeInBytes(elemTy);
-
-    /// Array itself only has one field which is the inner most element
-    stinfo->addOffsetWithType(0, elemTy);
-
-    while (const ArrayType* aty = dyn_cast<ArrayType>(elemTy)) {
-        out_num *= aty->getNumElements();
-        elemTy = aty->getElementType();
-        out_stride = getTypeSizeInBytes(elemTy);
-    }
-
-    /// Array's flatten field infor is the same as its element's
-    /// flatten infor with an additional slot for array's element
-    /// number and stride pair.
-    StInfo* elemStInfo = getStructInfo(elemTy);
-    u32_t nfE = elemStInfo->getFlattenFieldInfoVec().size();
-    for (u32_t j = 0; j < nfE; j++) {
-        u32_t off = elemStInfo->getFlattenFieldInfoVec()[j].getFlattenOffset();
-        const Type* fieldTy = elemStInfo->getFlattenFieldInfoVec()[j].getFlattenElemTy();
-        FieldInfo::ElemNumStridePairVec pair = elemStInfo->getFlattenFieldInfoVec()[j].getElemNumStridePairVect();
-        /// append the additional number
-        pair.push_back(std::make_pair(out_num, out_stride));
-        FieldInfo field(off, fieldTy, pair);
-        stinfo->getFlattenFieldInfoVec().push_back(field);
-    }
-    */
-}
-
-
-/*
- * Recursively collect the memory layout information for a struct type
- */
-void LocSymTableInfo::collectStructInfo(const StructType*)
-{
-    /*
-    StInfo *stinfo = new StInfo();
-    typeToFieldInfo[ty] = stinfo;
-
-    const StructLayout *stTySL = getDataLayout(getModule().getMainLLVMModule())->getStructLayout( const_cast<StructType *>(ty) );
-
-    u32_t field_idx = 0;
-    for (StructType::element_iterator it = ty->element_begin(), ie =
-                ty->element_end(); it != ie; ++it, ++field_idx) {
-        const Type *et = *it;
-
-        // The offset is where this element will be placed in the struct.
-        // This offset is computed after alignment with the current struct
-        u64_t eOffsetInBytes = stTySL->getElementOffset(field_idx);
-
-        //The offset is where this element will be placed in the exp. struct.
-        /// FIXME: As the layout size is uint_64, here we assume
-        /// offset with uint_32 (Size_t) is large enough and will not cause overflow
-        stinfo->addOffsetWithType(static_cast<u32_t>(eOffsetInBytes), et);
-
-        StInfo* fieldStinfo = getStructInfo(et);
-        u32_t nfE = fieldStinfo->getFlattenFieldInfoVec().size();
-        //Copy ST's info, whose element 0 is the size of ST itself.
-        for (u32_t j = 0; j < nfE; j++) {
-            u32_t oft = eOffsetInBytes + fieldStinfo->getFlattenFieldInfoVec()[j].getFlattenOffset();
-            const Type* elemTy = fieldStinfo->getFlattenFieldInfoVec()[j].getFlattenElemTy();
-            FieldInfo::ElemNumStridePairVec pair = fieldStinfo->getFlattenFieldInfoVec()[j].getElemNumStridePairVect();
-            pair.push_back(std::make_pair(1, 0));
-            FieldInfo newField(oft, elemTy, pair);
-            stinfo->getFlattenFieldInfoVec().push_back(newField);
-        }
-    }
-
-    //	verifyStructSize(stinfo,stTySL->getSizeInBytes());
-
-    //Record the size of the complete struct and update max_struct.
-    if (stTySL->getSizeInBytes() > maxStSize) {
-        maxStruct = ty;
-        maxStSize = stTySL->getSizeInBytes();
-    }
-    */
-}
-
-
-/*!
  * Given LocationSet from a Gep Instruction, return a new LocationSet which matches
  * the field information of this ObjTypeInfo by considering memory layout
  */
@@ -588,6 +496,13 @@ void LocSymTableInfo::verifyStructSize(StInfo *stinfo, u32_t structSize)
     /// Please note this verify may not be complete as different machine has different alignment mechanism
     assert((structSize == lastOff + strideSize + lastSize) && "struct size not consistent");
 
+}
+
+/*!
+ * Get the LocationSet offset the SymbolTableInfo is interested in (field offset or byte offset)
+ */
+Size_t LocSymTableInfo::getLocationSetOffset(const LocationSet& ls) {
+    return ls.getByteOffset();
 }
 
 /*!

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -414,6 +414,13 @@ LocationSet SymbolTableInfo::getModulusOffset(const MemObj* obj, const LocationS
     return LocationSet(offset);
 }
 
+/*!
+ * Get the LocationSet offset the SymbolTableInfo is interested in (field offset or byte offset)
+ */
+Size_t SymbolTableInfo::getLocationSetOffset(const LocationSet& ls) {
+    return ls.getOffset();
+}
+
 
 /*!
  * Invoke llvm passes to modify module


### PR DESCRIPTION
Pull request for issue #328 
Basically add a virtual method wrapper in `SymbolTableInfo`, i.e. `SymbolTableInfo::getLocationSetOffset`, which is overriden by `LocSymTableInfo` to select either `ls.getOffset()` or `ls.getByteOffset()`. 
I have added calls to such method in `PAG::getGepObjNode` and `PAG::addGepObjNode`: this should not break the compatibility between `locMM` and non `locMM` memory models.
Btw I'm not sure if I have to use `SymbolTableInfo::Symbolnfo()->getLocationSetOffset(ls)` in place of every invocation of `ls.getOffset()` in the entire code base, or just in the PAG methods.