### PR TITLE
Improve Program Assignment Graph (PAG) Debugging experience

### DIFF
--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -842,6 +842,9 @@ public:
     /// Dump PAG
     void dump(std::string name);
 
+    /// View graph from the debugger
+    void view();
+
 };
 
 } // End namespace SVF

--- a/include/Graphs/PAGNode.h
+++ b/include/Graphs/PAGNode.h
@@ -250,6 +250,9 @@ public:
 
     virtual const std::string toString() const;
 
+    /// Dump to console for debugging
+    void dump() const;
+
     //@}
     /// Overloading operator << for dumping PAGNode value
     //@{

--- a/include/Graphs/PAGNode.h
+++ b/include/Graphs/PAGNode.h
@@ -250,6 +250,9 @@ public:
 
     virtual const std::string toString() const;
 
+    /// Get shape and/or color of node for .dot display.
+    virtual const std::string getNodeAttributes() const;
+
     /// Dump to console for debugging
     void dump() const;
 

--- a/include/Graphs/PAGNode.h
+++ b/include/Graphs/PAGNode.h
@@ -251,7 +251,7 @@ public:
     virtual const std::string toString() const;
 
     /// Get shape and/or color of node for .dot display.
-    virtual const std::string getNodeAttributes() const;
+    virtual const std::string getNodeAttrForDotDisplay() const;
 
     /// Dump to console for debugging
     void dump() const;

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -85,6 +85,7 @@ public:
     static const llvm::cl::opt<bool> PStat;
     static const llvm::cl::opt<unsigned> StatBudget;
     static const llvm::cl::opt<bool> PAGDotGraph;
+    static const llvm::cl::opt<bool> PAGDotGraphShorter;
     static const llvm::cl::opt<bool> DumpICFG;
     static const llvm::cl::opt<bool> CallGraphDotGraph;
     static const llvm::cl::opt<bool> PAGPrint;

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -649,7 +649,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<PAG*>
     static std::string getNodeAttributes(NodeType *n, ConstraintGraph*)
     {
         PAGNode* node = PAG::getPAG()->getPAGNode(n->getId());
-        return node->getNodeAttributes();
+        return node->getNodeAttrForDotDisplay();
     }
 
     template<class EdgeIter>

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -649,40 +649,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<PAG*>
     static std::string getNodeAttributes(NodeType *n, ConstraintGraph*)
     {
         PAGNode* node = PAG::getPAG()->getPAGNode(n->getId());
-
-        if (SVFUtil::isa<ValPN>(node))
-        {
-            if(SVFUtil::isa<GepValPN>(node))
-                return "shape=hexagon";
-            else if (SVFUtil::isa<DummyValPN>(node))
-                return "shape=diamond";
-            else
-                return "shape=box";
-        }
-        else if (SVFUtil::isa<ObjPN>(node))
-        {
-            if(SVFUtil::isa<GepObjPN>(node))
-                return "shape=doubleoctagon";
-            else if(SVFUtil::isa<FIObjPN>(node))
-                return "shape=septagon";
-            else if (SVFUtil::isa<DummyObjPN>(node))
-                return "shape=house";
-            else
-                return "shape=invhouse";
-        }
-        else if (SVFUtil::isa<RetPN>(node))
-        {
-            return "shape=Mrecord";
-        }
-        else if (SVFUtil::isa<VarArgPN>(node))
-        {
-            return "shape=octagon";
-        }
-        else
-        {
-            assert(0 && "no such kind node!!");
-        }
-        return "";
+        return node->getNodeAttributes();
     }
 
     template<class EdgeIter>

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -657,7 +657,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<PAG*>
             else if (SVFUtil::isa<DummyValPN>(node))
                 return "shape=diamond";
             else
