### PR TITLE
Add KeySet template parameter

### DIFF
--- a/include/MemoryModel/AbstractPointsToDS.h
+++ b/include/MemoryModel/AbstractPointsToDS.h
@@ -35,12 +35,10 @@ namespace SVF
 /// Key:   "owning" variable of a points-to set.
 /// Datum: elements in points-to sets.
 /// Data:  the points-to set; a collection of Datums.
-template <typename Key, typename Datum, typename Data>
+template <typename Key, typename KeySet, typename Datum, typename Data>
 class PTData
 {
 public:
-    typedef Set<Key> KeySet;
-
     /// Types of a points-to data structures.
     enum PTDataTy
     {
@@ -98,11 +96,11 @@ protected:
 /// Abstract diff points-to data with cached information.
 /// This is an optimisation on top of the base points-to data structure.
 /// The points-to information is propagated incrementally only for the different parts.
-template <typename Key, typename Datum, typename Data>
-class DiffPTData : public PTData<Key, Datum, Data>
+template <typename Key, typename KeySet, typename Datum, typename Data>
+class DiffPTData : public PTData<Key, KeySet, Datum, Data>
 {
 public:
-    typedef PTData<Key, Datum, Data> BasePTData;
+    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     DiffPTData(bool reversePT = true, PTDataTy ty = PTDataTy::Diff) : BasePTData(reversePT, ty) { }
@@ -126,11 +124,11 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const DiffPTData<Key, Datum, Data> *)
+    static inline bool classof(const DiffPTData<Key, KeySet, Datum, Data> *)
     {
         return true;
     }
-    static inline bool classof(const PTData<Key, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
     {
         return ptd->getPTDTY() == PTDataTy::Diff || ptd->getPTDTY() == PTDataTy::MutDiff;
     }
@@ -141,11 +139,11 @@ public:
 /// Points-to information is maintained at each program point (statement).
 /// For address-taken variables, every program point has two sets: IN and OUT points-to sets.
 /// For top-level variables, points-to sets are maintained flow-insensitively via getPts(var).
-template <typename Key, typename Datum, typename Data>
-class DFPTData : public PTData<Key, Datum, Data>
+template <typename Key, typename KeySet, typename Datum, typename Data>
+class DFPTData : public PTData<Key, KeySet, Datum, Data>
 {
 public:
-    typedef PTData<Key, Datum, Data> BasePTData;
+    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     typedef NodeID LocID;
@@ -197,12 +195,12 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const DFPTData<Key, Datum, Data> *)
+    static inline bool classof(const DFPTData<Key, KeySet, Datum, Data> *)
     {
         return true;
     }
 
-    static inline bool classof(const PTData<Key, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
     {
         return ptd->getPTDTY() == BasePTData::DataFlow
                || ptd->getPTDTY() == BasePTData::MutDataFlow
@@ -214,15 +212,12 @@ public:
 /// PTData with normal keys and versioned keys. Replicates the PTData interface for
 /// versioned keys too. Intended to be used for versioned flow-sensitive PTA--hence the
 /// name--but can be used anywhere where there are two types of keys at play.
-template <typename Key, typename Datum, typename Data, typename VersionedKey>
-class VersionedPTData : public PTData<Key, Datum, Data>
+template <typename Key, typename KeySet, typename Datum, typename Data, typename VersionedKey, typename VersionedKeySet>
+class VersionedPTData : public PTData<Key, KeySet, Datum, Data>
 {
 public:
-    typedef PTData<Key, Datum, Data> BasePTData;
+    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
-    typedef typename BasePTData::KeySet KeySet;
-
-    typedef Set<VersionedKey> VersionedKeySet;
 
     VersionedPTData(bool reversePT = true, PTDataTy ty = PTDataTy::Versioned) : BasePTData(reversePT, ty) { }
 
@@ -243,12 +238,12 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const VersionedPTData<Key, Datum, Data, VersionedKey> *)
+    static inline bool classof(const VersionedPTData<Key, KeySet, Datum, Data, VersionedKey, VersionedKeySet> *)
     {
         return true;
     }
 
-    static inline bool classof(const PTData<Key, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
     {
         return ptd->getPTDTY() == PTDataTy::Versioned || ptd->getPTDTY() == PTDataTy::MutVersioned;
     }

--- a/include/MemoryModel/AbstractPointsToDS.h
+++ b/include/MemoryModel/AbstractPointsToDS.h
@@ -26,16 +26,17 @@ namespace SVF
 /// Basic points-to data structure
 /// Given a key (variable/condition variable), return its points-to data (pts/condition pts)
 /// It is designed flexible for different context, heap and path sensitive analysis
-/// Context Insensitive			   Key --> Variable, Data --> PointsTo
-/// Context sensitive:  			   Key --> CondVar,  Data --> PointsTo
-/// Heap sensitive:     			   Key --> Variable  Data --> CondPointsToSet
-/// Context and heap sensitive:     Key --> CondVar,  Data --> CondPointsToSet
+/// Context Insensitive			   Key --> Variable, DataSet --> PointsTo
+/// Context sensitive:  			   Key --> CondVar,  DataSet --> PointsTo
+/// Heap sensitive:     			   Key --> Variable  DataSet --> CondPointsToSet
+/// Context and heap sensitive:     Key --> CondVar,  DataSet --> CondPointsToSet
 ///
 /// This class is abstract to allow for multiple methods of actually storing points-to sets.
-/// Key:   "owning" variable of a points-to set.
-/// Datum: elements in points-to sets.
-/// Data:  the points-to set; a collection of Datums.
-template <typename Key, typename KeySet, typename Datum, typename Data>
+/// Key:     "owning" variable of a points-to set.
+/// KeySet:  collection of keys.
+/// Data:    elements in points-to sets.
+/// DataSet: the points-to set; a collection of Data.
+template <typename Key, typename KeySet, typename Data, typename DataSet>
 class PTData
 {
 public:
@@ -67,20 +68,20 @@ public:
     virtual void clear() = 0;
 
     /// Get points-to set of var.
-    virtual const Data& getPts(const Key& var) = 0;
-    /// Get reverse points-to set of datum.
-    virtual const KeySet& getRevPts(const Datum& datum) = 0;
+    virtual const DataSet& getPts(const Key& var) = 0;
+    /// Get reverse points-to set of a datum.
+    virtual const KeySet& getRevPts(const Data& datum) = 0;
 
     /// Adds element to the points-to set associated with var.
-    virtual bool addPts(const Key& var, const Datum& element) = 0;
+    virtual bool addPts(const Key& var, const Data& element) = 0;
 
     /// Performs pts(dstVar) = pts(dstVar) U pts(srcVar).
     virtual bool unionPts(const Key& dstVar, const Key& srcVar) = 0;
-    /// Performs pts(dstVar) = pts(dstVar) U srcData.
-    virtual bool unionPts(const Key& dstVar, const Data& srcData) = 0;
+    /// Performs pts(dstVar) = pts(dstVar) U srcDataSet.
+    virtual bool unionPts(const Key& dstVar, const DataSet& srcDataSet) = 0;
 
     /// Clears element from the points-to set of var.
-    virtual void clearPts(const Key& var, const Datum& element) = 0;
+    virtual void clearPts(const Key& var, const Data& element) = 0;
     /// Fully clears the points-to set of var.
     virtual void clearFullPts(const Key& var) = 0;
 
@@ -96,11 +97,11 @@ protected:
 /// Abstract diff points-to data with cached information.
 /// This is an optimisation on top of the base points-to data structure.
 /// The points-to information is propagated incrementally only for the different parts.
-template <typename Key, typename KeySet, typename Datum, typename Data>
-class DiffPTData : public PTData<Key, KeySet, Datum, Data>
+template <typename Key, typename KeySet, typename Data, typename DataSet>
+class DiffPTData : public PTData<Key, KeySet, Data, DataSet>
 {
 public:
-    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
+    typedef PTData<Key, KeySet, Data, DataSet> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     DiffPTData(bool reversePT = true, PTDataTy ty = PTDataTy::Diff) : BasePTData(reversePT, ty) { }
@@ -108,12 +109,12 @@ public:
     virtual ~DiffPTData() { }
 
     /// Get diff points to.
-    virtual const Data& getDiffPts(Key& var) = 0;
+    virtual const DataSet& getDiffPts(Key& var) = 0;
 
     /// Compute diff points to. Return TRUE if diff is not empty.
     /// 1. calculate diff: diff = all - propa.
     /// 2. update propagated pts: propa = all.
-    virtual bool computeDiffPts(Key& var, const Data& all) = 0;
+    virtual bool computeDiffPts(Key& var, const DataSet& all) = 0;
 
     /// Update dst's propagated points-to set with src's.
     /// The final result is the intersection of these two sets.
@@ -124,11 +125,11 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const DiffPTData<Key, KeySet, Datum, Data> *)
+    static inline bool classof(const DiffPTData<Key, KeySet, Data, DataSet> *)
     {
         return true;
     }
-    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Data, DataSet>* ptd)
     {
         return ptd->getPTDTY() == PTDataTy::Diff || ptd->getPTDTY() == PTDataTy::MutDiff;
     }
@@ -139,11 +140,11 @@ public:
 /// Points-to information is maintained at each program point (statement).
 /// For address-taken variables, every program point has two sets: IN and OUT points-to sets.
 /// For top-level variables, points-to sets are maintained flow-insensitively via getPts(var).
-template <typename Key, typename KeySet, typename Datum, typename Data>
-class DFPTData : public PTData<Key, KeySet, Datum, Data>
+template <typename Key, typename KeySet, typename Data, typename DataSet>
+class DFPTData : public PTData<Key, KeySet, Data, DataSet>
 {
 public:
-    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
+    typedef PTData<Key, KeySet, Data, DataSet> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     typedef NodeID LocID;
@@ -163,8 +164,8 @@ public:
     ///@{
     virtual bool hasDFOutSet(LocID loc, const Key& var) const = 0;
     virtual bool hasDFInSet(LocID loc, const Key& var) const = 0;
-    virtual const Data& getDFInPtsSet(LocID loc, const Key& var) = 0;
-    virtual const Data& getDFOutPtsSet(LocID loc, const Key& var) = 0;
+    virtual const DataSet& getDFInPtsSet(LocID loc, const Key& var) = 0;
+    virtual const DataSet& getDFOutPtsSet(LocID loc, const Key& var) = 0;
     ///@}
 
     /// Update points-to for IN/OUT set
@@ -195,12 +196,12 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const DFPTData<Key, KeySet, Datum, Data> *)
+    static inline bool classof(const DFPTData<Key, KeySet, Data, DataSet> *)
     {
         return true;
     }
 
-    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Data, DataSet>* ptd)
     {
         return ptd->getPTDTY() == BasePTData::DataFlow
                || ptd->getPTDTY() == BasePTData::MutDataFlow
@@ -212,38 +213,38 @@ public:
 /// PTData with normal keys and versioned keys. Replicates the PTData interface for
 /// versioned keys too. Intended to be used for versioned flow-sensitive PTA--hence the
 /// name--but can be used anywhere where there are two types of keys at play.
-template <typename Key, typename KeySet, typename Datum, typename Data, typename VersionedKey, typename VersionedKeySet>
-class VersionedPTData : public PTData<Key, KeySet, Datum, Data>
+template <typename Key, typename KeySet, typename Data, typename DataSet, typename VersionedKey, typename VersionedKeySet>
+class VersionedPTData : public PTData<Key, KeySet, Data, DataSet>
 {
 public:
-    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
+    typedef PTData<Key, KeySet, Data, DataSet> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     VersionedPTData(bool reversePT = true, PTDataTy ty = PTDataTy::Versioned) : BasePTData(reversePT, ty) { }
 
     virtual ~VersionedPTData() { }
 
-    virtual const Data& getPts(const VersionedKey& vk) = 0;
-    virtual const VersionedKeySet& getVersionedKeyRevPts(const Datum& datum) = 0;
+    virtual const DataSet& getPts(const VersionedKey& vk) = 0;
+    virtual const VersionedKeySet& getVersionedKeyRevPts(const Data& datum) = 0;
 
-    virtual bool addPts(const VersionedKey& vk, const Datum& element) = 0;
+    virtual bool addPts(const VersionedKey& vk, const Data& element) = 0;
 
     virtual bool unionPts(const VersionedKey& dstVar, const VersionedKey& srcVar) = 0;
     virtual bool unionPts(const VersionedKey& dstVar, const Key& srcVar) = 0;
     virtual bool unionPts(const Key& dstVar, const VersionedKey& srcVar) = 0;
-    virtual bool unionPts(const VersionedKey& dstVar, const Data& srcData) = 0;
+    virtual bool unionPts(const VersionedKey& dstVar, const DataSet& srcDataSet) = 0;
 
-    virtual void clearPts(const VersionedKey& vk, const Datum& element) = 0;
+    virtual void clearPts(const VersionedKey& vk, const Data& element) = 0;
     virtual void clearFullPts(const VersionedKey& vk) = 0;
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const VersionedPTData<Key, KeySet, Datum, Data, VersionedKey, VersionedKeySet> *)
+    static inline bool classof(const VersionedPTData<Key, KeySet, Data, DataSet, VersionedKey, VersionedKeySet> *)
     {
         return true;
     }
 
-    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Data, DataSet>* ptd)
     {
         return ptd->getPTDTY() == PTDataTy::Versioned || ptd->getPTDTY() == PTDataTy::MutVersioned;
     }

--- a/include/MemoryModel/AbstractPointsToDS.h
+++ b/include/MemoryModel/AbstractPointsToDS.h
@@ -19,6 +19,8 @@
 #ifndef ABSTRACT_POINTSTO_H_
 #define ABSTRACT_POINTSTO_H_
 
+#include "Util/SVFBasicTypes.h"
+
 namespace SVF
 {
 /// Basic points-to data structure

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -4,6 +4,9 @@
 #ifndef MUTABLE_POINTSTO_H_
 #define MUTABLE_POINTSTO_H_
 
+#include "MemoryModel/AbstractPointsToDS.h"
+#include "Util/SVFBasicTypes.h"
+
 namespace SVF
 {
 

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -27,23 +27,23 @@ void insertKey(const NodeID &key, NodeBS &keySet)
     keySet.set(key);
 }
 
-template <typename Key, typename KeySet, typename Datum, typename Data>
+template <typename Key, typename KeySet, typename Data, typename DataSet>
 class MutableDFPTData;
 
 /// PTData implemented using points-to sets which are created once and updated continuously.
-template <typename Key, typename KeySet, typename Datum, typename Data>
-class MutablePTData : public PTData<Key, KeySet, Datum, Data>
+template <typename Key, typename KeySet, typename Data, typename DataSet>
+class MutablePTData : public PTData<Key, KeySet, Data, DataSet>
 {
-    friend class MutableDFPTData<Key, KeySet, Datum, Data>;
+    friend class MutableDFPTData<Key, KeySet, Data, DataSet>;
 public:
-    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
+    typedef PTData<Key, KeySet, Data, DataSet> BasePTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
-    typedef Map<Key, Data> PtsMap;
-    typedef Map<Datum, KeySet> RevPtsMap;
+    typedef Map<Key, DataSet> PtsMap;
+    typedef Map<Data, KeySet> RevPtsMap;
     typedef typename PtsMap::iterator PtsMapIter;
     typedef typename PtsMap::const_iterator PtsMapConstIter;
-    typedef typename Data::iterator iterator;
+    typedef typename DataSet::iterator iterator;
 
     /// Constructor
     MutablePTData(bool reversePT = true, PTDataTy ty = PTDataTy::MutBase) : BasePTData(reversePT, ty) { }
@@ -62,18 +62,18 @@ public:
         revPtsMap.clear();
     }
 
-    virtual inline const Data& getPts(const Key& var) override
+    virtual inline const DataSet& getPts(const Key& var) override
     {
         return ptsMap[var];
     }
 
-    virtual inline const KeySet& getRevPts(const Datum& datum) override
+    virtual inline const KeySet& getRevPts(const Data& datum) override
     {
         assert(this->rev && "MutablePTData::getRevPts: constructed without reverse PT support!");
         return revPtsMap[datum];
     }
 
-    virtual inline bool addPts(const Key &dstKey, const Datum& element) override
+    virtual inline bool addPts(const Key &dstKey, const Data& element) override
     {
         addSingleRevPts(revPtsMap[element], dstKey);
         return addPts(ptsMap[dstKey], element);
@@ -85,10 +85,10 @@ public:
         return unionPts(ptsMap[dstKey], getPts(srcKey));
     }
 
-    virtual inline bool unionPts(const Key& dstKey, const Data& srcData) override
+    virtual inline bool unionPts(const Key& dstKey, const DataSet& srcDataSet) override
     {
-        addRevPts(srcData,dstKey);
-        return unionPts(ptsMap[dstKey], srcData);
+        addRevPts(srcDataSet,dstKey);
+        return unionPts(ptsMap[dstKey], srcDataSet);
     }
 
     virtual inline void dumpPTData() override
@@ -96,7 +96,7 @@ public:
         dumpPts(ptsMap);
     }
 
-    virtual void clearPts(const Key& var, const Datum& element) override
+    virtual void clearPts(const Key& var, const Data& element) override
     {
         ptsMap[var].reset(element);
     }
@@ -108,12 +108,12 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const MutablePTData<Key, KeySet, Datum, Data> *)
+    static inline bool classof(const MutablePTData<Key, KeySet, Data, DataSet> *)
     {
         return true;
     }
 
-    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Data, DataSet>* ptd)
     {
         return ptd->getPTDTY() == PTDataTy::MutBase;
     }
@@ -125,11 +125,11 @@ protected:
         for (PtsMapConstIter nodeIt = ptsSet.begin(); nodeIt != ptsSet.end(); nodeIt++)
         {
             const Key& var = nodeIt->first;
-            const Data & pts = nodeIt->second;
+            const DataSet & pts = nodeIt->second;
             if (pts.empty())
                 continue;
             O << var << " ==> { ";
-            for(typename Data::iterator cit = pts.begin(), ecit=pts.end(); cit!=ecit; ++cit)
+            for(typename DataSet::iterator cit = pts.begin(), ecit=pts.end(); cit!=ecit; ++cit)
             {
                 O << *cit << " ";
             }
@@ -140,11 +140,11 @@ protected:
 private:
     /// Internal union/add points-to helper methods.
     ///@{
-    inline bool unionPts(Data& dstData, const Data& srcData)
+    inline bool unionPts(DataSet& dstDataSet, const DataSet& srcDataSet)
     {
-        return dstData |= srcData;
+        return dstDataSet |= srcDataSet;
     }
-    inline bool addPts(Data &d, const Datum& e)
+    inline bool addPts(DataSet &d, const Data& e)
     {
         return d.test_and_set(e);
     }
@@ -152,7 +152,7 @@ private:
     {
         if (this->rev) insertKey<Key, KeySet>(tgr, revData);
     }
-    inline void addRevPts(const Data &ptsData, const Key& tgr)
+    inline void addRevPts(const DataSet &ptsData, const Key& tgr)
     {
         if (this->rev)
         {
@@ -168,15 +168,15 @@ protected:
 };
 
 /// DiffPTData implemented with points-to sets which are updated continuously.
-template <typename Key, typename KeySet, typename Datum, typename Data>
-class MutableDiffPTData : public DiffPTData<Key, KeySet, Datum, Data>
+template <typename Key, typename KeySet, typename Data, typename DataSet>
+class MutableDiffPTData : public DiffPTData<Key, KeySet, Data, DataSet>
 {
 public:
-    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
-    typedef DiffPTData<Key, KeySet, Datum, Data> BaseDiffPTData;
+    typedef PTData<Key, KeySet, Data, DataSet> BasePTData;
+    typedef DiffPTData<Key, KeySet, Data, DataSet> BaseDiffPTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
-    typedef typename MutablePTData<Key, KeySet, Datum, Data>::PtsMap PtsMap;
+    typedef typename MutablePTData<Key, KeySet, Data, DataSet>::PtsMap PtsMap;
 
     /// Constructor
     MutableDiffPTData(bool reversePT = true, PTDataTy ty = PTDataTy::Diff) : BaseDiffPTData(reversePT, ty), mutPTData(reversePT) { }
@@ -193,18 +193,18 @@ public:
         mutPTData.clear();
     }
 
-    virtual inline const Data& getPts(const Key& var) override
+    virtual inline const DataSet& getPts(const Key& var) override
     {
         return mutPTData.getPts(var);
     }
 
-    virtual inline const KeySet& getRevPts(const Datum& datum) override
+    virtual inline const KeySet& getRevPts(const Data& datum) override
     {
         assert(this->rev && "MutableDiffPTData::getRevPts: constructed without reverse PT support!");
         return mutPTData.getRevPts(datum);
     }
 
-    virtual inline bool addPts(const Key &dstKey, const Datum& element) override
+    virtual inline bool addPts(const Key &dstKey, const Data& element) override
     {
         return mutPTData.addPts(dstKey, element);
     }
@@ -214,12 +214,12 @@ public:
         return mutPTData.unionPts(dstKey, srcKey);
     }
 
-    virtual inline bool unionPts(const Key& dstKey, const Data& srcData) override
+    virtual inline bool unionPts(const Key& dstKey, const DataSet& srcDataSet) override
     {
-        return mutPTData.unionPts(dstKey, srcData);
+        return mutPTData.unionPts(dstKey, srcDataSet);
     }
 
-    virtual void clearPts(const Key& var, const Datum& element) override
+    virtual void clearPts(const Key& var, const Data& element) override
     {
         mutPTData.clearPts(var, element);
     }
@@ -234,18 +234,18 @@ public:
         mutPTData.dumpPTData();
     }
 
-    virtual inline const Data &getDiffPts(Key &var) override
+    virtual inline const DataSet &getDiffPts(Key &var) override
     {
         return getMutDiffPts(var);
     }
 
-    virtual inline bool computeDiffPts(Key &var, const Data &all) override
+    virtual inline bool computeDiffPts(Key &var, const DataSet &all) override
     {
         /// Clear diff pts.
-        Data& diff = getMutDiffPts(var);
+        DataSet& diff = getMutDiffPts(var);
         diff.clear();
         /// Get all pts.
-        Data& propa = getPropaPts(var);
+        DataSet& propa = getPropaPts(var);
         diff.intersectWithComplement(all, propa);
         propa = all;
         return !diff.empty();
@@ -253,8 +253,8 @@ public:
 
     virtual inline void updatePropaPtsMap(Key &src, Key &dst) override
     {
-        Data& srcPropa = getPropaPts(src);
-        Data& dstPropa = getPropaPts(dst);
+        DataSet& srcPropa = getPropaPts(src);
+        DataSet& dstPropa = getPropaPts(dst);
         dstPropa &= srcPropa;
     }
 
@@ -265,12 +265,12 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const MutableDiffPTData<Key, KeySet, Datum, Data> *)
+    static inline bool classof(const MutableDiffPTData<Key, KeySet, Data, DataSet> *)
     {
         return true;
     }
 
-    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Data, DataSet>* ptd)
     {
         return ptd->getPTDTY() == PTDataTy::MutDiff;
     }
@@ -278,33 +278,33 @@ public:
 
 protected:
     /// Get diff PTS that can be modified.
-    inline Data &getMutDiffPts(Key &var)
+    inline DataSet &getMutDiffPts(Key &var)
     {
         return diffPtsMap[var];
     }
 
     /// Get propagated points to.
-    inline Data &getPropaPts(Key &var)
+    inline DataSet &getPropaPts(Key &var)
     {
         return propaPtsMap[var];
     }
 
 private:
     /// Backing to implement the basic PTData methods. This allows us to avoid multiple-inheritance.
-    MutablePTData<Key, KeySet, Datum, Data> mutPTData;
+    MutablePTData<Key, KeySet, Data, DataSet> mutPTData;
     /// Diff points-to to be propagated.
     PtsMap diffPtsMap;
     /// Points-to already propagated.
     PtsMap propaPtsMap;
 };
 
-template <typename Key, typename KeySet, typename Datum, typename Data>
-class MutableDFPTData : public DFPTData<Key, KeySet, Datum, Data>
+template <typename Key, typename KeySet, typename Data, typename DataSet>
+class MutableDFPTData : public DFPTData<Key, KeySet, Data, DataSet>
 {
 public:
-    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
-    typedef MutablePTData<Key, KeySet, Datum, Data> BaseMutPTData;
-    typedef DFPTData<Key, KeySet, Datum, Data> BaseDFPTData;
+    typedef PTData<Key, KeySet, Data, DataSet> BasePTData;
+    typedef MutablePTData<Key, KeySet, Data, DataSet> BaseMutPTData;
+    typedef DFPTData<Key, KeySet, Data, DataSet> BaseDFPTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     typedef typename BaseDFPTData::LocID LocID;
@@ -329,12 +329,12 @@ public:
         mutPTData.clear();
     }
 
-    virtual inline const Data& getPts(const Key& var) override
+    virtual inline const DataSet& getPts(const Key& var) override
     {
         return mutPTData.getPts(var);
     }
 
-    virtual inline const KeySet& getRevPts(const Datum& datum) override
+    virtual inline const KeySet& getRevPts(const Data& datum) override
     {
         assert(this->rev && "MutableDFPTData::getRevPts: constructed without reverse PT support!");
         return mutPTData.getRevPts(datum);
@@ -368,13 +368,13 @@ public:
         return (ptsMap.find(var) != ptsMap.end());
     }
 
-    virtual inline Data& getDFInPtsSet(LocID loc, const Key& var) override
+    virtual inline DataSet& getDFInPtsSet(LocID loc, const Key& var) override
     {
         PtsMap& inSet = dfInPtsMap[loc];
         return inSet[var];
     }
 
-    virtual inline Data& getDFOutPtsSet(LocID loc, const Key& var) override
+    virtual inline DataSet& getDFOutPtsSet(LocID loc, const Key& var) override
     {
         PtsMap& outSet = dfOutPtsMap[loc];
         return outSet[var];
@@ -470,11 +470,11 @@ public:
     {
         return unionPts(mutPTData.ptsMap[dstKey], getPts(srcKey));
     }
-    virtual inline bool unionPts(const Key& dstKey, const Data& srcData) override
+    virtual inline bool unionPts(const Key& dstKey, const DataSet& srcDataSet) override
     {
-        return unionPts(mutPTData.ptsMap[dstKey],srcData);
+        return unionPts(mutPTData.ptsMap[dstKey],srcDataSet);
     }
-    virtual void clearPts(const Key& var, const Datum& element) override
+    virtual void clearPts(const Key& var, const Data& element) override
     {
         mutPTData.clearPts(var, element);
     }
@@ -486,11 +486,11 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const MutableDFPTData<Key, KeySet, Datum, Data> *)
+    static inline bool classof(const MutableDFPTData<Key, KeySet, Data, DataSet> *)
     {
         return true;
     }
-    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Data, DataSet>* ptd)
     {
         return ptd->getPTDTY() == BaseDFPTData::MutDataFlow
                || ptd->getPTDTY() == BaseDFPTData::IncMutDataFlow;
@@ -500,11 +500,11 @@ public:
 protected:
     /// Internal union/add points-to helper methods.
     ///@{
-    inline bool unionPts(Data& dstData, const Data& srcData)
+    inline bool unionPts(DataSet& dstDataSet, const DataSet& srcDataSet)
     {
-        return dstData |= srcData;
+        return dstDataSet |= srcDataSet;
     }
-    inline bool addPts(Data &d, const Datum& e)
+    inline bool addPts(DataSet &d, const Data& e)
     {
         return d.test_and_set(e);
     }
@@ -564,7 +564,7 @@ public:
         for (PtsMapConstIter nodeIt = ptsSet.begin(); nodeIt != ptsSet.end(); nodeIt++)
         {
             const Key& var = nodeIt->first;
-            const Data & pts = nodeIt->second;
+            const DataSet & pts = nodeIt->second;
             if (pts.empty())
                 continue;
             O << "<" << var << ",{";
@@ -581,25 +581,25 @@ protected:
     DFPtsMap dfOutPtsMap;
     /// Backing to implement the basic PTData methods which are not overridden.
     /// This allows us to avoid multiple-inheritance.
-    MutablePTData<Key, KeySet, Datum, Data> mutPTData;
+    MutablePTData<Key, KeySet, Data, DataSet> mutPTData;
 };
 
 /// Incremental version of the mutable data-flow points-to data structure.
-template <typename Key, typename KeySet, typename Datum, typename Data>
-class IncMutableDFPTData : public MutableDFPTData<Key, KeySet, Datum, Data>
+template <typename Key, typename KeySet, typename Data, typename DataSet>
+class IncMutableDFPTData : public MutableDFPTData<Key, KeySet, Data, DataSet>
 {
 public:
-    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
-    typedef MutablePTData<Key, KeySet, Datum, Data> BaseMutPTData;
-    typedef DFPTData<Key, KeySet, Datum, Data> BaseDFPTData;
-    typedef MutableDFPTData<Key, KeySet, Datum, Data> BaseMutDFPTData;
+    typedef PTData<Key, KeySet, Data, DataSet> BasePTData;
+    typedef MutablePTData<Key, KeySet, Data, DataSet> BaseMutPTData;
+    typedef DFPTData<Key, KeySet, Data, DataSet> BaseDFPTData;
+    typedef MutableDFPTData<Key, KeySet, Data, DataSet> BaseMutDFPTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     typedef typename BaseDFPTData::LocID LocID;
-    typedef Map<LocID, Data> UpdatedVarMap;	///< for propagating only newly added variable in IN/OUT set
+    typedef Map<LocID, DataSet> UpdatedVarMap;	///< for propagating only newly added variable in IN/OUT set
     typedef typename UpdatedVarMap::iterator UpdatedVarMapIter;
     typedef typename UpdatedVarMap::const_iterator UpdatedVarconstIter;
-    typedef typename Data::iterator DataIter;
+    typedef typename DataSet::iterator DataIter;
 
 private:
     UpdatedVarMap outUpdatedVarMap;
@@ -673,7 +673,7 @@ public:
         if (this->hasDFInSet(loc))
         {
             /// Only variables has new pts from IN set need to be updated.
-            Data pts = getDFInUpdatedVar(loc);
+            DataSet pts = getDFInUpdatedVar(loc);
             for (DataIter ptsIt = pts.begin(), ptsEit = pts.end(); ptsIt != ptsEit; ++ptsIt)
             {
                 const Key var = *ptsIt;
@@ -711,7 +711,7 @@ public:
     {
         if (this->hasDFOutSet(loc))
         {
-            Data pts = getDFOutUpdatedVar(loc);
+            DataSet pts = getDFOutUpdatedVar(loc);
             for (DataIter ptsIt = pts.begin(), ptsEit = pts.end(); ptsIt != ptsEit; ++ptsIt)
             {
                 const Key var = *ptsIt;
@@ -722,12 +722,12 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const IncMutableDFPTData<Key, KeySet, Datum, Data> *)
+    static inline bool classof(const IncMutableDFPTData<Key, KeySet, Data, DataSet> *)
     {
         return true;
     }
 
-    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Data, DataSet>* ptd)
     {
         return ptd->getPTDTY() == BasePTData::IncMutDataFlow;
     }
@@ -756,7 +756,7 @@ private:
         return false;
     }
     /// Get all var which have new pts informationin loc's IN set
-    inline const Data& getDFInUpdatedVar(LocID loc)
+    inline const DataSet& getDFInUpdatedVar(LocID loc)
     {
         return inUpdatedVarMap[loc];
     }
@@ -785,22 +785,22 @@ private:
         return false;
     }
     /// Get all var which have new pts informationin loc's OUT set
-    inline const Data& getDFOutUpdatedVar(LocID loc)
+    inline const DataSet& getDFOutUpdatedVar(LocID loc)
     {
         return outUpdatedVarMap[loc];
     }
     //@}
 };
 
-/// VersionedPTData implemented with mutable points-to set (Data).
+/// VersionedPTData implemented with mutable points-to set (DataSet).
 /// Implemented as a wrapper around two MutablePTDatas: one for Keys, one
 /// for VersionedKeys.
-template <typename Key, typename KeySet, typename Datum, typename Data, typename VersionedKey, typename VersionedKeySet>
-class MutableVersionedPTData : public VersionedPTData<Key, KeySet, Datum, Data, VersionedKey, VersionedKeySet>
+template <typename Key, typename KeySet, typename Data, typename DataSet, typename VersionedKey, typename VersionedKeySet>
+class MutableVersionedPTData : public VersionedPTData<Key, KeySet, Data, DataSet, VersionedKey, VersionedKeySet>
 {
 public:
-    typedef PTData<Key, KeySet, Datum, Data> BasePTData;
-    typedef VersionedPTData<Key, KeySet, Datum, Data, VersionedKey, VersionedKeySet> BaseVersionedPTData;
+    typedef PTData<Key, KeySet, Data, DataSet> BasePTData;
+    typedef VersionedPTData<Key, KeySet, Data, DataSet, VersionedKey, VersionedKeySet> BaseVersionedPTData;
     typedef typename BasePTData::PTDataTy PTDataTy;
 
     MutableVersionedPTData(bool reversePT = true, PTDataTy ty = PTDataTy::MutVersioned)
@@ -814,31 +814,31 @@ public:
         atPTData.clear();
     }
 
-    virtual const Data& getPts(const Key& vk) override
+    virtual const DataSet& getPts(const Key& vk) override
     {
         return tlPTData.getPts(vk);
     }
-    virtual const Data& getPts(const VersionedKey& vk) override
+    virtual const DataSet& getPts(const VersionedKey& vk) override
     {
         return atPTData.getPts(vk);
     }
 
-    virtual const KeySet& getRevPts(const Datum& datum) override
+    virtual const KeySet& getRevPts(const Data& datum) override
     {
         assert(this->rev && "MutableVersionedPTData::getRevPts: constructed without reverse PT support!");
         return tlPTData.getRevPts(datum);
     }
-    virtual const VersionedKeySet& getVersionedKeyRevPts(const Datum& datum) override
+    virtual const VersionedKeySet& getVersionedKeyRevPts(const Data& datum) override
     {
         assert(this->rev && "MutableVersionedPTData::getVersionedKeyRevPts: constructed without reverse PT support!");
         return atPTData.getRevPts(datum);
     }
 
-    virtual bool addPts(const Key& k, const Datum& element) override
+    virtual bool addPts(const Key& k, const Data& element) override
     {
         return tlPTData.addPts(k, element);
     }
-    virtual bool addPts(const VersionedKey& vk, const Datum& element) override
+    virtual bool addPts(const VersionedKey& vk, const Data& element) override
     {
         return atPTData.addPts(vk, element);
     }
@@ -859,20 +859,20 @@ public:
     {
         return tlPTData.unionPts(dstVar, atPTData.getPts(srcVar));
     }
-    virtual bool unionPts(const Key& dstVar, const Data& srcData) override
+    virtual bool unionPts(const Key& dstVar, const DataSet& srcDataSet) override
     {
-        return tlPTData.unionPts(dstVar, srcData);
+        return tlPTData.unionPts(dstVar, srcDataSet);
     }
-    virtual bool unionPts(const VersionedKey& dstVar, const Data& srcData) override
+    virtual bool unionPts(const VersionedKey& dstVar, const DataSet& srcDataSet) override
     {
-        return atPTData.unionPts(dstVar, srcData);
+        return atPTData.unionPts(dstVar, srcDataSet);
     }
 
-    virtual void clearPts(const Key& k, const Datum& element) override
+    virtual void clearPts(const Key& k, const Data& element) override
     {
         tlPTData.clearPts(k, element);
     }
-    virtual void clearPts(const VersionedKey& vk, const Datum& element) override
+    virtual void clearPts(const VersionedKey& vk, const Data& element) override
     {
         atPTData.clearPts(vk, element);
     }
@@ -896,12 +896,12 @@ public:
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
     ///@{
-    static inline bool classof(const MutableVersionedPTData<Key, KeySet, Datum, Data, VersionedKey, VersionedKeySet> *)
+    static inline bool classof(const MutableVersionedPTData<Key, KeySet, Data, DataSet, VersionedKey, VersionedKeySet> *)
     {
         return true;
     }
 
-    static inline bool classof(const PTData<Key, KeySet, Datum, Data>* ptd)
+    static inline bool classof(const PTData<Key, KeySet, Data, DataSet>* ptd)
     {
         return ptd->getPTDTY() == PTDataTy::MutVersioned;
     }
@@ -909,9 +909,9 @@ public:
 
 private:
     /// PTData for Keys (top-level pointers, generally).
-    MutablePTData<Key, KeySet, Datum, Data> tlPTData;
+    MutablePTData<Key, KeySet, Data, DataSet> tlPTData;
     /// PTData for VersionedKeys (address-taken objects, generally).
-    MutablePTData<VersionedKey, VersionedKeySet, Datum, Data> atPTData;
+    MutablePTData<VersionedKey, VersionedKeySet, Data, DataSet> atPTData;
 };
 
 } // End namespace SVF

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -6,6 +6,7 @@
 
 #include "MemoryModel/AbstractPointsToDS.h"
 #include "Util/SVFBasicTypes.h"
