### PR TITLE
Make options global

### DIFF
--- a/include/MemoryModel/PTAStat.h
+++ b/include/MemoryModel/PTAStat.h
@@ -31,6 +31,7 @@
 #define ANDERSENSTAT_H_
 
 #include "Util/BasicTypes.h"
+#include "Util/Options.h"
 #include <iostream>
 #include <map>
 #include <string>
@@ -117,22 +118,12 @@ public:
 
     static const char* NumOfNullPointer;	///< Number of pointers points-to null
 
-    /// If set, only return the clock when getClk is called as getClk(true).
-    /// Retrieving the clock is slow but it should be fine for a few calls.
-    /// This is good for benchmarking when we don't need to know how long processLoad
-    /// takes, for example (many calls), but want to know things like total solve time.
-    /// Does not affect CLOCK_IN_MS.
-    static bool markedClocksOnly;
-
     typedef Map<const char*,u32_t> NUMStatMap;
 
     typedef Map<const char*,double> TIMEStatMap;
 
     PTAStat(PointerAnalysis* p);
     virtual ~PTAStat() {}
-
-    /// Sets setMarkedClocksOnly through MarkedClocksOnly in PTAStat.cpp.
-    static void setMarkedClocksOnly(void);
 
     virtual inline void startClk()
     {
@@ -143,13 +134,11 @@ public:
         endTime = CLOCK_IN_MS();
     }
     /// When mark is true, real clock is always returned. When mark is false, it is
-    /// only returned when markedClocksOnly is not set; this is the default case.
+    /// only returned when Options::MarkedClocksOnly is not set.
+    /// Default call for getClk is unmarked, while MarkedClocksOnly is false by default.
     static inline double getClk(bool mark=false)
     {
-        // Unideal, but should have no effects on performance, compiler should be smart enough
-        // to inline. It would be best if the global MarkedClocksOnly was directly accessible here.
-        setMarkedClocksOnly();
-        if (markedClocksOnly && !mark) return 0.0;
+        if (Options::MarkedClocksOnly && !mark) return 0.0;
         return CLOCK_IN_MS();
     }
 

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -11,6 +11,13 @@ class Options
 {
 public:
     Options(void) = delete;
+
+    /// If set, only return the clock when getClk is called as getClk(true).
+    /// Retrieving the clock is slow but it should be fine for a few calls.
+    /// This is good for benchmarking when we don't need to know how long processLoad
+    /// takes, for example (many calls), but want to know things like total solve time.
+    /// Should be used only to affect getClk, not CLOCK_IN_MS.
+    static const llvm::cl::opt<bool> MarkedClocksOnly;
 };
 
 };  // namespace SVF

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -24,6 +24,9 @@ public:
     /// Allocation strategy to be used by the node ID allocator.
     /// Currently dense, seq, or debug.
     static const llvm::cl::opt<SVF::NodeIDAllocator::Strategy> NodeAllocStrat;
+
+    /// Maximum number of field derivations for an object.
+    static const llvm::cl::opt<unsigned> MaxFieldLimit;
 };
 
 };  // namespace SVF

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -6,21 +6,11 @@
 namespace SVF
 {
 
-/// Carries around command line options. To be used a singleton.
+/// Carries around command line options.
 class Options
 {
 public:
-    /// Return (singleton) Options instance with all options set.
-    static const Options *get(void);
-
-private:
-    /// Fills all fields from llvm::cl::opt.
-    Options(void);
-
-public:
-
-private:
-    static const Options *options;
+    Options(void) = delete;
 };
 
 };  // namespace SVF

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -1,0 +1,28 @@
+//===- Options.h -- Command line options ------------------------//
+
+#ifndef OPTIONS_H_
+#define OPTIONS_H_
+
+namespace SVF
+{
+
+/// Carries around command line options. To be used a singleton.
+class Options
+{
+public:
+    /// Return (singleton) Options instance with all options set.
+    static const Options *get(void);
+
+private:
+    /// Fills all fields from llvm::cl::opt.
+    Options(void);
+
+public:
+
+private:
+    static const Options *options;
+};
+
+};  // namespace SVF
+
+#endif  // ifdef OPTIONS_H_

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -3,6 +3,8 @@
 #ifndef OPTIONS_H_
 #define OPTIONS_H_
 
