### PR TITLE
3 udpates

### DIFF
--- a/include/SVF-FE/CHG.h
+++ b/include/SVF-FE/CHG.h
@@ -168,7 +168,7 @@ private:
      *
      * virtualFunctionVectors = {{Af1, Af2, ...}, {Bg1, Bg2, ...}}
      */
-    std::vector<std::vector<const SVFFunction*>> virtualFunctionVectors;
+    std::vector<FuncVector> virtualFunctionVectors;
 };
 
 /// class hierarchy graph
@@ -284,6 +284,9 @@ public:
     {
         return chg->getKind() == Standard;
     }
+
+protected:
+    void addFuncToFuncVector(CHNode::FuncVector &v, const SVFFunction *f);
 
 private:
     SVFModule* svfMod;

--- a/include/SVF-FE/CPPUtil.h
+++ b/include/SVF-FE/CPPUtil.h
@@ -47,6 +47,7 @@ struct DemangledName
 {
     std::string className;
     std::string funcName;
+    bool isThunkFunc;
 };
 
 struct DemangledName demangle(const std::string &name);

--- a/include/SVF-FE/CPPUtil.h
+++ b/include/SVF-FE/CPPUtil.h
@@ -58,6 +58,8 @@ bool isLoadVtblInst(const LoadInst *loadInst);
 bool isVirtualCallSite(CallSite cs);
 bool isConstructor(const Function *F);
 bool isDestructor(const Function *F);
+bool isCPPThunkFunction(const Function *F);
+const Function *getThunkTarget(const Function *F);
 
 /*
  * VtableA = {&A::foo}

--- a/lib/SVF-FE/CHG.cpp
+++ b/lib/SVF-FE/CHG.cpp
@@ -383,6 +383,18 @@ const CHGraph::CHNodeSetTy& CHGraph::getInstancesAndDescendants(const string cla
     }
 }
 
+
+void CHGraph::addFuncToFuncVector(CHNode::FuncVector &v, const SVFFunction *f) {
+    const auto *lf = f->getLLVMFun();
+    if (isCPPThunkFunction(lf)) {
+        const auto *tf = getThunkTarget(lf);
+        v.push_back(svfMod->getSVFFunction(tf));
+    } else {
+        v.push_back(f);
+    }
+}
+
+
 /*
  * do the following things:
  * 1. initialize virtualFunctions for each class
@@ -508,7 +520,7 @@ void CHGraph::analyzeVTables(const Module &M)
                             if (const Function* f = SVFUtil::dyn_cast<Function>(bitcastValue))
                             {
                                 const SVFFunction* func = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(f);
-                                virtualFunctions.push_back(func);
+                                addFuncToFuncVector(virtualFunctions, func);
                                 if (func->getName().str().compare(pureVirtualFunName) == 0)
                                 {
                                     pure_abstract &= true;
@@ -534,7 +546,7 @@ void CHGraph::analyzeVTables(const Module &M)
                                                 SVFUtil::dyn_cast<Function>(aliasValue))
                                     {
                                         const SVFFunction* func = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(aliasFunc);
-                                        virtualFunctions.push_back(func);
+                                        addFuncToFuncVector(virtualFunctions, func);
                                     }
                                     else if (const ConstantExpr *aliasconst =
                                                  SVFUtil::dyn_cast<ConstantExpr>(aliasValue))
@@ -547,7 +559,7 @@ void CHGraph::analyzeVTables(const Module &M)
                                         assert(aliasbitcastfunc &&
                                                "aliased bitcast in vtable not a function");
                                         const SVFFunction* func = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(aliasbitcastfunc);
-                                        virtualFunctions.push_back(func);
+                                        addFuncToFuncVector(virtualFunctions, func);
                                     }
                                     else
                                     {

--- a/lib/SVF-FE/CPPUtil.cpp
+++ b/lib/SVF-FE/CPPUtil.cpp
@@ -141,7 +141,8 @@ static void handleThunkFunction(cppUtil::DemangledName &dname) {
     // if the classname starts with part of a
     // demangled name starts with
     // these prefixes, we need to remove the prefix
-    // to get the real class anme
+    // to get the real class name
+
     static vector<string> thunkPrefixes = {VThunkFuncLabel, NVThunkFunLabel};
     for (unsigned i = 0; i < thunkPrefixes.size(); i++) {
         auto prefix = thunkPrefixes[i];
@@ -149,6 +150,9 @@ static void handleThunkFunction(cppUtil::DemangledName &dname) {
             dname.className.compare(0, prefix.size(), prefix) == 0)
         {
             dname.className = dname.className.substr(prefix.size());
+            dname.isThunkFunc = true;
+            return;
+
         }
     }
 }
@@ -177,6 +181,7 @@ static void handleThunkFunction(cppUtil::DemangledName &dname) {
 struct cppUtil::DemangledName cppUtil::demangle(const string &name)
 {
     struct cppUtil::DemangledName dname;
+    dname.isThunkFunc = false;
 
     s32_t status;
     char *realname = abi::__cxa_demangle(name.c_str(), 0, 0, &status);


### PR DESCRIPTION
1. Improve the code for detecting thunk functions
2. When a thunk function is detected in vtable, instead of thunk function itself, its target function is  inserted into the parsed vtable
3. When parsing passible targets from the vtable, a argument type based filtering mechanism is added