### PR TITLE
Move base check after modulus offset

### DIFF
--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -572,14 +572,14 @@ NodeID PAG::getGepObjNode(const MemObj* obj, const LocationSet& ls)
 {
     NodeID base = getObjectNode(obj);
 
-    // Base and first field are the same memory location.
-    if (Options::FirstFieldEqBase && ls.getOffset() == 0) return base;
-
     /// if this obj is field-insensitive, just return the field-insensitive node.
     if (obj->isFieldInsensitive())
         return getFIObjNode(obj);
 
     LocationSet newLS = SymbolTableInfo::SymbolInfo()->getModulusOffset(obj,ls);
+
+    // Base and first field are the same memory location.
+    if (Options::FirstFieldEqBase && ls.getOffset() == 0) return base;
 
     NodeLocationSetMap::iterator iter = GepObjNodeMap.find(std::make_pair(base, newLS));
     if (iter == GepObjNodeMap.end())


### PR DESCRIPTION
The offset of `newLS` can be 0, which is the base object (when `Options::FirstFieldEqBase`). This appears to be the source of rare non-subsetness of VFS (and probably FS), as we discussed earlier, since it would try to create a GEP object from the offset of `newLS`.