### PR TITLE
Improve Interprocedural Control-Flow Graph (ICFG) debugging experience

### DIFF
--- a/include/Graphs/ICFG.h
+++ b/include/Graphs/ICFG.h
@@ -103,6 +103,9 @@ public:
     /// Dump graph into dot file
     void dump(const std::string& file, bool simple = false);
 
+    /// View graph from the debugger
+    void view();
+
     /// update ICFG for indirect calls
     void updateCallGraph(PTACallGraph* callgraph);
 

--- a/include/Graphs/ICFGNode.h
+++ b/include/Graphs/ICFGNode.h
@@ -126,6 +126,8 @@ public:
 
     virtual const std::string toString() const;
 
+    void dump() const;
+
 protected:
     const SVFFunction* fun;
     const BasicBlock* bb;

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -153,6 +153,13 @@ public:
         }
         return pag;
     }
+
+    /// Return pointer to PAG if it has been built, otherwise nullptr.
+    static inline PAG* tryGetPAG()
+    {
+        return pag;
+    }
+
     static void releasePAG()
     {
         if (pag)

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -144,11 +144,16 @@ public:
     }
 
     /// Singleton design here to make sure we only have one instance during any analysis
+    /// Sometimes we want to check if PAG has been made, but not make it if it has not.
+    /// In that case use skipCreate = true.
     //@{
-    static inline PAG* getPAG(bool buildFromFile = false)
+    static inline PAG* getPAG(bool buildFromFile = false, bool skipCreate = false)
     {
         if (pag == nullptr)
         {
+            if (skipCreate) {
+                return nullptr;
+            }
             pag = new PAG(buildFromFile);
         }
         return pag;

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -144,16 +144,11 @@ public:
     }
 
     /// Singleton design here to make sure we only have one instance during any analysis
-    /// Sometimes we want to check if PAG has been made, but not make it if it has not.
-    /// In that case use skipCreate = true.
     //@{
