### PR TITLE
Add --print-symbol-table option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ doxygen/
 *.opt
 *.log
 *.status
+*.obj

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -423,6 +423,11 @@ public:
     /// Debug method
     void printFlattenFields(const Type* type);
 
+    static std::string toString(SYMTYPE symtype);
+
+    /// Another debug method
+    virtual void dump();
+
 protected:
     /// Collect the struct info
     virtual void collectStructInfo(const StructType *T);

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -163,6 +163,7 @@ public:
     // SymbolTableInfo.cpp
     static const llvm::cl::opt<bool> LocMemModel;
     static const llvm::cl::opt<bool> ModelConsts;
+    static const llvm::cl::opt<bool> SymTabPrint;
 
     // Conditions.cpp
     static const llvm::cl::opt<unsigned> MaxBddSize;

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -45,7 +45,6 @@ using namespace std;
 using namespace SVF;
 using namespace SVFUtil;
 
-
 DataLayout* SymbolTableInfo::dl = nullptr;
 SymbolTableInfo* SymbolTableInfo::symInfo = nullptr;
 
@@ -585,6 +584,9 @@ void SymbolTableInfo::buildMemModel(SVFModule* svfModule)
     }
 
     NodeIDAllocator::get()->endSymbolAllocation();
+    if (Options::SymTabPrint) {
+        SymbolTableInfo::SymbolInfo()->dump();
+    }
 }
 
 /*!
@@ -999,6 +1001,94 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     }
 }
 
+std::string SymbolTableInfo::toString(SYMTYPE symtype)
+{
+    switch (symtype) {
+        case SYMTYPE::BlackHole: {
+            return "BlackHole";
+        }
+        case SYMTYPE::ConstantObj: {
+            return "ConstantObj";
+        }
+        case SYMTYPE::BlkPtr: {
+            return "BlkPtr";
+        }
+        case SYMTYPE::NullPtr: {
+            return "NullPtr";
+        }
+        case SYMTYPE::ValSym: {
+            return "ValSym";
+        }
+        case SYMTYPE::ObjSym: {
+            return "ObjSym";
+        }
+        case SYMTYPE::RetSym: {
+            return "RetSym";
+        }
+        case SYMTYPE::VarargSym: {
+            return "VarargSym";
+        }
+        default: {
+            return "Invalid SYMTYPE";
+        }
+    }
+}
+
+void SymbolTableInfo::dump()
+{
+    OrderedMap<SymID, Value*> idmap;
+    SymID maxid = 0;
+    for (ValueToIDMapTy::iterator iter = valSymMap.begin(); iter != valSymMap.end();
+         ++iter)
+    {
+        const SymID i = iter->second;
+        maxid = max(i, maxid);
+        Value* val = (Value*) iter->first;
+        idmap[i] = val;
+    }
+    for (ValueToIDMapTy::iterator iter = objSymMap.begin(); iter != objSymMap.end();
+         ++iter)
+    {
+        const SymID i = iter->second;
+        maxid = max(i, maxid);
+        Value* val = (Value*) iter->first;
+        idmap[i] = val;
+    }
+    for (FunToIDMapTy::iterator iter = returnSymMap.begin(); iter != returnSymMap.end();
+         ++iter)
+    {
+        const SymID i = iter->second;
+        maxid = max(i, maxid);
+        Value* val = (Value*) iter->first;
+        idmap[i] = val;
+    }
+    for (FunToIDMapTy::iterator iter = varargSymMap.begin(); iter != varargSymMap.end();
+         ++iter)
+    {
+        const SymID i = iter->second;
+        maxid = max(i, maxid);
+        Value* val = (Value*) iter->first;
+        idmap[i] = val;
+    }
+    outs() << "{SymbolTableInfo \n";
+    for (SymID symid = 0; symid <= maxid; ++symid) {
+        SYMTYPE symtype = this->symTyMap.at(symid);
+        string typestring = toString(symtype);
+        outs() << "  " << typestring << symid;
+        if (symtype < SYMTYPE::ValSym) {
+            outs() << "\n";
+        } else {
+            auto I = idmap.find(symid);
+            if (I == idmap.end()) {
+                outs() << "No value\n";
+                break;
+            }
+            const Value* val = I->second;
+            outs() << " -> " << value2String(val) << "\n";
+        }
+    }
+    outs() << "}\n";
+}
 
 /*
  * Get the type size given a target data layout

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -526,7 +526,12 @@ namespace SVF
         llvm::cl::desc("Modeling individual constant objects")
     );
 
-    
+    const llvm::cl::opt<bool> Options::SymTabPrint(
+            "print-symbol-table", llvm::cl::init(false),
+            llvm::cl::desc("Print Symbol Table to command line")
+    );
+
+
     // Conditions.cpp
     const llvm::cl::opt<unsigned> Options::MaxBddSize(
         "max-bdd-size",  


### PR DESCRIPTION
It is helpful to be able to correlate the SymID numbers in the symbol table with the LLVM IR. This pull request adds a

--print-symbol-table

option which will print the symbol table after it has been created.
This version uses outs() instead of dbgs(), and uses Value:print instead
of Value::dump [which only exists in debug builds].