+#include "Util/SVFUtil.h"
 
 namespace SVF
 {

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -247,7 +247,7 @@ public:
 
     /// Given an object, get all the nodes having whose pointsto contains the object.
     /// Similar to getPts, this also needs to be implemented in child classes.
-    virtual const NodeSet& getRevPts(NodeID nodeId) = 0;
+    virtual const NodeBS& getRevPts(NodeID nodeId) = 0;
 
     /// Clear points-to data
     virtual void clearPts()

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -42,15 +42,15 @@ class BVDataPTAImpl : public PointerAnalysis
 {
 
 public:
-    typedef PTData<NodeID, NodeID, PointsTo> PTDataTy;
-    typedef MutablePTData<NodeID, NodeID, PointsTo> MutPTDataTy;
-    typedef DiffPTData<NodeID, NodeID, PointsTo> DiffPTDataTy;
-    typedef MutableDiffPTData<NodeID, NodeID, PointsTo> MutDiffPTDataTy;
-    typedef DFPTData<NodeID, NodeID, PointsTo> DFPTDataTy;
-    typedef MutableDFPTData<NodeID, NodeID, PointsTo> MutDFPTDataTy;
-    typedef IncMutableDFPTData<NodeID, NodeID, PointsTo> IncMutDFPTDataTy;
-    typedef VersionedPTData<NodeID, NodeID, PointsTo, VersionedVar> VersionedPTDataTy;
-    typedef MutableVersionedPTData<NodeID, NodeID, PointsTo, VersionedVar> MutVersionedPTDataTy;
+    typedef PTData<NodeID, NodeBS, NodeID, PointsTo> PTDataTy;
+    typedef MutablePTData<NodeID, NodeBS, NodeID, PointsTo> MutPTDataTy;
+    typedef DiffPTData<NodeID, NodeBS, NodeID, PointsTo> DiffPTDataTy;
+    typedef MutableDiffPTData<NodeID, NodeBS, NodeID, PointsTo> MutDiffPTDataTy;
+    typedef DFPTData<NodeID, NodeBS, NodeID, PointsTo> DFPTDataTy;
+    typedef MutableDFPTData<NodeID, NodeBS, NodeID, PointsTo> MutDFPTDataTy;
+    typedef IncMutableDFPTData<NodeID, NodeBS, NodeID, PointsTo> IncMutDFPTDataTy;
+    typedef VersionedPTData<NodeID, NodeBS, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> VersionedPTDataTy;
+    typedef MutableVersionedPTData<NodeID, NodeBS, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> MutVersionedPTDataTy;
 
     /// Constructor
     BVDataPTAImpl(PAG* pag, PointerAnalysis::PTATY type, bool alias_check = true);
@@ -79,7 +79,7 @@ public:
     {
         return ptD->getPts(id);
     }
-    virtual inline const NodeSet& getRevPts(NodeID nodeId)
+    virtual inline const NodeBS& getRevPts(NodeID nodeId)
     {
         return ptD->getRevPts(nodeId);
     }
@@ -257,10 +257,10 @@ class CondPTAImpl : public PointerAnalysis
 public:
     typedef CondVar<Cond> CVar;
     typedef CondStdSet<CVar>  CPtSet;
-    typedef PTData<CVar, CVar, CPtSet> PTDataTy;
-    typedef MutablePTData<CVar, CVar, CPtSet> MutPTDataTy;
+    typedef PTData<CVar, Set<CVar>, CVar, CPtSet> PTDataTy;
+    typedef MutablePTData<CVar, Set<CVar>, CVar, CPtSet> MutPTDataTy;
     typedef Map<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
-    typedef Map<NodeID, NodeSet> PtrToNSMap;
+    typedef Map<NodeID, NodeBS> PtrToNSMap;
     typedef Map<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
 
     /// Constructor
@@ -457,7 +457,7 @@ protected:
                 for(typename CPtSet::const_iterator cit = it->second.begin(), ecit=it->second.end(); cit!=ecit; ++cit)
                 {
                     ptrToBVPtsMap[(it->first).get_id()].set(cit->get_id());
-                    objToNSRevPtsMap[cit->get_id()].insert((it->first).get_id());
+                    objToNSRevPtsMap[cit->get_id()].set((it->first).get_id());
                     ptrToCPtsMap[(it->first).get_id()].set(*cit);
                 }
             }
@@ -504,7 +504,7 @@ public:
         return ptrToCPtsMap[ptr];
     }
     /// Given an object return all pointers points to this object