-    static inline PAG* getPAG(bool buildFromFile = false, bool skipCreate = false)
+    static inline PAG* getPAG(bool buildFromFile = false)
     {
         if (pag == nullptr)
         {
-            if (skipCreate) {
-                return nullptr;
-            }
             pag = new PAG(buildFromFile);
         }
         return pag;

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -86,6 +86,7 @@ public:
     static const llvm::cl::opt<unsigned> StatBudget;
     static const llvm::cl::opt<bool> PAGDotGraph;
     static const llvm::cl::opt<bool> DumpICFG;
+    static const llvm::cl::opt<bool> IncludePAGInICFGDump;
     static const llvm::cl::opt<bool> CallGraphDotGraph;
     static const llvm::cl::opt<bool> PAGPrint;
     static const llvm::cl::opt<unsigned> IndirectCallLimit;

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -27,6 +27,7 @@
  *      Author: Yulei Sui
  */
 
+#include <Util/Options.h>
 #include "SVF-FE/LLVMUtil.h"
 #include "Util/SVFModule.h"
 #include "Graphs/ICFG.h"
@@ -64,6 +65,9 @@ const std::string ICFGNode::toString() const {
     return rawstr.str();
 }
 
+void ICFGNode::dump() const {
+    outs() << this->toString() << "\n";
+}
 
 const std::string GlobalBlockNode::toString() const {
     std::string str;
@@ -397,6 +401,14 @@ void ICFG::dump(const std::string& file, bool simple)
 }
 
 /*!
+ * View ICFG
+ */
+void ICFG::view()
+{
+    llvm::ViewGraph(this, "Interprocedural Control-Flow Graph");
+}
+
+/*!
  * Update ICFG for indirect calls
  */
 void ICFG::updateCallGraph(PTACallGraph* callgraph)
@@ -460,11 +472,16 @@ struct DOTGraphTraits<ICFG*> : public DOTGraphTraits<PAG*>
         if (IntraBlockNode* bNode = SVFUtil::dyn_cast<IntraBlockNode>(node))
         {
             rawstr << "IntraBlockNode ID: " << bNode->getId() << " \t";
-            PAG::PAGEdgeList&  edges = PAG::getPAG()->getInstPTAPAGEdgeList(bNode);
-            for (PAG::PAGEdgeList::iterator it = edges.begin(), eit = edges.end(); it != eit; ++it)
-            {
-                const PAGEdge* edge = *it;
-                rawstr << edge->toString();
+            rawstr << value2String(bNode->getInst()) << " \t";
+            if (Options::IncludePAGInICFGDump) {
+                if (PAG* pag = PAG::tryGetPAG()) {
+                    PAG::PAGEdgeList&  edges = pag->getInstPTAPAGEdgeList(bNode);
+                    for (PAG::PAGEdgeList::iterator it = edges.begin(), eit = edges.end(); it != eit; ++it)
+                    {
+                        const PAGEdge* edge = *it;
+                        rawstr << edge->toString();
+                    }
+                }
             }
             rawstr << " {fun: " << bNode->getFun()->getName() << "}";
         }
@@ -486,11 +503,15 @@ struct DOTGraphTraits<ICFG*> : public DOTGraphTraits<PAG*>
         }
         else if (GlobalBlockNode* glob  = SVFUtil::dyn_cast<GlobalBlockNode>(node) )
         {
-            PAG::PAGEdgeList&  edges = PAG::getPAG()->getInstPTAPAGEdgeList(glob);
-            for (PAG::PAGEdgeList::iterator it = edges.begin(), eit = edges.end(); it != eit; ++it)
-            {
-                const PAGEdge* edge = *it;
-                rawstr << edge->toString();
+            if (Options::IncludePAGInICFGDump) {
+                if (PAG* pag = PAG::tryGetPAG()) {
+                    PAG::PAGEdgeList&  edges = pag->getInstPTAPAGEdgeList(glob);
+                    for (PAG::PAGEdgeList::iterator it = edges.begin(), eit = edges.end(); it != eit; ++it)
+                    {
+                        const PAGEdge* edge = *it;
+                        rawstr << edge->toString();
+                    }
+                }
             }
         }
         else

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -572,14 +572,14 @@ NodeID PAG::getGepObjNode(const MemObj* obj, const LocationSet& ls)
 {
     NodeID base = getObjectNode(obj);
 
-    // Base and first field are the same memory location.
-    if (Options::FirstFieldEqBase && ls.getOffset() == 0) return base;
-
     /// if this obj is field-insensitive, just return the field-insensitive node.
     if (obj->isFieldInsensitive())
         return getFIObjNode(obj);
 
     LocationSet newLS = SymbolTableInfo::SymbolInfo()->getModulusOffset(obj,ls);
+
+    // Base and first field are the same memory location.
+    if (Options::FirstFieldEqBase && ls.getOffset() == 0) return base;
 
     NodeLocationSetMap::iterator iter = GepObjNodeMap.find(std::make_pair(base, newLS));
     if (iter == GepObjNodeMap.end())

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -261,6 +261,12 @@ namespace SVF
         llvm::cl::desc("Dump dot graph of ICFG")
     );
 
+    const llvm::cl::opt<bool> Options::IncludePAGInICFGDump(
+         "include-pag-icfg-dump",
+         llvm::cl::init(true),
+         llvm::cl::desc("When dumping ICFG, include Program Assignment Graph information.")
+    );
+
     const llvm::cl::opt<bool> Options::CallGraphDotGraph(
         "dump-callgraph", 
         llvm::cl::init(false),


### PR DESCRIPTION
The changes are for the following:
1. Probably most importantly, when the dot graph of the ICFG
   is produced, it was not showing the LLVM instruction for the
   IntraBlockNodes. This changed adds the needed code.
2. Added a dump method for ICFGNodes which just prints the
   toString() contents to the console.
3. Added a ICFG::view() method that will pop up a dot dump of the
   ICFG using the viewer selected by xdg-open for .dot files.
4. It is possible one might want to view the ICFG before the
   Program Assignment Graph (PAG) has been built. However
   the ICFG stores some data related to the PAG and the
   graph writer for the ICFG tries to access the PAG.
   This change modifes PAG::getPAG by adding an additional
   parameter, skipCreate, which defaults to false.
   When the ICFG dot graph is being created, it calls
   PAG::getPAP with skipCreate false. This will return the
   PAG pointer, if it has been created, but return null if not.
   If it is null, then it skips trying to dump PAG-related
   information.