### PR TITLE
Add --print-symbol-table option

### DIFF
--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -423,6 +423,11 @@ public:
     /// Debug method
     void printFlattenFields(const Type* type);
 
+    static std::string toString(SYMTYPE symtype);
+
+    /// Another debug method
+    virtual void dump();
+
 protected:
     /// Collect the struct info
     virtual void collectStructInfo(const StructType *T);

--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -55,6 +55,12 @@ inline raw_ostream &errs()
     return llvm::errs();
 }
 
+/// Overwrite llvm::errs()
+inline raw_ostream &dbgs()
+{
+    return llvm::dbgs();
+}
+
 /// Dump sparse bitvector set
 void dumpSet(NodeBS To, raw_ostream & O = SVFUtil::outs());
 


### PR DESCRIPTION
It is helpful to be able to correlate the SymID numbers in the symbol table with the LLVM IR. This pull request adds a 

--print-symbol-table 

option which will print the symbol table after it has been created. 