### PR TITLE
Add new node allocation strategy

### DIFF
--- a/include/Util/NodeIDAllocator.h
+++ b/include/Util/NodeIDAllocator.h
@@ -31,12 +31,6 @@ public:
         DEBUG,
     };
 
-    /// Option strings as written by the user.
-    ///@{
-    static const std::string userStrategyDense;
-    static const std::string userStrategyDebug;
-    ///@}
-
     /// These nodes, and any nodes before them are assumed allocated
     /// as objects and values. For simplicity's sake, numObjects and
     /// numVals thus start at 4 (and the other counters are set
@@ -88,7 +82,7 @@ private:
     NodeID numNodes;
     ///@}
 
-    /// Strategy to allocate with. Initially NONE.
+    /// Strategy to allocate with.
     enum Strategy strategy;
 
     /// Single allocator.

--- a/include/Util/NodeIDAllocator.h
+++ b/include/Util/NodeIDAllocator.h
@@ -18,12 +18,12 @@ public:
     /// Allocation strategy to use.
     enum Strategy
     {
-        /// Used to initialise from llvm::cl::opt.
-        NONE,
         /// Allocate objects contiguously, separate from values, and vice versa.
         /// If [****...*****] is the space of unsigned integers, we allocate as,
         /// [ssssooooooo...vvvvvvv] (o = object, v = value, s = special).
         DENSE,
+        /// Allocate objects objects and values sequentially, intermixed.
+        SEQ,
         /// Allocate values and objects as they come in with a single counter.
         /// GEP objects are allocated as an offset from their base (see implementation
         /// of allocateGepObjectId). The purpose of this allocation strategy

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -13,7 +13,7 @@ namespace SVF
 
     static llvm::cl::opt<NodeIDAllocator::Strategy> nodeAllocStrat(
         "node-alloc-strat", llvm::cl::init(SVF::NodeIDAllocator::Strategy::DENSE),
-        llvm::cl::desc("Method of allocating (LLVM) values to node IDs"),
+        llvm::cl::desc("Method of allocating (LLVM) values and memory objects as node IDs"),
         llvm::cl::values(
             clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately"),
             clEnumValN(NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets")

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -16,6 +16,7 @@ namespace SVF
         llvm::cl::desc("Method of allocating (LLVM) values and memory objects as node IDs"),
         llvm::cl::values(
             clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately"),
+            clEnumValN(NodeIDAllocator::Strategy::SEQ, "seq", "allocate values and objects sequentially, intermixed"),
             clEnumValN(NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets")
         ));
 
@@ -50,6 +51,11 @@ namespace SVF
             // We allocate objects from 0(-ish, considering the special nodes) to # of objects.
             id = numObjects;
         }
+        else if (strategy == Strategy::SEQ)
+        {
+            // Everything is sequential and intermixed.
+            id = numNodes;
+        }
         else if (strategy == Strategy::DEBUG)
         {
             // Non-GEPs just grab the next available ID.
@@ -77,6 +83,11 @@ namespace SVF
         {
             // Nothing different to the other case.
             id =  numObjects;
+        }
+        else if (strategy == Strategy::SEQ)
+        {
+            // Everything is sequential and intermixed.
+            id = numNodes;
         }
         else if (strategy == Strategy::DEBUG)
         {
@@ -113,6 +124,11 @@ namespace SVF
             // TODO: UINT_MAX does not allow for an easily changeable type
             //       of NodeID (though it is already in use elsewhere).
             id = UINT_MAX - numValues;
+        }
+        else if (strategy == Strategy::SEQ)
+        {
+            // Everything is sequential and intermixed.
+            id = numNodes;
         }
         else if (strategy == Strategy::DEBUG)
         {


### PR DESCRIPTION
This adds a new node allocation strategy, `seq`, which just allocates _everything_ sequentially, so like the `debug` strategy but allocates GEPs sequentially too.

I also moved the option code to `clEnum`.