### PR TITLE
Small fixes

### DIFF
--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -96,7 +96,7 @@ void AndersenBase::finalize()
 
 	if (PrintCGGraph)
 		consCG->print();
-    PointerAnalysis::finalize();
+    BVDataPTAImpl::finalize();
 }
 
 

--- a/lib/WPA/Steensgaard.cpp
+++ b/lib/WPA/Steensgaard.cpp
@@ -10,6 +10,8 @@
 using namespace SVF;
 using namespace SVFUtil;
 
+Steensgaard *Steensgaard::steens = nullptr;
+
 /*!
  * Steensgaard analysis
  */


### PR DESCRIPTION
I did a bit of profiling of the normalisation code. Since I can't run any huge benchmarks, I didn't see any difference not-within-a-margin-of-error when following a `processGepPts` style. It might be fine as is. However, it wasn't being run because the wrong parent's finalize was being called.

I've also initialised `steens`.