-                return "shape=circle";
+                return "shape=box";
         }
         else if (SVFUtil::isa<ObjPN>(node))
         {
@@ -666,9 +666,9 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<PAG*>
             else if(SVFUtil::isa<FIObjPN>(node))
                 return "shape=septagon";
             else if (SVFUtil::isa<DummyObjPN>(node))
-                return "shape=Mcircle";
+                return "shape=house";
             else
-                return "shape=doublecircle";
+                return "shape=invhouse";
         }
         else if (SVFUtil::isa<RetPN>(node))
         {

--- a/lib/Graphs/OfflineConsG.cpp
+++ b/lib/Graphs/OfflineConsG.cpp
@@ -243,7 +243,7 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<PAG*>
         if (PAG::getPAG()->findPAGNode(n->getId()))
         {
             PAGNode *node = PAG::getPAG()->getPAGNode(n->getId());
-            return node->getNodeAttributes();
+            return node->getNodeAttrForDotDisplay();
         }
         else
         {

--- a/lib/Graphs/OfflineConsG.cpp
+++ b/lib/Graphs/OfflineConsG.cpp
@@ -243,43 +243,11 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<PAG*>
         if (PAG::getPAG()->findPAGNode(n->getId()))
         {
             PAGNode *node = PAG::getPAG()->getPAGNode(n->getId());
-            if (SVFUtil::isa<ValPN>(node))
-            {
-                if (SVFUtil::isa<GepValPN>(node))
-                    return "shape=hexagon";
-                else if (SVFUtil::isa<DummyValPN>(node))
-                    return "shape=diamond";
-                else
-                    return "shape=box";
-            }
-            else if (SVFUtil::isa<ObjPN>(node))
-            {
-                if (SVFUtil::isa<GepObjPN>(node))
-                    return "shape=doubleoctagon";
-                else if (SVFUtil::isa<FIObjPN>(node))
-                    return "shape=septagon";
-                else if (SVFUtil::isa<DummyObjPN>(node))
-                    return "shape=house";
-                else
-                    return "shape=invhouse";
-            }
-            else if (SVFUtil::isa<RetPN>(node))
-            {
-                return "shape=Mrecord";
-            }
-            else if (SVFUtil::isa<VarArgPN>(node))
-            {
-                return "shape=octagon";
-            }
-            else
-            {
-                assert(0 && "no such kind node!!");
-            }
-            return "";
+            return node->getNodeAttributes();
         }
         else
         {
-            return "shape=invhouse";
+            return "shape=folder";
         }
     }
 

--- a/lib/Graphs/OfflineConsG.cpp
+++ b/lib/Graphs/OfflineConsG.cpp
@@ -250,7 +250,7 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<PAG*>
                 else if (SVFUtil::isa<DummyValPN>(node))
                     return "shape=diamond";
                 else
-                    return "shape=circle";
+                    return "shape=box";
             }
             else if (SVFUtil::isa<ObjPN>(node))
             {
@@ -259,9 +259,9 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<PAG*>
                 else if (SVFUtil::isa<FIObjPN>(node))
                     return "shape=septagon";
                 else if (SVFUtil::isa<DummyObjPN>(node))
-                    return "shape=Mcircle";
+                    return "shape=house";
                 else
-                    return "shape=doublecircle";
+                    return "shape=invhouse";
             }
             else if (SVFUtil::isa<RetPN>(node))
             {
@@ -279,7 +279,7 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<PAG*>
         }
         else
         {
-            return "shape=doublecircle";
+            return "shape=invhouse";
         }
     }
 

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -50,6 +50,45 @@ const std::string PAGNode::toString() const {
     return rawstr.str();
 }
 
