### PR TITLE
Improve Interprocedural Control-Flow Graph (ICFG) debugging experience

### DIFF
--- a/include/Graphs/ICFG.h
+++ b/include/Graphs/ICFG.h
@@ -103,6 +103,9 @@ public:
     /// Dump graph into dot file
     void dump(const std::string& file, bool simple = false);
 
+    /// View graph from the debugger
+    void view();
+
     /// update ICFG for indirect calls
     void updateCallGraph(PTACallGraph* callgraph);
 

--- a/include/Graphs/ICFGNode.h
+++ b/include/Graphs/ICFGNode.h
@@ -126,6 +126,8 @@ public:
 
     virtual const std::string toString() const;
 
+    void dump() const;
+
 protected:
     const SVFFunction* fun;
     const BasicBlock* bb;

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -86,6 +86,7 @@ public:
     static const llvm::cl::opt<unsigned> StatBudget;
     static const llvm::cl::opt<bool> PAGDotGraph;
     static const llvm::cl::opt<bool> DumpICFG;
+    static const llvm::cl::opt<bool> IncludePAGInICFGDump;
     static const llvm::cl::opt<bool> CallGraphDotGraph;
     static const llvm::cl::opt<bool> PAGPrint;
     static const llvm::cl::opt<unsigned> IndirectCallLimit;

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -27,6 +27,7 @@
  *      Author: Yulei Sui
  */
 
+#include <Util/Options.h>
 #include "SVF-FE/LLVMUtil.h"
 #include "Util/SVFModule.h"
 #include "Graphs/ICFG.h"
@@ -64,6 +65,9 @@ const std::string ICFGNode::toString() const {
     return rawstr.str();
 }
 
+void ICFGNode::dump() const {
+    outs() << this->toString() << "\n";
+}
 
 const std::string GlobalBlockNode::toString() const {
     std::string str;
@@ -397,6 +401,14 @@ void ICFG::dump(const std::string& file, bool simple)
 }
 
 /*!
+ * View ICFG
+ */
+void ICFG::view()
+{
+    llvm::ViewGraph(this, "Interprocedural Control-Flow Graph");
+}
+
+/*!
  * Update ICFG for indirect calls
  */
 void ICFG::updateCallGraph(PTACallGraph* callgraph)
@@ -460,11 +472,22 @@ struct DOTGraphTraits<ICFG*> : public DOTGraphTraits<PAG*>
         if (IntraBlockNode* bNode = SVFUtil::dyn_cast<IntraBlockNode>(node))
         {
             rawstr << "IntraBlockNode ID: " << bNode->getId() << " \t";
-            PAG::PAGEdgeList&  edges = PAG::getPAG()->getInstPTAPAGEdgeList(bNode);
-            for (PAG::PAGEdgeList::iterator it = edges.begin(), eit = edges.end(); it != eit; ++it)
-            {
-                const PAGEdge* edge = *it;
-                rawstr << edge->toString();
+            if (Options::IncludePAGInICFGDump) {
+                PAG::PAGEdgeList&  edges = PAG::getPAG()->getInstPTAPAGEdgeList(bNode);
+                rawstr << value2String(bNode->getInst()) << " \t";
+                PAG::PAGEdgeList::iterator it = edges.begin(), eit = edges.end();
+                if (it == eit) {
+                    // No edges, so we need to dump the instruction.
+                    rawstr << value2String(bNode->getInst()) << " \t";
+                }  else {
+                    for (; it != eit; ++it)
+                    {
+                        const PAGEdge* edge = *it;
+                        rawstr << edge->toString();
+                    }
+                }
+            } else {
+                rawstr << value2String(bNode->getInst()) << " \t";
             }
             rawstr << " {fun: " << bNode->getFun()->getName() << "}";
         }
@@ -486,11 +509,13 @@ struct DOTGraphTraits<ICFG*> : public DOTGraphTraits<PAG*>
         }
         else if (GlobalBlockNode* glob  = SVFUtil::dyn_cast<GlobalBlockNode>(node) )
         {
-            PAG::PAGEdgeList&  edges = PAG::getPAG()->getInstPTAPAGEdgeList(glob);
-            for (PAG::PAGEdgeList::iterator it = edges.begin(), eit = edges.end(); it != eit; ++it)
-            {
-                const PAGEdge* edge = *it;
-                rawstr << edge->toString();
+            if (Options::IncludePAGInICFGDump) {
+                PAG::PAGEdgeList&  edges = PAG::getPAG()->getInstPTAPAGEdgeList(glob);
+                for (PAG::PAGEdgeList::iterator it = edges.begin(), eit = edges.end(); it != eit; ++it)
+                {
+                    const PAGEdge* edge = *it;
+                    rawstr << edge->toString();
+                }
             }
         }
         else

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -261,6 +261,12 @@ namespace SVF
         llvm::cl::desc("Dump dot graph of ICFG")
     );
 
+    const llvm::cl::opt<bool> Options::IncludePAGInICFGDump(
+         "include-pag-icfg-dump",
+         llvm::cl::init(true),
+         llvm::cl::desc("When dumping ICFG, include Program Assignment Graph information.")
+    );
+
     const llvm::cl::opt<bool> Options::CallGraphDotGraph(
         "dump-callgraph", 
         llvm::cl::init(false),


### PR DESCRIPTION
The changes are for the following:
1. Probably most importantly, when the dot graph of the ICFG
   is produced, it was not showing the LLVM instruction for the
   IntraBlockNodes if there were no PAG edges, or if the
   user selected not to show PAG information.
   This changed adds the needed code.
2. Added a dump method for ICFGNodes which just prints the
   toString() contents to the console.
3. Added a ICFG::view() method that will pop up a dot dump of the
   ICFG using the viewer selected by xdg-open for .dot files.
4. Add -include-pag-icfg-dump option to control PAG info in ICFG dump
   This change puts the dumping of program assignment graph (PAG) information
   as part of dumping the interprocedural control-flow graph (ICFG)
   under the control of an option. The option defaults to true so as
   to preserve the current behavior.