### PR TITLE
Introduce dense node ID allocation

### DIFF
--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -723,7 +723,7 @@ public:
     //@{
     inline NodeID addDummyValNode()
     {
-        return addDummyValNode(NodeIDAllocator::allocateValueId());
+        return addDummyValNode(NodeIDAllocator::get()->allocateValueId());
     }
     inline NodeID addDummyValNode(NodeID i)
     {
@@ -731,7 +731,7 @@ public:
     }
     inline NodeID addDummyObjNode(const Type* type = NULL)
     {
-        return addDummyObjNode(NodeIDAllocator::allocateObjectId(), type);
+        return addDummyObjNode(NodeIDAllocator::get()->allocateObjectId(), type);
     }
     inline NodeID addDummyObjNode(NodeID i, const Type* type)
     {

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -33,6 +33,7 @@
 
 #include "PAGEdge.h"
 #include "PAGNode.h"
+#include "Util/NodeIDAllocator.h"
 #include "Util/SVFUtil.h"
 #include "Graphs/ICFG.h"
 
@@ -722,7 +723,7 @@ public:
     //@{
     inline NodeID addDummyValNode()
     {
-        return addDummyValNode(SymbolTableInfo::newValSymID());
+        return addDummyValNode(NodeIDAllocator::allocateValueId());
     }
     inline NodeID addDummyValNode(NodeID i)
     {
@@ -730,7 +731,7 @@ public:
     }
     inline NodeID addDummyObjNode(const Type* type = NULL)
     {
-        return addDummyObjNode(SymbolTableInfo::newObjSymID(), type);
+        return addDummyObjNode(NodeIDAllocator::allocateObjectId(), type);
     }
     inline NodeID addDummyObjNode(NodeID i, const Type* type)
     {

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -722,7 +722,7 @@ public:
     //@{
     inline NodeID addDummyValNode()
     {
-        return addDummyValNode(nodeNum);
+        return addDummyValNode(SymbolTableInfo::newValSymID());
     }
     inline NodeID addDummyValNode(NodeID i)
     {
@@ -730,7 +730,7 @@ public:
     }
     inline NodeID addDummyObjNode(const Type* type = NULL)
     {
-        return addDummyObjNode(nodeNum, type);
+        return addDummyObjNode(SymbolTableInfo::newObjSymID(), type);
     }
     inline NodeID addDummyObjNode(NodeID i, const Type* type)
     {

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -32,6 +32,7 @@
 
 #include "MemoryModel/MemModel.h"
 #include "SVF-FE/LLVMModule.h"
+#include "Util/NodeIDAllocator.h"
 
 namespace SVF
 {
@@ -62,21 +63,9 @@ public:
 
     //@}
 
-    enum NodeAllocationStrategy
-    {
-        /// Allocate objects contiguously, separete from values, and vice versa.
-        DENSE,
-        /// Allocate values and objects as they come in with a single counter.
-        /// GEP objects are allocated as an offset from their base. The purpose
-        /// of this allocation strategy is human readability.
-        DEBUG,
-    };
-
 private:
     /// Data layout on a target machine
     static DataLayout *dl;
-
-    static enum NodeAllocationStrategy allocStrat;
 
     ValueToIDMapTy valSymMap;	///< map a value to its sym id
     ValueToIDMapTy objSymMap;	///< map a obj reference to its sym id
@@ -110,18 +99,9 @@ protected:
     SymbolTableInfo(void);
 
 public:
-    /// Option strings as written by the user.
-    ///@{
-    static const std::string userNodeAllocationStrategyDense;
-    static const std::string userNodeAllocationStrategyDebug;
-    ///@}
-
     /// Statistics
     //@{
     static SymID totalSymNum;
-    static SymID totalObjSymNum;
-    static SymID totalValSymNum;
-    static SymID totalBaseSymNum;
     //@}
 
     /// Singleton design here to make sure we only have one instance during any analysis
@@ -193,20 +173,6 @@ public:
     void collectRet(const Function *val);
 
     void collectVararg(const Function *val);
-
-    /// Increments the number of objects and returns an ID that
-    /// can be assign to an object, specifically.
-    /// Also increments the total number of values.
-    /// The <indicator, base, offset> tuple is to allocate GEP node IDs
-    /// as an offset from the base object if desired (indicated by the 
-    /// first element).
-    /// Only makes a difference when the allocation strategy is DEBUG.
-    static SymID newObjSymID(
-        std::tuple<bool, NodeID, u32_t> gepMeta = std::make_tuple(false, 0, 0));
-
-    /// Increments the number of values and returns an ID that can
-    /// be assigned to a value.
-    static SymID newValSymID(void);
     //@}
 
     /// special value

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -104,6 +104,7 @@ public:
     /// Statistics
     //@{
     static SymID totalSymNum;
+    static SymID totalObjSymNum;
     //@}
 
     /// Singleton design here to make sure we only have one instance during any analysis
@@ -175,6 +176,15 @@ public:
     void collectRet(const Function *val);
 
     void collectVararg(const Function *val);
+
+    /// Increments the number of objects and returns an ID that
+    /// can be assign to an object, specifically.
+    /// Also increments the total number of values.
+    static SymID newObjSymID(void);
+
+    /// Increments the number of values and returns an ID that can
+    /// be assigned to a value.
+    static SymID newValSymID(void);
     //@}
 
     /// special value

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -121,6 +121,7 @@ public:
     static SymID totalSymNum;
     static SymID totalObjSymNum;
     static SymID totalValSymNum;
+    static SymID totalBaseSymNum;
     //@}
 
     /// Singleton design here to make sure we only have one instance during any analysis

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -96,7 +96,10 @@ private:
 
 protected:
     /// Constructor
-    SymbolTableInfo(void);
+    SymbolTableInfo(void) :
+        modelConstants(false), maxStruct(NULL), maxStSize(0)
+    {
+    }
 
 public:
     /// Statistics

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -32,7 +32,6 @@
 
 #include "MemoryModel/MemModel.h"
 #include "SVF-FE/LLVMModule.h"
-#include "Util/NodeIDAllocator.h"
 
 namespace SVF
 {

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -105,6 +105,7 @@ public:
     //@{
     static SymID totalSymNum;
     static SymID totalObjSymNum;
+    static SymID totalValSymNum;
     //@}
 
     /// Singleton design here to make sure we only have one instance during any analysis

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -196,7 +196,12 @@ public:
     /// Increments the number of objects and returns an ID that
     /// can be assign to an object, specifically.
     /// Also increments the total number of values.
-    static SymID newObjSymID(void);
+    /// The <indicator, base, offset> tuple is to allocate GEP node IDs
+    /// as an offset from the base object if desired (indicated by the 
+    /// first element).
+    /// Only makes a difference when the allocation strategy is DEBUG.
+    static SymID newObjSymID(
+        std::tuple<bool, NodeID, u32_t> gepMeta = std::make_tuple(false, 0, 0));
 
     /// Increments the number of values and returns an ID that can
     /// be assigned to a value.

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -62,9 +62,21 @@ public:
 
     //@}
 
+    enum NodeAllocationStrategy
+    {
+        /// Allocate objects contiguously, separete from values, and vice versa.
+        DENSE,
+        /// Allocate values and objects as they come in with a single counter.
+        /// GEP objects are allocated as an offset from their base. The purpose
+        /// of this allocation strategy is human readability.
+        DEBUG,
+    };
+
 private:
     /// Data layout on a target machine
     static DataLayout *dl;
+
+    enum NodeAllocationStrategy allocStrat;
 
     ValueToIDMapTy valSymMap;	///< map a value to its sym id
     ValueToIDMapTy objSymMap;	///< map a obj reference to its sym id
@@ -95,12 +107,15 @@ private:
 
 protected:
     /// Constructor
-    SymbolTableInfo() :
-        modelConstants(false), maxStruct(NULL), maxStSize(0)
-    {
-    }
+    SymbolTableInfo(void);
 
 public:
+    /// Option strings as written by the user.
+    ///@{
+    static const std::string userNodeAllocationStrategyDense;
+    static const std::string userNodeAllocationStrategyDebug;
+    ///@}
+
     /// Statistics
     //@{
     static SymID totalSymNum;

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -76,7 +76,7 @@ private:
     /// Data layout on a target machine
     static DataLayout *dl;
 
-    enum NodeAllocationStrategy allocStrat;
+    static enum NodeAllocationStrategy allocStrat;
 
     ValueToIDMapTy valSymMap;	///< map a value to its sym id
     ValueToIDMapTy objSymMap;	///< map a obj reference to its sym id

--- a/include/Util/NodeIDAllocator.h
+++ b/include/Util/NodeIDAllocator.h
@@ -1,0 +1,90 @@
+//===- NodeIDAllocator.h -- Allocates node IDs on request ------------------------//
+
+#ifndef NODEIDALLOCATOR_H_
+#define NODEIDALLOCATOR_H_
+
+#include "Util/SVFBasicTypes.h"
+
+namespace SVF
+{
+
+/// Allocates node IDs for objects and values, upon request, according to
+/// some strategy which can be user-defined.
+/// It is the job of SymbolTableInfo to tell the NodeIDAllocator when
+/// all symbols have been allocated through endSymbolAllocation.
+class NodeIDAllocator
+{
+public:
+    /// Allocation strategy to use.
+    enum Strategy
+    {
+        /// Used to initialise from llvm::cl::opt.
+        NONE,
+        /// Allocate objects contiguously, separate from values, and vice versa.
+        /// If [****...*****] is the space of unsigned integers, we allocate as,
+        /// [ssssooooooo...vvvvvvv] (o = object, v = value, s = special).
+        DENSE,
+        /// Allocate values and objects as they come in with a single counter.
+        /// GEP objects are allocated as an offset from their base (see implementation
+        /// of allocateGepObjectId). The purpose of this allocation strategy
+        /// is human readability.
+        DEBUG,
+    };
+
+    /// Option strings as written by the user.
+    ///@{
+    static const std::string userStrategyDense;
+    static const std::string userStrategyDebug;
+    ///@}
+
+    /// These nodes, and any nodes before them are assumed allocated
+    /// as objects and values. For simplicity's sake, numObjects and
+    /// numVals thus start at 4 (and the other counters are set
+    /// appropriately).
+    ///@{
+    static const NodeID blackHoleObjectId;
+    static const NodeID constantObjectId;
+    static const NodeID blackHolePointerId;
+    static const NodeID nullPointerId;
+    ///@}
+
+    /// Allocate an object ID as determined by the strategy.
+    static NodeID allocateObjectId(void);
+
+    /// Allocate a GEP object ID as determined by the strategy.
+    /// allocateObjectId is still fine for GEP objects, but
+    /// for some strategies (DEBUG, namely), GEP objects can
+    /// be allocated differently (more readable, for DEBUG).
+    /// Regardless, numObjects is shared; there is no special
+    /// numGepObjects.
+    static NodeID allocateGepObjectId(NodeID base, u32_t offset, u32_t maxFieldLimit);
+
+    /// Allocate a value ID as determined by the strategy.
+    static NodeID allocateValueId(void);
+
+    /// Notify the allocator that all symbols have had IDs allocated.
+    static void endSymbolAllocation(void);
+
+    /// Set the strategy from the user-facing strategy names.
+    static void setStrategy(std::string userStrategy);
+
+private:
+    /// These are moreso counters than amounts; they start from 0.
+    ///@{
+    /// Number of memory objects allocated.
+    static NodeID numObjects;
+    /// Number of values allocated.
+    static NodeID numValues;
+    /// Number of explicit symbols allocated (e.g., llvm::Values).
+    static NodeID numSymbols;
+    /// Total number of objects and values allocated.
+    static NodeID numNodes;
+    ///@}
+
+    /// Strategy to allocate with. Initially NONE.
+    static enum Strategy strategy;
+};
+
+};  // namespace SVF
+
+#endif  // ifdef NODEIDALLOCATOR_H_

--- a/include/Util/NodeIDAllocator.h
+++ b/include/Util/NodeIDAllocator.h
@@ -69,13 +69,13 @@ public:
     static void setStrategy(std::string userStrategy);
 
 private:
-    /// These are moreso counters than amounts; they start from 0.
+    /// These are moreso counters than amounts.
     ///@{
-    /// Number of memory objects allocated.
+    /// Number of memory objects allocated, including specials.
     static NodeID numObjects;
-    /// Number of values allocated.
+    /// Number of values allocated, including specials.
     static NodeID numValues;
-    /// Number of explicit symbols allocated (e.g., llvm::Values).
+    /// Number of explicit symbols allocated (e.g., llvm::Values), including specials.
     static NodeID numSymbols;
     /// Total number of objects and values allocated.
     static NodeID numNodes;

--- a/include/Util/NodeIDAllocator.h
+++ b/include/Util/NodeIDAllocator.h
@@ -48,8 +48,14 @@ public:
     static const NodeID nullPointerId;
     ///@}
 
+    /// Return (singleton) allocator.
+    static NodeIDAllocator *get(void);
+
+    /// Deletes the (singleton) allocator.
+    static void unset(void);
+
     /// Allocate an object ID as determined by the strategy.
-    static NodeID allocateObjectId(void);
+    NodeID allocateObjectId(void);
 
     /// Allocate a GEP object ID as determined by the strategy.
     /// allocateObjectId is still fine for GEP objects, but
@@ -57,32 +63,36 @@ public:
     /// be allocated differently (more readable, for DEBUG).
     /// Regardless, numObjects is shared; there is no special
     /// numGepObjects.
-    static NodeID allocateGepObjectId(NodeID base, u32_t offset, u32_t maxFieldLimit);
+    NodeID allocateGepObjectId(NodeID base, u32_t offset, u32_t maxFieldLimit);
 
     /// Allocate a value ID as determined by the strategy.
-    static NodeID allocateValueId(void);
+    NodeID allocateValueId(void);
 
     /// Notify the allocator that all symbols have had IDs allocated.
-    static void endSymbolAllocation(void);
+    void endSymbolAllocation(void);
 
-    /// Set the strategy from the user-facing strategy names.
-    static void setStrategy(std::string userStrategy);
+private:
+    /// Builds a node ID allocator with the strategy specified on the command line.
+    NodeIDAllocator(void);
 
 private:
     /// These are moreso counters than amounts.
     ///@{
     /// Number of memory objects allocated, including specials.
-    static NodeID numObjects;
+    NodeID numObjects;
     /// Number of values allocated, including specials.
-    static NodeID numValues;
+    NodeID numValues;
     /// Number of explicit symbols allocated (e.g., llvm::Values), including specials.
-    static NodeID numSymbols;
+    NodeID numSymbols;
     /// Total number of objects and values allocated.
-    static NodeID numNodes;
+    NodeID numNodes;
     ///@}
 
     /// Strategy to allocate with. Initially NONE.
-    static enum Strategy strategy;
+    enum Strategy strategy;
+
+    /// Single allocator.
+    static NodeIDAllocator *allocator;
 };
 
 };  // namespace SVF

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -634,6 +634,7 @@ NodeID PAG::addGepObjNode(const MemObj* obj, const LocationSet& ls)
     assert(0==GepObjNodeMap.count(std::make_pair(base, ls))
            && "this node should not be created before");
 
+    /* TODO: somehow make this work as an option...
     //for a gep id, base id is set at lower bits, and offset is set at higher bits
     //e.g. 1100050 denotes base=50 and offset=10
     // The offset is 10, not 11, because we add 1 to the offset to ensure that the
@@ -644,6 +645,8 @@ NodeID PAG::addGepObjNode(const MemObj* obj, const LocationSet& ls)
                                             getNodeNumAfterPAGBuild() : StInfo::getMaxFieldLimit()
                                         )));
     NodeID gepId = (ls.getOffset() + 1) * gepMultiplier + base;
+    */
+    NodeID gepId = SymbolTableInfo::newObjSymID();
     GepObjNodeMap[std::make_pair(base, ls)] = gepId;
     GepObjPN *node = new GepObjPN(obj, gepId, ls);
     memToFieldsMap[base].set(gepId);

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -634,19 +634,7 @@ NodeID PAG::addGepObjNode(const MemObj* obj, const LocationSet& ls)
     assert(0==GepObjNodeMap.count(std::make_pair(base, ls))
            && "this node should not be created before");
 
-    /* TODO: somehow make this work as an option...
-    //for a gep id, base id is set at lower bits, and offset is set at higher bits
-    //e.g. 1100050 denotes base=50 and offset=10
-    // The offset is 10, not 11, because we add 1 to the offset to ensure that the
-    // high bits are never 0. For example, we do not want the gep id to be 50 when
-    // the base is 50 and the offset is 0.
-    NodeID gepMultiplier = pow(10, ceil(log10(
-                                            getNodeNumAfterPAGBuild() > StInfo::getMaxFieldLimit() ?
-                                            getNodeNumAfterPAGBuild() : StInfo::getMaxFieldLimit()
-                                        )));
-    NodeID gepId = (ls.getOffset() + 1) * gepMultiplier + base;
-    */
-    NodeID gepId = SymbolTableInfo::newObjSymID();
+    NodeID gepId = SymbolTableInfo::newObjSymID(std::make_tuple(true, base, ls.getOffset()));
     GepObjNodeMap[std::make_pair(base, ls)] = gepId;
     GepObjPN *node = new GepObjPN(obj, gepId, ls);
     memToFieldsMap[base].set(gepId);

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -634,7 +634,7 @@ NodeID PAG::addGepObjNode(const MemObj* obj, const LocationSet& ls)
     assert(0==GepObjNodeMap.count(std::make_pair(base, ls))
            && "this node should not be created before");
 
-    NodeID gepId = NodeIDAllocator::allocateGepObjectId(base, ls.getOffset(), StInfo::getMaxFieldLimit());
+    NodeID gepId = NodeIDAllocator::get()->allocateGepObjectId(base, ls.getOffset(), StInfo::getMaxFieldLimit());
     GepObjNodeMap[std::make_pair(base, ls)] = gepId;
     GepObjPN *node = new GepObjPN(obj, gepId, ls);
     memToFieldsMap[base].set(gepId);

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -634,7 +634,7 @@ NodeID PAG::addGepObjNode(const MemObj* obj, const LocationSet& ls)
     assert(0==GepObjNodeMap.count(std::make_pair(base, ls))
            && "this node should not be created before");
 
-    NodeID gepId = SymbolTableInfo::newObjSymID(std::make_tuple(true, base, ls.getOffset()));
+    NodeID gepId = NodeIDAllocator::allocateGepObjectId(base, ls.getOffset(), StInfo::getMaxFieldLimit());
     GepObjNodeMap[std::make_pair(base, ls)] = gepId;
     GepObjPN *node = new GepObjPN(obj, gepId, ls);
     memToFieldsMap[base].set(gepId);

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -1382,7 +1382,7 @@ NodeID PAGBuilder::getGepValNode(const Value* val, const LocationSet& ls, const 
         const Value* cval = getCurrentValue();
         const BasicBlock* cbb = getCurrentBB();
         setCurrentLocation(curVal, NULL);
-        NodeID gepNode= pag->addGepValNode(curVal, val,ls, SymbolTableInfo::newValSymID(),type,fieldidx);
+        NodeID gepNode= pag->addGepValNode(curVal, val,ls, NodeIDAllocator::allocateValueId(),type,fieldidx);
         addGepEdge(base, gepNode, ls, true);
         setCurrentLocation(cval, cbb);
         return gepNode;

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -1382,7 +1382,7 @@ NodeID PAGBuilder::getGepValNode(const Value* val, const LocationSet& ls, const 
         const Value* cval = getCurrentValue();
         const BasicBlock* cbb = getCurrentBB();
         setCurrentLocation(curVal, NULL);
-        NodeID gepNode= pag->addGepValNode(curVal, val,ls, NodeIDAllocator::allocateValueId(),type,fieldidx);
+        NodeID gepNode= pag->addGepValNode(curVal, val,ls, NodeIDAllocator::get()->allocateValueId(),type,fieldidx);
         addGepEdge(base, gepNode, ls, true);
         setCurrentLocation(cval, cbb);
         return gepNode;

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -1363,7 +1363,7 @@ NodeID PAGBuilder::getGepValNode(const Value* val, const LocationSet& ls, const 
         const Value* cval = getCurrentValue();
         const BasicBlock* cbb = getCurrentBB();
         setCurrentLocation(curVal, NULL);
-        NodeID gepNode= pag->addGepValNode(curVal, val,ls,pag->getPAGNodeNum(),type,fieldidx);
+        NodeID gepNode= pag->addGepValNode(curVal, val,ls, SymbolTableInfo::newValSymID(),type,fieldidx);
         addGepEdge(base, gepNode, ls, true);
         setCurrentLocation(cval, cbb);
         return gepNode;

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -50,6 +50,8 @@ SymID SymbolTableInfo::totalValSymNum = 0;
 
 const std::string SymbolTableInfo::userNodeAllocationStrategyDense = "dense";
 const std::string SymbolTableInfo::userNodeAllocationStrategyDebug = "debug";
+enum SymbolTableInfo::NodeAllocationStrategy SymbolTableInfo::allocStrat =
+    SymbolTableInfo::NodeAllocationStrategy::DENSE;
 
 static llvm::cl::opt<unsigned> maxFieldNumLimit("fieldlimit",  llvm::cl::init(512),
         llvm::cl::desc("Maximum field number for field sensitive analysis"));

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -90,10 +90,6 @@ void MemObj::init(const Value *val)
     }
 }
 
-SymbolTableInfo::SymbolTableInfo(void)
-    : modelConstants(false), maxStruct(NULL), maxStSize(0)
-{ }
-
 /*!
  * Get the symbol table instance
  */

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -48,6 +48,9 @@ SymID SymbolTableInfo::totalSymNum = 0;
 SymID SymbolTableInfo::totalObjSymNum = 0;
 SymID SymbolTableInfo::totalValSymNum = 0;
 
+const std::string SymbolTableInfo::userNodeAllocationStrategyDense = "dense";
+const std::string SymbolTableInfo::userNodeAllocationStrategyDebug = "debug";
+
 static llvm::cl::opt<unsigned> maxFieldNumLimit("fieldlimit",  llvm::cl::init(512),
         llvm::cl::desc("Maximum field number for field sensitive analysis"));
 
@@ -57,7 +60,9 @@ static llvm::cl::opt<bool> LocMemModel("locMM", llvm::cl::init(false),
 static llvm::cl::opt<bool> modelConsts("modelConsts", llvm::cl::init(false),
                                        llvm::cl::desc("Modeling individual constant objects"));
 
-
+static llvm::cl::opt<std::string> nodeAllocationStrategy(
+    "node-alloc-strat", llvm::cl::init(SymbolTableInfo::userNodeAllocationStrategyDense),
+    llvm::cl::desc("Method of allocating (LLVM) values to node IDs"));
 
 /*
  * Initial the memory object here
@@ -91,6 +96,23 @@ void MemObj::init(const Value *val)
         writeWrnMsg(val->getName());
         writeWrnMsg("(" + getSourceLoc(val) + ")");
         assert(false && "Memory object must be held by a pointer-typed ref value.");
+    }
+}
+
+SymbolTableInfo::SymbolTableInfo(void)
+    : modelConstants(false), maxStruct(NULL), maxStSize(0)
+{
+    if (nodeAllocationStrategy == userNodeAllocationStrategyDense)
+    {
+        allocStrat = NodeAllocationStrategy::DENSE;
+    }
+    else if (nodeAllocationStrategy == userNodeAllocationStrategyDebug)
+    {
+        allocStrat = NodeAllocationStrategy::DEBUG;
+    }
+    else
+    {
+        assert(false && "Bad argument given to -node-alloc-strat; expected \"dense\" or \"debug\"");
     }
 }
 

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -45,6 +45,7 @@ using namespace SVFUtil;
 DataLayout* SymbolTableInfo::dl = NULL;
 SymbolTableInfo* SymbolTableInfo::symlnfo = NULL;
 SymID SymbolTableInfo::totalSymNum = 0;
+SymID SymbolTableInfo::totalObjSymNum = 0;
 
 static llvm::cl::opt<unsigned> maxFieldNumLimit("fieldlimit",  llvm::cl::init(512),
         llvm::cl::desc("Maximum field number for field sensitive analysis"));
@@ -470,6 +471,9 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule)
     assert(totalSymNum == NullPtr && "Something changed!");
     symTyMap.insert(std::make_pair(totalSymNum, NullPtr));
 
+    // Prevent objects from clashing with the special objects/pointers.
+    totalObjSymNum += 4;
+
     // Add symbols for all the globals .
     for (SVFModule::global_iterator I = svfModule->global_begin(), E =
                 svfModule->global_end(); I != E; ++I)
@@ -648,10 +652,11 @@ void SymbolTableInfo::collectVal(const Value *val)
     if (iter == valSymMap.end())
     {
         // create val sym and sym type
-        valSymMap.insert(std::make_pair(val, ++totalSymNum));
-        symTyMap.insert(std::make_pair(totalSymNum, ValSym));
+        SymID id = newValSymID();
+        valSymMap.insert(std::make_pair(val, id));
+        symTyMap.insert(std::make_pair(id, ValSym));
         DBOUT(DMemModel,
-              outs() << "create a new value sym " << totalSymNum << "\n");
+              outs() << "create a new value sym " << id << "\n");
         ///  handle global constant expression here
         if (const GlobalVariable* globalVar = SVFUtil::dyn_cast<GlobalVariable>(val))
             handleGlobalCE(globalVar);
@@ -679,15 +684,16 @@ void SymbolTableInfo::collectObj(const Value *val)
         else
         {
             // create obj sym and sym type
-            objSymMap.insert(std::make_pair(val, ++totalSymNum));
-            symTyMap.insert(std::make_pair(totalSymNum, ObjSym));
+            SymID id = newObjSymID();
+            objSymMap.insert(std::make_pair(val, id));
+            symTyMap.insert(std::make_pair(id, ObjSym));
             DBOUT(DMemModel,
-                  outs() << "create a new obj sym " << totalSymNum << "\n");
+                  outs() << "create a new obj sym " << id << "\n");
 
             // create a memory object
-            MemObj* mem = new MemObj(val, totalSymNum);
-            assert(objMap.find(totalSymNum) == objMap.end());
-            objMap[totalSymNum] = mem;
+            MemObj* mem = new MemObj(val, id);
+            assert(objMap.find(id) == objMap.end());
+            objMap[id] = mem;
         }
     }
 }
@@ -700,10 +706,11 @@ void SymbolTableInfo::collectRet(const Function *val)
     FunToIDMapTy::iterator iter = returnSymMap.find(val);
     if (iter == returnSymMap.end())
     {
-        returnSymMap.insert(std::make_pair(val, ++totalSymNum));
-        symTyMap.insert(std::make_pair(totalSymNum, RetSym));
+        SymID id = newValSymID();
+        returnSymMap.insert(std::make_pair(val, id));
+        symTyMap.insert(std::make_pair(id, RetSym));
         DBOUT(DMemModel,
-              outs() << "create a return sym " << totalSymNum << "\n");
+              outs() << "create a return sym " << id << "\n");
     }
 }
 
@@ -715,11 +722,29 @@ void SymbolTableInfo::collectVararg(const Function *val)
     FunToIDMapTy::iterator iter = varargSymMap.find(val);
     if (iter == varargSymMap.end())
     {
-        varargSymMap.insert(std::make_pair(val, ++totalSymNum));
-        symTyMap.insert(std::make_pair(totalSymNum, VarargSym));
+        SymID id = newValSymID();
+        varargSymMap.insert(std::make_pair(val, id));
+        symTyMap.insert(std::make_pair(id, VarargSym));
         DBOUT(DMemModel,
-              outs() << "create a vararg sym " << totalSymNum << "\n");
+              outs() << "create a vararg sym " << id << "\n");
     }
+}
+
+SymID SymbolTableInfo::newObjSymID(void)
+{
+    ++totalObjSymNum;
+    ++totalSymNum;
+    // We allocate objects from 0 to # of objects.
+    return totalObjSymNum;
+}
+
+SymID SymbolTableInfo::newValSymID(void)
+{
+    ++totalSymNum;
+    // We allocate values from UINT_MAX to UINT_MAX - # of values.
+    // TODO: UINT_MAX does not allow for an easily changeable type
+    //       of SymID (though it is already in use elsewhere).
+    return UINT_MAX - totalSymNum;
 }
 
 /*!

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -803,10 +803,22 @@ SymID SymbolTableInfo::newValSymID(void)
 {
     ++totalValSymNum;
     ++totalSymNum;
-    // We allocate values from UINT_MAX to UINT_MAX - # of values.
-    // TODO: UINT_MAX does not allow for an easily changeable type
-    //       of SymID (though it is already in use elsewhere).
-    return UINT_MAX - totalValSymNum;
+
+    if (allocStrat == NodeAllocationStrategy::DEBUG)
+    {
+        return totalSymNum;
+    }
+    else if (allocStrat == NodeAllocationStrategy::DENSE)
+    {
+        // We allocate values from UINT_MAX to UINT_MAX - # of values.
+        // TODO: UINT_MAX does not allow for an easily changeable type
+        //       of SymID (though it is already in use elsewhere).
+        return UINT_MAX - totalValSymNum;
+    }
+    else
+    {
+        assert(false && "SymbolTableInfo::newValSymID: unimplemented node allocation strategy");
+    }
 }
 
 /*!

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -30,6 +30,7 @@
 
 #include "SVF-FE/SymbolTableInfo.h"
 #include "MemoryModel/MemModel.h"
+#include "Util/NodeIDAllocator.h"
 #include "Util/SVFModule.h"
 #include "Util/SVFUtil.h"
 #include "SVF-FE/LLVMUtil.h"
@@ -589,7 +590,7 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule)
         }
     }
 
-    NodeIDAllocator::endSymbolAllocation();
+    NodeIDAllocator::get()->endSymbolAllocation();
 }
 
 /*!
@@ -648,7 +649,7 @@ void SymbolTableInfo::collectVal(const Value *val)
     if (iter == valSymMap.end())
     {
         // create val sym and sym type
-        SymID id = NodeIDAllocator::allocateValueId();
+        SymID id = NodeIDAllocator::get()->allocateValueId();
         valSymMap.insert(std::make_pair(val, id));
         symTyMap.insert(std::make_pair(id, ValSym));
         DBOUT(DMemModel,
@@ -680,7 +681,7 @@ void SymbolTableInfo::collectObj(const Value *val)
         else
         {
             // create obj sym and sym type
-            SymID id = NodeIDAllocator::allocateObjectId();
+            SymID id = NodeIDAllocator::get()->allocateObjectId();
             objSymMap.insert(std::make_pair(val, id));
             symTyMap.insert(std::make_pair(id, ObjSym));
             DBOUT(DMemModel,
@@ -702,7 +703,7 @@ void SymbolTableInfo::collectRet(const Function *val)
     FunToIDMapTy::iterator iter = returnSymMap.find(val);
     if (iter == returnSymMap.end())
     {
-        SymID id = NodeIDAllocator::allocateValueId();
+        SymID id = NodeIDAllocator::get()->allocateValueId();
         returnSymMap.insert(std::make_pair(val, id));
         symTyMap.insert(std::make_pair(id, RetSym));
         DBOUT(DMemModel,
@@ -718,7 +719,7 @@ void SymbolTableInfo::collectVararg(const Function *val)
     FunToIDMapTy::iterator iter = varargSymMap.find(val);
     if (iter == varargSymMap.end())
     {
-        SymID id = NodeIDAllocator::allocateValueId();
+        SymID id = NodeIDAllocator::get()->allocateValueId();
         varargSymMap.insert(std::make_pair(val, id));
         symTyMap.insert(std::make_pair(id, VarargSym));
         DBOUT(DMemModel,

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -46,6 +46,7 @@ DataLayout* SymbolTableInfo::dl = NULL;
 SymbolTableInfo* SymbolTableInfo::symlnfo = NULL;
 SymID SymbolTableInfo::totalSymNum = 0;
 SymID SymbolTableInfo::totalObjSymNum = 0;
+SymID SymbolTableInfo::totalValSymNum = 0;
 
 static llvm::cl::opt<unsigned> maxFieldNumLimit("fieldlimit",  llvm::cl::init(512),
         llvm::cl::desc("Maximum field number for field sensitive analysis"));
@@ -471,8 +472,10 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule)
     assert(totalSymNum == NullPtr && "Something changed!");
     symTyMap.insert(std::make_pair(totalSymNum, NullPtr));
 
-    // Prevent objects from clashing with the special objects/pointers.
+    // Prevent clashing with the special objects/pointers.
+    // totalSymNum was already incremented.
     totalObjSymNum += 4;
+    totalValSymNum += 4;
 
     // Add symbols for all the globals .
     for (SVFModule::global_iterator I = svfModule->global_begin(), E =
@@ -740,11 +743,12 @@ SymID SymbolTableInfo::newObjSymID(void)
 
 SymID SymbolTableInfo::newValSymID(void)
 {
+    ++totalValSymNum;
     ++totalSymNum;
     // We allocate values from UINT_MAX to UINT_MAX - # of values.
     // TODO: UINT_MAX does not allow for an easily changeable type
     //       of SymID (though it is already in use elsewhere).
-    return UINT_MAX - totalSymNum;
+    return UINT_MAX - totalValSymNum;
 }
 
 /*!

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -47,6 +47,7 @@ SymbolTableInfo* SymbolTableInfo::symlnfo = NULL;
 SymID SymbolTableInfo::totalSymNum = 0;
 SymID SymbolTableInfo::totalObjSymNum = 0;
 SymID SymbolTableInfo::totalValSymNum = 0;
+SymID SymbolTableInfo::totalBaseSymNum = 0;
 
 const std::string SymbolTableInfo::userNodeAllocationStrategyDense = "dense";
 const std::string SymbolTableInfo::userNodeAllocationStrategyDebug = "debug";
@@ -621,6 +622,8 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule)
             //@}
         }
     }
+
+    totalBaseSymNum = totalSymNum;
 }
 
 /*!
@@ -787,8 +790,8 @@ SymID SymbolTableInfo::newObjSymID(std::tuple<bool, NodeID, u32_t> gepMeta)
             // high bits are never 0. For example, we do not want the gep id to be 50 when
             // the base is 50 and the offset is 0.
             NodeID gepMultiplier = pow(10, ceil(log10(
-                                                    totalSymNum > StInfo::getMaxFieldLimit() ?
-                                                    totalSymNum : StInfo::getMaxFieldLimit()
+                                                    totalBaseSymNum > StInfo::getMaxFieldLimit() ?
+                                                    totalBaseSymNum : StInfo::getMaxFieldLimit()
                                                 )));
             return (offset + 1) * gepMultiplier + base;
         }

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -807,16 +807,16 @@ SymID SymbolTableInfo::newValSymID(void)
     ++totalValSymNum;
     ++totalSymNum;
 
-    if (allocStrat == NodeAllocationStrategy::DEBUG)
-    {
-        return totalSymNum;
-    }
-    else if (allocStrat == NodeAllocationStrategy::DENSE)
+    if (allocStrat == NodeAllocationStrategy::DENSE)
     {
         // We allocate values from UINT_MAX to UINT_MAX - # of values.
         // TODO: UINT_MAX does not allow for an easily changeable type
         //       of SymID (though it is already in use elsewhere).
         return UINT_MAX - totalValSymNum;
+    }
+    else if (allocStrat == NodeAllocationStrategy::DEBUG)
+    {
+        return totalSymNum;
     }
     else
     {

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -1,0 +1,120 @@
+//===- NodeIDAllocator.cpp -- Allocates node IDs on request ------------------------//
+
+#include "Util/NodeIDAllocator.h"
+
+static llvm::cl::opt<std::string> nodeAllocStrat(
+    "node-alloc-strat", llvm::cl::init(SVF::NodeIDAllocator::userStrategyDense),
+    llvm::cl::desc("Method of allocating (LLVM) values to node IDs [dense, debug]"));
+
+
+namespace SVF
+{
+    NodeID NodeIDAllocator::numObjects = 3;
+    NodeID NodeIDAllocator::numValues = 3;
+    NodeID NodeIDAllocator::numSymbols = 3;
+    NodeID NodeIDAllocator::numNodes = 4;
+
+    enum NodeIDAllocator::Strategy NodeIDAllocator::strategy = NodeIDAllocator::Strategy::NONE;
+
+    const std::string NodeIDAllocator::userStrategyDense = "dense";
+    const std::string NodeIDAllocator::userStrategyDebug = "debug";
+
+    const NodeID NodeIDAllocator::blackHoleObjectId = 0;
+    const NodeID NodeIDAllocator::constantObjectId = 1;
+    const NodeID NodeIDAllocator::blackHolePointerId = 2;
+    const NodeID NodeIDAllocator::nullPointerId = 3;
+
+    NodeID NodeIDAllocator::allocateObjectId(void)
+    {
+        if (strategy == Strategy::NONE) setStrategy(nodeAllocStrat);
+
+        ++numNodes;
+        ++numObjects;
+
+        if (strategy == Strategy::DENSE)
+        {
+            // We allocate objects from 0(-ish, considering the special nodes) to # of objects.
+            return numObjects;
+        }
+        else if (strategy == Strategy::DEBUG)
+        {
+            // Non-GEPs just grab the next available ID.
+            // We may have "holes" because GEPs increment the total
+            // but allocate far away. This is not a problem because
+            // we don't care about the relative distances between nodes.
+            return numNodes;
+        }
+        else
+        {
+            assert(false && "NodeIDAllocator::allocateObjectId: unimplemented node allocation strategy.");
+        }
+    }
+
+    NodeID NodeIDAllocator::allocateGepObjectId(NodeID base, u32_t offset, u32_t maxFieldLimit)
+    {
+        if (strategy == Strategy::NONE) setStrategy(nodeAllocStrat);
+
+        ++numNodes;
+        ++numObjects;
+
+        if (strategy == Strategy::DENSE)
+        {
+            // Nothing different to the other case.
+            return numNodes;
+        }
+        else if (strategy == Strategy::DEBUG)
+        {
+            // For a gep id, base id is set at lower bits, and offset is set at higher bits
+            // e.g., 1100050 denotes base=50 and offset=10
+            // The offset is 10, not 11, because we add 1 to the offset to ensure that the
+            // high bits are never 0. For example, we do not want the gep id to be 50 when
+            // the base is 50 and the offset is 0.
+            NodeID gepMultiplier = pow(10, ceil(log10(
+                                                    numSymbols > maxFieldLimit ?
+                                                    numSymbols : maxFieldLimit
+                                                )));
+            return (offset + 1) * gepMultiplier + base;
+        }
+        else
+        {
+            assert(false && "NodeIDAllocator::allocateGepObjectId: unimplemented node allocation strategy");
+        }
+    }
+
+    NodeID NodeIDAllocator::allocateValueId(void)
+    {
+        if (strategy == Strategy::NONE) setStrategy(nodeAllocStrat);
+
+        ++numValues;
+        ++numNodes;
+
+        if (strategy == Strategy::DENSE)
+        {
+            // We allocate values from UINT_MAX to UINT_MAX - # of values.
+            // TODO: UINT_MAX does not allow for an easily changeable type
+            //       of NodeID (though it is already in use elsewhere).
+            return UINT_MAX - numValues;
+        }
+        else if (strategy == Strategy::DEBUG)
+        {
+            return numNodes;
+        }
+        else
+        {
+            assert(false && "NodeIDAllocator::allocateValueId: unimplemented node allocation strategy");
+        }
+    }
+
+    void NodeIDAllocator::setStrategy(std::string userStrategy)
+    {
+        if (userStrategy == userStrategyDebug) strategy = Strategy::DEBUG;
+        else if (userStrategy == userStrategyDense) strategy = Strategy::DENSE;
+        else assert(false && "Unknown node allocation strategy specified; expected \"dense\" or \"debug\"");
+    }
+
+    void NodeIDAllocator::endSymbolAllocation(void)
+    {
+        numSymbols = numNodes;
+    }
+
+};  // namespace SVF.

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -2,11 +2,6 @@
 
 #include "Util/NodeIDAllocator.h"
 
-static llvm::cl::opt<std::string> nodeAllocStrat(
-    "node-alloc-strat", llvm::cl::init(SVF::NodeIDAllocator::userStrategyDense),
-    llvm::cl::desc("Method of allocating (LLVM) values to node IDs [dense, debug]"));
-
-
 namespace SVF
 {
     NodeID NodeIDAllocator::numObjects = 3;
@@ -23,6 +18,10 @@ namespace SVF
     const NodeID NodeIDAllocator::constantObjectId = 1;
     const NodeID NodeIDAllocator::blackHolePointerId = 2;
     const NodeID NodeIDAllocator::nullPointerId = 3;
+
+    static llvm::cl::opt<std::string> nodeAllocStrat(
+        "node-alloc-strat", llvm::cl::init(SVF::NodeIDAllocator::userStrategyDense),
+        llvm::cl::desc("Method of allocating (LLVM) values to node IDs [dense, debug]"));
 
     NodeID NodeIDAllocator::allocateObjectId(void)
     {

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -108,7 +108,7 @@ namespace SVF
     {
         if (userStrategy == userStrategyDebug) strategy = Strategy::DEBUG;
         else if (userStrategy == userStrategyDense) strategy = Strategy::DENSE;
-        else assert(false && "Unknown node allocation strategy specified; expected \"dense\" or \"debug\"");
+        else assert(false && "Unknown node allocation strategy specified; expected 'dense' or 'debug'");
     }
 
     void NodeIDAllocator::endSymbolAllocation(void)

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -59,7 +59,7 @@ namespace SVF
         if (strategy == Strategy::DENSE)
         {
             // Nothing different to the other case.
-            return numNodes;
+            return numObjects;
         }
         else if (strategy == Strategy::DEBUG)
         {

--- a/lib/Util/TypeBasedHeapCloning.cpp
+++ b/lib/Util/TypeBasedHeapCloning.cpp
@@ -500,19 +500,19 @@ const MDNode *TypeBasedHeapCloning::getRawCTirMetadata(const Value *v)
 
 NodeID TypeBasedHeapCloning::addCloneDummyObjNode(const MemObj *mem)
 {
-    NodeID id = SymbolTableInfo::newObjSymID();
+    NodeID id = NodeIDAllocator::allocateObjectId();
     return ppag->addObjNode(NULL, new CloneDummyObjPN(id, mem), id);
 }
 
 NodeID TypeBasedHeapCloning::addCloneGepObjNode(const MemObj *mem, const LocationSet &l)
 {
-    NodeID id = SymbolTableInfo::newObjSymID();
+    NodeID id = NodeIDAllocator::allocateObjectId();
     return ppag->addObjNode(mem->getRefVal(), new CloneGepObjPN(mem, id, l), id);
 }
 
 NodeID TypeBasedHeapCloning::addCloneFIObjNode(const MemObj *mem)
 {
-    NodeID id = SymbolTableInfo::newObjSymID();
+    NodeID id = NodeIDAllocator::allocateObjectId();
     return ppag->addObjNode(mem->getRefVal(), new CloneFIObjPN(mem->getRefVal(), id, mem), id);
 }
 

--- a/lib/Util/TypeBasedHeapCloning.cpp
+++ b/lib/Util/TypeBasedHeapCloning.cpp
@@ -500,19 +500,19 @@ const MDNode *TypeBasedHeapCloning::getRawCTirMetadata(const Value *v)
 
 NodeID TypeBasedHeapCloning::addCloneDummyObjNode(const MemObj *mem)
 {
-    NodeID id = NodeIDAllocator::allocateObjectId();
+    NodeID id = NodeIDAllocator::get()->allocateObjectId();
     return ppag->addObjNode(NULL, new CloneDummyObjPN(id, mem), id);
 }
 
 NodeID TypeBasedHeapCloning::addCloneGepObjNode(const MemObj *mem, const LocationSet &l)
 {
-    NodeID id = NodeIDAllocator::allocateObjectId();
+    NodeID id = NodeIDAllocator::get()->allocateObjectId();
     return ppag->addObjNode(mem->getRefVal(), new CloneGepObjPN(mem, id, l), id);
 }
 
 NodeID TypeBasedHeapCloning::addCloneFIObjNode(const MemObj *mem)
 {
-    NodeID id = NodeIDAllocator::allocateObjectId();
+    NodeID id = NodeIDAllocator::get()->allocateObjectId();
     return ppag->addObjNode(mem->getRefVal(), new CloneFIObjPN(mem->getRefVal(), id, mem), id);
 }
 

--- a/lib/Util/TypeBasedHeapCloning.cpp
+++ b/lib/Util/TypeBasedHeapCloning.cpp
@@ -500,19 +500,19 @@ const MDNode *TypeBasedHeapCloning::getRawCTirMetadata(const Value *v)
 
 NodeID TypeBasedHeapCloning::addCloneDummyObjNode(const MemObj *mem)
 {
-    NodeID id = ppag->getPAGNodeNum();
+    NodeID id = SymbolTableInfo::newObjSymID();
     return ppag->addObjNode(NULL, new CloneDummyObjPN(id, mem), id);
 }
 
 NodeID TypeBasedHeapCloning::addCloneGepObjNode(const MemObj *mem, const LocationSet &l)
 {
-    NodeID id = ppag->getPAGNodeNum();
+    NodeID id = SymbolTableInfo::newObjSymID();
     return ppag->addObjNode(mem->getRefVal(), new CloneGepObjPN(mem, id, l), id);
 }
 
 NodeID TypeBasedHeapCloning::addCloneFIObjNode(const MemObj *mem)
 {
-    NodeID id = ppag->getPAGNodeNum();
+    NodeID id = SymbolTableInfo::newObjSymID();
     return ppag->addObjNode(mem->getRefVal(), new CloneFIObjPN(mem->getRefVal(), id, mem), id);
 }
 


### PR DESCRIPTION
This PR introduces dense node ID allocation, keeping the old allocation as an option.

Dense allocation:
Allocates all objects in a cluster, and all values in a cluster. This makes points-to sets more compact. This is the extent of the heuristic, however you should see good memory and time improvements, even in Andersen's.

Debug allocation:
The old allocation: objects and values are interleaved and GEPs use the multiplier.

New option is `-node-alloc-strat` and takes either `debug` or `dense` and defaults to `dense`. Node ID allocation is separated from the symbol table and used in multiple places.