-    virtual inline NodeSet& getRevPts(NodeID obj)
+    virtual inline NodeBS& getRevPts(NodeID obj)
     {
         assert(normalized && "Pts of all context-var have to be merged/normalized. Want to use getPts(CVar cvar)??");
         return objToNSRevPtsMap[obj];

--- a/include/WPA/VersionedFlowSensitive.h
+++ b/include/WPA/VersionedFlowSensitive.h
@@ -173,7 +173,7 @@ private:
     FIFOWorkList<NodeID> vWorklist;
 
     /// Points-to DS for working with versions.
-    VersionedPTData<NodeID, NodeID, PointsTo, VersionedVar> *vPtD;
+    BVDataPTAImpl::VersionedPTDataTy *vPtD;
 
     /// Additional statistics.
     //@{

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -9,6 +9,7 @@
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "SVF-FE/CPPUtil.h"
 #include "SVF-FE/DCHG.h"
+#include "Util/Options.h"
 #include <fstream>
 #include <sstream>
 
@@ -29,9 +30,14 @@ BVDataPTAImpl::BVDataPTAImpl(PAG* p, PointerAnalysis::PTATY type, bool alias_che
 {
     if (type == Andersen_BASE || type == Andersen_WPA || type == AndersenWaveDiff_WPA || type == AndersenHCD_WPA || type == AndersenHLCD_WPA
             || type == AndersenLCD_WPA || type == TypeCPP_WPA || type == FlowS_DDA || type == AndersenWaveDiffWithType_WPA
-            || type == AndersenSCD_WPA || type == AndersenSFR_WPA || type == Steensgaard_WPA)
+            || type == AndersenSCD_WPA || type == AndersenSFR_WPA)
     {
-        ptD = new MutDiffPTDataTy();
+        // Only maintain reverse points-to when the analysis is field-sensitive.
+        ptD = new MutDiffPTDataTy(Options::MaxFieldLimit != 0);
+    }
+    else if (type == Steensgaard_WPA)
+    {
+        ptD = new MutDiffPTDataTy(false);
     }
     else if (type == FSSPARSE_WPA || type == FSTBHC_WPA)
     {

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -519,14 +519,13 @@ bool Andersen::collapseField(NodeID nodeId)
         if (fieldId != baseId)
         {
             // use the reverse pts of this field node to find all pointers point to it
-            const NodeSet &revPts = getRevPts(fieldId);
-            for (NodeSet::const_iterator ptdIt = revPts.begin(), ptdEit = revPts.end();
-                    ptdIt != ptdEit; ptdIt++)
+            const NodeBS &revPts = getRevPts(fieldId);
+            for (const NodeID o : revPts)
             {
                 // change the points-to target from field to base node
-                clearPts(*ptdIt, fieldId);
-                addPts(*ptdIt, baseId);
-                pushIntoWorklist(*ptdIt);
+                clearPts(o, fieldId);
+                addPts(o, baseId);
+                pushIntoWorklist(o);
 
                 changed = true;
             }


### PR DESCRIPTION
As discussed, the reverse set data structure is now controllable.

I also disabled the reverse set when the analysis is field-insensitive. Steensgaard is always field-insensitive of course, so it's never enabled.