+/// Get shape and/or color of node for .dot display.
+const std::string PAGNode::getNodeAttributes() const {
+    // TODO: Maybe use over-rides instead of these ifs,
+    // But this puts them conveniently together.
+    if (SVFUtil::isa<ValPN>(this))
+    {
+        if(SVFUtil::isa<GepValPN>(this))
+            return "shape=hexagon";
+        else if (SVFUtil::isa<DummyValPN>(this))
+            return "shape=diamond";
+        else
+            return "shape=box";
+    }
+    else if (SVFUtil::isa<ObjPN>(this))
+    {
+        if(SVFUtil::isa<GepObjPN>(this))
+            return "shape=doubleoctagon";
+        else if(SVFUtil::isa<FIObjPN>(this))
+            return "shape=box3d";
+        else if (SVFUtil::isa<DummyObjPN>(this))
+            return "shape=house";
+        else
+            return "shape=invhouse";
+    }
+    else if (SVFUtil::isa<RetPN>(this))
+    {
+        return "shape=Mrecord";
+    }
+    else if (SVFUtil::isa<VarArgPN>(this))
+    {
+        return "shape=octagon";
+    }
+    else
+    {
+        assert(0 && "no such kind!!");
+    }
+    return "";
+}
+
 void PAGNode::dump() const {
     outs() << this->toString() << "\n";
 }
@@ -58,6 +97,7 @@ const std::string ValPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "ValPN ID: " << getId();
+    rawstr << "\n";
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -66,6 +106,7 @@ const std::string ObjPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "ObjPN ID: " << getId();
+    rawstr << "\n";
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -74,6 +115,7 @@ const std::string GepValPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "GepValPN ID: " << getId() << " with offset_" + llvm::utostr(getOffset());
+    rawstr << "\n";
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -82,6 +124,7 @@ const std::string GepObjPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "GepObjPN ID: " << getId() << " with offset_" + llvm::itostr(ls.getOffset());
+    rawstr << "\n";
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -90,6 +133,7 @@ const std::string FIObjPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "FIObjPN ID: " << getId() << " (base object)";
+    rawstr << "\n";
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -154,6 +198,7 @@ const std::string AddrPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "AddrPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -162,6 +207,7 @@ const std::string CopyPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "CopyPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -170,6 +216,7 @@ const std::string CmpPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "CmpPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -178,6 +225,7 @@ const std::string BinaryOPPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "BinaryOPPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -186,6 +234,7 @@ const std::string UnaryOPPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "UnaryOPPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -194,6 +243,7 @@ const std::string LoadPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "LoadPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -202,6 +252,7 @@ const std::string StorePE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "StorePE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -210,6 +261,7 @@ const std::string GepPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "GepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -218,6 +270,7 @@ const std::string NormalGepPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "VariantGepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -226,6 +279,7 @@ const std::string VariantGepPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "VariantGepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -234,6 +288,7 @@ const std::string CallPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "CallPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -242,6 +297,7 @@ const std::string RetPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "RetPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -250,6 +306,7 @@ const std::string TDForkPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "TDForkPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -258,6 +315,7 @@ const std::string TDJoinPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "TDJoinPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "\n";
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -1049,39 +1107,7 @@ struct DOTGraphTraits<PAG*> : public DefaultDOTGraphTraits
 
     static std::string getNodeAttributes(PAGNode *node, PAG*)
     {
-        if (SVFUtil::isa<ValPN>(node))
-        {
-            if(SVFUtil::isa<GepValPN>(node))
-                return "shape=hexagon";
-            else if (SVFUtil::isa<DummyValPN>(node))
-                return "shape=diamond";
-            else
-                return "shape=box";
-        }
-        else if (SVFUtil::isa<ObjPN>(node))
-        {
-            if(SVFUtil::isa<GepObjPN>(node))
-                return "shape=doubleoctagon";
-            else if(SVFUtil::isa<FIObjPN>(node))
-                return "shape=septagon";
-            else if (SVFUtil::isa<DummyObjPN>(node))
-                return "shape=house";
-            else
-                return "shape=invhouse";
-        }
-        else if (SVFUtil::isa<RetPN>(node))
-        {
-            return "shape=Mrecord";
-        }
-        else if (SVFUtil::isa<VarArgPN>(node))
-        {
-            return "shape=octagon";
-        }
-        else
-        {
-            assert(0 && "no such kind node!!");
-        }
-        return "";
+        return node->getNodeAttributes();
     }
 
     template<class EdgeIter>

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -105,7 +105,6 @@ const std::string ObjPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "ObjPN ID: " << getId();
-    rawstr << "\n";
     rawstr << value2String(value);
     return rawstr.str();
 }

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -97,6 +97,9 @@ const std::string ValPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "ValPN ID: " << getId();
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -105,6 +108,9 @@ const std::string ObjPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "ObjPN ID: " << getId();
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -113,7 +119,9 @@ const std::string GepValPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "GepValPN ID: " << getId() << " with offset_" + llvm::utostr(getOffset());
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -122,7 +130,9 @@ const std::string GepObjPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "GepObjPN ID: " << getId() << " with offset_" + llvm::itostr(ls.getOffset());
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -131,7 +141,9 @@ const std::string FIObjPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "FIObjPN ID: " << getId() << " (base object)";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -196,7 +208,9 @@ const std::string AddrPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "AddrPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -205,7 +219,9 @@ const std::string CopyPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "CopyPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -214,7 +230,9 @@ const std::string CmpPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "CmpPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -223,7 +241,9 @@ const std::string BinaryOPPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "BinaryOPPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -232,7 +252,9 @@ const std::string UnaryOPPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "UnaryOPPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -241,7 +263,9 @@ const std::string LoadPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "LoadPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -250,7 +274,9 @@ const std::string StorePE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "StorePE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -259,7 +285,9 @@ const std::string GepPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "GepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -268,7 +296,9 @@ const std::string NormalGepPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "VariantGepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -277,7 +307,9 @@ const std::string VariantGepPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "VariantGepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -286,7 +318,9 @@ const std::string CallPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "CallPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -295,7 +329,9 @@ const std::string RetPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "RetPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -304,7 +340,9 @@ const std::string TDForkPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "TDForkPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }
@@ -313,7 +351,9 @@ const std::string TDJoinPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "TDJoinPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
-    rawstr << "\n";
+    if (Options::PAGDotGraphShorter) {
+        rawstr << "\n";
+    }
     rawstr << value2String(getValue());
     return rawstr.str();
 }

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -50,6 +50,10 @@ const std::string PAGNode::toString() const {
     return rawstr.str();
 }
 
