### PR TITLE
simplify solve() in Andersen and FlowSensitive analysis

### DIFF
--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -332,16 +332,8 @@ protected:
     /// Update call graph for the input indirect callsites
     virtual bool updateCallGraph(const CallSiteToFunPtrMap& callsites);
 
-    /// Update call graph for all the indirect callsites
-    virtual inline bool updateCallGraph()
-    {
-        return updateCallGraph(getIndirectCallsites());
-    }
-
     /// Connect formal and actual parameters for indirect callsites
     void connectCaller2CalleeParams(CallSite cs, const SVFFunction* F, NodePairSet& cpySrcNodes);
-
-
 
     /// Merge sub node to its rep
     virtual void mergeNodeToRep(NodeID nodeId,NodeID newRepId);

--- a/include/WPA/WPASolver.h
+++ b/include/WPA/WPASolver.h
@@ -99,27 +99,6 @@ protected:
         return getSCCDetector()->topoNodeStack();
     }
 
-    /// Constraint Solving
-    virtual inline void solve()
-    {
-        initWorklist();
-        do
-        {
-            numOfIteration++;
-            if (0 == numOfIteration % iterationForPrintStat)
-                printStat();
-
-            reanalyze = false;
-
-            solveWorklist();
-
-            if (updateCallGraph())
-                reanalyze = true;
-
-        }
-        while (reanalyze);
-    }
-
     virtual inline void initWorklist()
     {
         NodeStack& nodeStack = SCCDetect();
@@ -147,16 +126,10 @@ protected:
     //@{
     /// Process each node on the graph, to be implemented in the child class
     virtual inline void processNode(NodeID) {}
-    /// update callgraph for all indirect callsites
-    virtual bool updateCallGraph()
-    {
-        return false;
-    }
     /// collapse positive weight cycles of a graph
     virtual void collapsePWCNode(NodeID) {}
     virtual void collapseFields() {};
     /// dump statistics
-    virtual void printStat() {}
     /// Propagation for the solving, to be implemented in the child class
     virtual void propagate(GNODE* v)
     {

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -116,7 +116,24 @@ void AndersenBase::analyze()
     {
         // Start solving constraints
         DBOUT(DGENERAL, outs() << SVFUtil::pasMsg("Start Solving Constraints\n"));
-        solve();
+
+        initWorklist();
+        do
+        {
+            numOfIteration++;
+            if (0 == numOfIteration % iterationForPrintStat)
+                printStat();
+
+            reanalyze = false;
+
+            solveWorklist();
+
+            if (updateCallGraph(getIndirectCallsites()))
+                reanalyze = true;
+
+        }
+        while (reanalyze);
+
         DBOUT(DGENERAL, outs() << SVFUtil::pasMsg("Finish Solving Constraints\n"));
 
         // Finalize the analysis

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -78,8 +78,8 @@ void FlowSensitive::analyze()
 
         callGraphSCC->find();
 
-        solve();
-
+        initWorklist();
+        solveWorklist();
     }
     while (updateCallGraph(getIndirectCallsites()));
 


### PR DESCRIPTION
Move the body of `solve()` in WPASolver.h to `Andersen.cpp` and `FlowSensitive.cpp` to simplify the code. 