### PR TITLE
Improve Interprocedural Control-Flow Graph (ICFG) debugging experience

### DIFF
--- a/include/Graphs/ICFG.h
+++ b/include/Graphs/ICFG.h
@@ -103,6 +103,9 @@ public:
     /// Dump graph into dot file
     void dump(const std::string& file, bool simple = false);
 
+    /// View graph from the debugger
+    void view();
+
     /// update ICFG for indirect calls
     void updateCallGraph(PTACallGraph* callgraph);
 

--- a/include/Graphs/ICFGNode.h
+++ b/include/Graphs/ICFGNode.h
@@ -126,6 +126,8 @@ public:
 
     virtual const std::string toString() const;
 
+    void dump() const;
+
 protected:
     const SVFFunction* fun;
     const BasicBlock* bb;

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -86,6 +86,7 @@ public:
     static const llvm::cl::opt<unsigned> StatBudget;
     static const llvm::cl::opt<bool> PAGDotGraph;
     static const llvm::cl::opt<bool> DumpICFG;
+    static const llvm::cl::opt<bool> IncludePAGInICFGDump;
     static const llvm::cl::opt<bool> CallGraphDotGraph;
     static const llvm::cl::opt<bool> PAGPrint;
     static const llvm::cl::opt<unsigned> IndirectCallLimit;

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -261,6 +261,12 @@ namespace SVF
         llvm::cl::desc("Dump dot graph of ICFG")
     );
 
+    const llvm::cl::opt<bool> Options::IncludePAGInICFGDump(
+         "include-pag-icfg-dump",
+         llvm::cl::init(true),
+         llvm::cl::desc("When dumping ICFG, include Program Assignment Graph information.")
+    );
+
     const llvm::cl::opt<bool> Options::CallGraphDotGraph(
         "dump-callgraph", 
         llvm::cl::init(false),


### PR DESCRIPTION
The changes are for the following:
1. Probably most importantly, when the dot graph of the ICFG
   is produced, it was not showing the LLVM instruction for the
   IntraBlockNodes. This changed adds the needed code.
2. Added a dump method for ICFGNodes which just prints the
   toString() contents to the console.
3. Added a ICFG::view() method that will pop up a dot dump of the
   ICFG using the viewer selected by xdg-open for .dot files.
4. Add -include-pag-icfg-dump option to control PAG info in ICFG dump
   This change puts the dumping of program assignment graph (PAG) information
   as part of dumping the interprocedural control-flow graph (ICFG)
   under the control of an option. The option defaults to true so as
   to preserve the current behavior.