+void PAGNode::dump() const {
+    outs() << this->toString() << "\n";
+}
+
 const std::string ValPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
@@ -983,6 +987,13 @@ void PAG::dump(std::string name)
     GraphPrinter::WriteGraphToFile(outs(), name, this);
 }
 
+/*!
+ * View PAG
+ */
+void PAG::view()
+{
+    llvm::ViewGraph(this, "ProgramAssignmentGraph");
+}
 
 /*!
  * Whether to handle blackhole edge
@@ -1045,7 +1056,7 @@ struct DOTGraphTraits<PAG*> : public DefaultDOTGraphTraits
             else if (SVFUtil::isa<DummyValPN>(node))
                 return "shape=diamond";
             else
-                return "shape=circle";
+                return "shape=box";
         }
         else if (SVFUtil::isa<ObjPN>(node))
         {
@@ -1054,9 +1065,9 @@ struct DOTGraphTraits<PAG*> : public DefaultDOTGraphTraits
             else if(SVFUtil::isa<FIObjPN>(node))
                 return "shape=septagon";
             else if (SVFUtil::isa<DummyObjPN>(node))
-                return "shape=Mcircle";
+                return "shape=house";
             else
-                return "shape=doublecircle";
+                return "shape=invhouse";
         }
         else if (SVFUtil::isa<RetPN>(node))
         {

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -70,9 +70,9 @@ const std::string PAGNode::getNodeAttributes() const {
         else if(SVFUtil::isa<FIObjPN>(this))
             return "shape=box3d";
         else if (SVFUtil::isa<DummyObjPN>(this))
-            return "shape=house";
+            return "shape=tab";
         else
-            return "shape=invhouse";
+            return "shape=component";
     }
     else if (SVFUtil::isa<RetPN>(this))
     {

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -51,7 +51,7 @@ const std::string PAGNode::toString() const {
 }
 
 /// Get shape and/or color of node for .dot display.
-const std::string PAGNode::getNodeAttributes() const {
+const std::string PAGNode::getNodeAttrForDotDisplay() const {
     // TODO: Maybe use over-rides instead of these ifs,
     // But this puts them conveniently together.
     if (SVFUtil::isa<ValPN>(this))
@@ -97,7 +97,6 @@ const std::string ValPN::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "ValPN ID: " << getId();
-    rawstr << "\n";
     rawstr << value2String(value);
     return rawstr.str();
 }
@@ -1107,7 +1106,7 @@ struct DOTGraphTraits<PAG*> : public DefaultDOTGraphTraits
 
     static std::string getNodeAttributes(PAGNode *node, PAG*)
     {
-        return node->getNodeAttributes();
+        return node->getNodeAttrForDotDisplay();
     }
 
     template<class EdgeIter>

--- a/lib/Graphs/PTACallGraph.cpp
+++ b/lib/Graphs/PTACallGraph.cpp
@@ -350,7 +350,7 @@ struct DOTGraphTraits<PTACallGraph*> : public DefaultDOTGraphTraits
         const SVFFunction* fun = node->getFunction();
         if (!SVFUtil::isExtCall(fun))
         {
-            return "shape=circle";
+            return "shape=box";
         }
         else
             return "shape=Mrecord";

--- a/lib/SVF-FE/CHG.cpp
+++ b/lib/SVF-FE/CHG.cpp
@@ -918,10 +918,10 @@ struct DOTGraphTraits<CHGraph*> : public DefaultDOTGraphTraits
     {
         if (node->isPureAbstract())
         {
-            return "shape=Mcircle";
+            return "shape=house";
         }
         else
-            return "shape=circle";
+            return "shape=box";
     }
 
     template<class EdgeIter>

--- a/lib/SVF-FE/CHG.cpp
+++ b/lib/SVF-FE/CHG.cpp
@@ -918,7 +918,7 @@ struct DOTGraphTraits<CHGraph*> : public DefaultDOTGraphTraits
     {
         if (node->isPureAbstract())
         {
-            return "shape=house";
+            return "shape=tab";
         }
         else
             return "shape=box";

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -257,7 +257,7 @@ namespace SVF
 
     const llvm::cl::opt<bool> Options::PAGDotGraphShorter(
             "dump-pag-shorter",
-            llvm::cl::init(false),
+            llvm::cl::init(true),
             llvm::cl::desc("If dumping dot graph of PAG, use shorter lines")
     );
 

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -255,6 +255,12 @@ namespace SVF
         llvm::cl::desc("Dump dot graph of PAG")
     );
 
+    const llvm::cl::opt<bool> Options::PAGDotGraphShorter(
+            "dump-pag-shorter",
+            llvm::cl::init(false),
+            llvm::cl::desc("If dumping dot graph of PAG, use shorter lines")
+    );
+
     const llvm::cl::opt<bool> Options::DumpICFG(
         "dump-icfg", 
         llvm::cl::init(false),


### PR DESCRIPTION
1. In the .dot dump of the PAG, and some other .dot dumps, change the
circle shapes to something different as the circles get really high
when the contents is wide. In particular made the following changes

circle         -> box
Mcircle        -> house
doublecircle   -> invhouse

2. Add a PAGNode::dump() method that will write
the value of PAGNode::toString() to outs().

3. Added PAG::view() method callable from within the
debugger that will pop up the formatted .dot dump,
provided the user configures xdg-open to display
.dot files.