### PR TITLE
Add --print-symbol-table option to print SymbolTableInfo after it is built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ doxygen/
 *.opt
 *.log
 *.status
+*.obj
+toc.txt
+cmake-build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project("SVF")
 # To support both in- and out-of-source builds,
 # we check for the presence of the add_llvm_loadable_module command.
 # - if this command is not present, we are building out-of-source
+set(ENV{LLVM_DIR} "/home/fordrl/localllvm")
 if(NOT COMMAND add_llvm_library)
     if (DEFINED LLVM_DIR)
         set(ENV{LLVM_DIR} "${LLVM_DIR}")

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -423,6 +423,11 @@ public:
     /// Debug method
     void printFlattenFields(const Type* type);
 
+    static std::string toString(SYMTYPE symtype);
+
+    /// Another debug method
+    virtual void dump();
+
 protected:
     /// Collect the struct info
     virtual void collectStructInfo(const StructType *T);

--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -55,6 +55,12 @@ inline raw_ostream &errs()
     return llvm::errs();
 }
 
+/// Overwrite llvm::errs()
+inline raw_ostream &dbgs()
+{
+    return llvm::dbgs();
+}
+
 /// Dump sparse bitvector set
 void dumpSet(NodeBS To, raw_ostream & O = SVFUtil::outs());
 

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -45,6 +45,8 @@ using namespace std;
 using namespace SVF;
 using namespace SVFUtil;
 
+static llvm::cl::opt<bool> SymTabPrint("print-symbol-table", llvm::cl::init(false),
+                                    llvm::cl::desc("Print Symbol Table to command line"));
 
 DataLayout* SymbolTableInfo::dl = nullptr;
 SymbolTableInfo* SymbolTableInfo::symInfo = nullptr;
@@ -591,6 +593,9 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule)
     }
 
     NodeIDAllocator::get()->endSymbolAllocation();
+    if (SymTabPrint) {
+        SymbolTableInfo::SymbolInfo()->dump();
+    }
 }
 
 /*!
@@ -1005,6 +1010,101 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     }
 }
 
+std::string SymbolTableInfo::toString(SYMTYPE symtype)
+{
+    switch (symtype) {
+        case SYMTYPE::BlackHole: {
+            return "BlackHole";
+        }
+        case SYMTYPE::ConstantObj: {
+            return "ConstantObj";
+        }
+        case SYMTYPE::BlkPtr: {
+            return "BlkPtr";
+        }
+        case SYMTYPE::NullPtr: {
+            return "NullPtr";
+        }
+        case SYMTYPE::ValSym: {
+            return "ValSym";
+        }
+        case SYMTYPE::ObjSym: {
+            return "ObjSym";
+        }
+        case SYMTYPE::RetSym: {
+            return "RetSym";
+        }
+        case SYMTYPE::VarargSym: {
+            return "VarargSym";
+        }
+        default: {
+            return "Invalid SYMTYPE";
+        }
+    }
+}
+
+void SymbolTableInfo::dump()
+{
+    OrderedMap<SymID, Value*> idmap;
+    SymID maxid = 0;
+    for (ValueToIDMapTy::iterator iter = valSymMap.begin(); iter != valSymMap.end();
+         ++iter)
+    {
+        const SymID i = iter->second;
+        maxid = max(i, maxid);
+        Value* val = (Value*) iter->first;
+        idmap[i] = val;
+    }
+    for (ValueToIDMapTy::iterator iter = objSymMap.begin(); iter != objSymMap.end();
+         ++iter)
+    {
+        const SymID i = iter->second;
+        maxid = max(i, maxid);
+        Value* val = (Value*) iter->first;
+        idmap[i] = val;
+    }
+    for (FunToIDMapTy::iterator iter = returnSymMap.begin(); iter != returnSymMap.end();
+         ++iter)
+    {
+        const SymID i = iter->second;
+        maxid = max(i, maxid);
+        Value* val = (Value*) iter->first;
+        idmap[i] = val;
+    }
+    for (FunToIDMapTy::iterator iter = varargSymMap.begin(); iter != varargSymMap.end();
+         ++iter)
+    {
+        const SymID i = iter->second;
+        maxid = max(i, maxid);
+        Value* val = (Value*) iter->first;
+        idmap[i] = val;
+    }
+    dbgs() << "{SymbolTableInfo \n";
+    for (SymID symid = 0; symid <= maxid; ++symid) {
+        SYMTYPE symtype = this->symTyMap.at(symid);
+        string typestring = toString(symtype);
+        dbgs() << "  " << typestring << symid;
+        if (symtype < SYMTYPE::ValSym) {
+            dbgs() << "\n";
+        } else {
+            auto I = idmap.find(symid);
+            if (I == idmap.end()) {
+                dbgs() << "No value\n";
+                break;
+            }
+            const Value* val = I->second;
+            dbgs() << " -> ";
+            if (const Function *fun = SVFUtil::dyn_cast<Function>(val)) {
+                // fun->dump();
+                string nm = fun->getName();
+                dbgs() << "Function " << nm << "\n";
+            }else{
+                val->dump();
+            }
+        }
+    }
+    dbgs() << "}\n";
+}
 
 /*
  * Get the type size given a target data layout


### PR DESCRIPTION
The purpose of dumping the SymbolTableInfo is to be able to correlate the SymID numbers with the LLVM IR. The --print-symbol-table option will print the information for each symbol id in order.