+#include "Util/NodeIDAllocator.h"
+
 namespace SVF
 {
 
@@ -18,6 +20,10 @@ public:
     /// takes, for example (many calls), but want to know things like total solve time.
     /// Should be used only to affect getClk, not CLOCK_IN_MS.
     static const llvm::cl::opt<bool> MarkedClocksOnly;
+
+    /// Allocation strategy to be used by the node ID allocator.
+    /// Currently dense, seq, or debug.
+    static const llvm::cl::opt<SVF::NodeIDAllocator::Strategy> NodeAllocStrat;
 };
 
 };  // namespace SVF

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -33,6 +33,7 @@
 #include "SVF-FE/SymbolTableInfo.h"
 #include "MemoryModel/MemModel.h"
 #include "Util/NodeIDAllocator.h"
+#include "Util/Options.h"
 #include "Util/SVFModule.h"
 #include "Util/SVFUtil.h"
 #include "SVF-FE/LLVMUtil.h"
@@ -47,9 +48,6 @@ using namespace SVFUtil;
 
 DataLayout* SymbolTableInfo::dl = NULL;
 SymbolTableInfo* SymbolTableInfo::symInfo = NULL;
-
-static llvm::cl::opt<unsigned> maxFieldNumLimit("fieldlimit",  llvm::cl::init(512),
-        llvm::cl::desc("Maximum field number for field sensitive analysis"));
 
 static llvm::cl::opt<bool> LocMemModel("locMM", llvm::cl::init(false),
                                        llvm::cl::desc("Bytes/bits modeling of memory locations"));
@@ -78,9 +76,9 @@ void MemObj::init(const Value *val)
     {
         Type *objTy = refTy->getElementType();
         if(LocMemModel)
-            typeInfo = new LocObjTypeInfo(val, objTy, maxFieldNumLimit);
+            typeInfo = new LocObjTypeInfo(val, objTy, Options::MaxFieldLimit);
         else
-            typeInfo = new ObjTypeInfo(val, objTy, maxFieldNumLimit);
+            typeInfo = new ObjTypeInfo(val, objTy, Options::MaxFieldLimit);
         typeInfo->init(val);
     }
     else
@@ -451,7 +449,7 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule)
 
     mod = svfModule;
 
-    StInfo::setMaxFieldLimit(maxFieldNumLimit);
+    StInfo::setMaxFieldLimit(Options::MaxFieldLimit);
 
     // Object #0 is black hole the object that may point to any object
     assert(totalSymNum == BlackHole && "Something changed!");

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -1,6 +1,7 @@
 //===- NodeIDAllocator.cpp -- Allocates node IDs on request ------------------------//
 
 #include "Util/NodeIDAllocator.h"
