### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -288,7 +288,8 @@ public:
     inline const typename MutPTDataTy::PtsMap& getPtsMap() const
     {
         if (MutPTDataTy *m = SVFUtil::dyn_cast<MutPTDataTy>(ptD)) return m->getPtsMap();
-        else assert(false && "CondPTAImpl::getPtsMap: not a PTData with a PtsMap!");
+        assert(false && "CondPTAImpl::getPtsMap: not a PTData with a PtsMap!");
+        exit(1);
     }
 
     /// Get points-to and reverse points-to

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -1145,10 +1145,9 @@ struct DOTGraphTraits<PAG*> : public DefaultDOTGraphTraits
         {
             return "color=black,style=dotted";
         }
-        else
-        {
-            assert(0 && "No such kind edge!!");
-        }
+
+        assert(false && "No such kind edge!!");
+        exit(1);
     }
 
     template<class EdgeIter>


### PR DESCRIPTION
GCC 9.3 is complaining about reaching the end of a non-void function.