### PR TITLE
Removed redundant destroy()

### DIFF
--- a/include/Graphs/ICFG.h
+++ b/include/Graphs/ICFG.h
@@ -76,7 +76,6 @@ public:
     /// Destructor
     virtual ~ICFG()
     {
-        destroy();
     }
 
     /// Get a ICFG node


### PR DESCRIPTION
In ICFG's parent class GenericGraph, destroy() has been called once. In child's virtual destructor, we don't need to call it again since parent destructor will do that. 