### PR TITLE
Add SVFFunction::viewCFG* methods

### DIFF
--- a/include/Util/BasicTypes.h
+++ b/include/Util/BasicTypes.h
@@ -253,6 +253,12 @@ public:
         return getLLVMFun()->isVarArg();
     }
 
+    // Dump Control Flow Graph of llvm function, with instructions
+    void viewCFG();
+
+    // Dump Control Flow Graph of llvm function, without instructions
+    void viewCFGOnly();
+
 };
 
 class SVFGlobal : public SVFValue

--- a/lib/Util/SVFUtil.cpp
+++ b/lib/Util/SVFUtil.cpp
@@ -341,3 +341,15 @@ const std::string SVFUtil::value2String(const Value* value) {
     }
     return rawstr.str();
 }
+
+void SVFFunction::viewCFG() {
+    if (fun != nullptr) {
+        fun->viewCFG();
+    }
+}
+
+void SVFFunction::viewCFGOnly() {
+    if (fun != nullptr) {
+        fun->viewCFGOnly();
+    }
+}


### PR DESCRIPTION
This pull request adds a couple of methods that make use of the LLVM ViewGraph facility whereby graphs can be displayed dynamically during a debugging session. These particular methods will dump the function control flow graph corresponding to an SVFFunction, either with the instructions (viewCFG), or without the instructions (viewCFGOnly).