+#include "Util/Options.h"
 
 namespace SVF
 {
@@ -10,15 +11,6 @@ namespace SVF
     const NodeID NodeIDAllocator::nullPointerId = 3;
 
     NodeIDAllocator *NodeIDAllocator::allocator = nullptr;
-
-    static llvm::cl::opt<NodeIDAllocator::Strategy> nodeAllocStrat(
-        "node-alloc-strat", llvm::cl::init(SVF::NodeIDAllocator::Strategy::DENSE),
-        llvm::cl::desc("Method of allocating (LLVM) values and memory objects as node IDs"),
-        llvm::cl::values(
-            clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately"),
-            clEnumValN(NodeIDAllocator::Strategy::SEQ, "seq", "allocate values and objects sequentially, intermixed"),
-            clEnumValN(NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets")
-        ));
 
     NodeIDAllocator *NodeIDAllocator::get(void)
     {
@@ -40,7 +32,7 @@ namespace SVF
 
     // Initialise counts to 4 because that's how many special nodes we have.
     NodeIDAllocator::NodeIDAllocator(void)
-        : numNodes(4), numObjects(4), numValues(4), numSymbols(4), strategy(nodeAllocStrat)
+        : numNodes(4), numObjects(4), numValues(4), numSymbols(4), strategy(Options::NodeAllocStrat)
     { }
 
     NodeID NodeIDAllocator::allocateObjectId(void)

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -23,4 +23,11 @@ namespace SVF
         )
     );
 
+
+    const llvm::cl::opt<unsigned> Options::MaxFieldLimit(
+        "fieldlimit",
+        llvm::cl::init(512),
+        llvm::cl::desc("Maximum number of fields for field sensitive analysis")
+    );
+
 };  // namespace SVF.

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -6,6 +6,8 @@
 
 namespace SVF
 {
+    const Options *Options::options = nullptr;
+
     const Options *Options::get(void)
     {
         if (options == nullptr)

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -6,4 +6,11 @@
 
 namespace SVF
 {
+    const llvm::cl::opt<bool> Options::MarkedClocksOnly(
+        "marked-clocks-only",
+        llvm::cl::init(false),
+        llvm::cl::desc("Only measure times where explicitly marked")
+    );
+
+
 };  // namespace SVF.

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -1,0 +1,21 @@
+//===- Options.cpp -- Command line options ------------------------//
+
+#include <llvm/Support/CommandLine.h>
+
+#include "Util/Options.h"
+
+namespace SVF
+{
+    const Options *Options::get(void)
+    {
+        if (options == nullptr)
+        {
+            options = new Options();
+        }
+
+        return options;
+    }
+
+    Options::Options(void) { }
+
+};  // namespace SVF.

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -17,7 +17,7 @@ namespace SVF
         llvm::cl::init(NodeIDAllocator::Strategy::DENSE),
         llvm::cl::desc("Method of allocating (LLVM) values and memory objects as node IDs"),
         llvm::cl::values(
-            clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately"),
+            clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately (default)"),
             clEnumValN(NodeIDAllocator::Strategy::SEQ,     "seq", "allocate values and objects sequentially, intermixed"),
             clEnumValN(NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets")
         )

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -6,18 +6,4 @@
 
 namespace SVF
 {
-    const Options *Options::options = nullptr;
-
-    const Options *Options::get(void)
-    {
-        if (options == nullptr)
-        {
-            options = new Options();
-        }
-
-        return options;
-    }
-
-    Options::Options(void) { }
-
 };  // namespace SVF.

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -12,5 +12,15 @@ namespace SVF
         llvm::cl::desc("Only measure times where explicitly marked")
     );
 
+    const llvm::cl::opt<NodeIDAllocator::Strategy> Options::NodeAllocStrat(
+        "node-alloc-strat",
+        llvm::cl::init(NodeIDAllocator::Strategy::DENSE),
+        llvm::cl::desc("Method of allocating (LLVM) values and memory objects as node IDs"),
+        llvm::cl::values(
+            clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately"),
+            clEnumValN(NodeIDAllocator::Strategy::SEQ,     "seq", "allocate values and objects sequentially, intermixed"),
+            clEnumValN(NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets")
+        )
+    );
 
 };  // namespace SVF.

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -35,9 +35,6 @@
 
 using namespace SVF;
 
-static llvm::cl::opt<bool> MarkedClocksOnly("marked-clocks-only", llvm::cl::init(false),
-                                            llvm::cl::desc("Only measure times where explicitly marked"));
-
 const char* PTAStat:: TotalAnalysisTime = "TotalTime";	///< PAG value nodes
 const char* PTAStat:: SCCDetectionTime = "SCCDetectTime"; ///< Total SCC detection time
 const char* PTAStat:: SCCMergeTime = "SCCMergeTime"; ///< Total SCC merge time
@@ -107,16 +104,9 @@ const char* PTAStat:: MaxNumOfNodesInSCC = "MaxNodesInSCC";	///< max Number of n
 
 const char* PTAStat:: NumOfNullPointer = "NullPointer";	///< Number of pointers points-to null
 
-bool PTAStat::markedClocksOnly = false;
-
 PTAStat::PTAStat(PointerAnalysis* p) : startTime(0), endTime(0), pta(p)
 {
 
-}
-
-void PTAStat::setMarkedClocksOnly(void)
-{
-    markedClocksOnly = MarkedClocksOnly;
 }
 
 void PTAStat::performStat()


### PR DESCRIPTION
The Options class gathers all command line options (or at least, aims to). For example, option `X` would be accessed as `Options::X` after including `Util/Options.h`.

Why not singleton? Command line options are set once for the entire execution, it makes no sense to change these (unless we might want to internally mess with an option depending on other options, perhaps?).

**Rationale**
I wanted to add an option used in many files. It is possible to declare an `llvm::cl::opt` as `extern` in some header, then initialise it in some `.cpp`, but I thought this would be cleaner as it puts all options in one place rather than interspersed across files and allows everyone to view *any* options from one place.

**Status**
I haven't moved every option to `Options` as the testing effort would be too large. I've moved `marked-clocks-only` and `node-alloc-strat` as examples. I think `Options.h`/`.cpp` are very readable and it clears some clutter from other files. My suggestion is we add new options here, and move existing options slowly over time.