### PR TITLE
Improve debugging of Constraint Graph

### DIFF
--- a/include/Graphs/ConsG.h
+++ b/include/Graphs/ConsG.h
@@ -362,6 +362,9 @@ public:
     void dump(std::string name);
     /// Print CG into terminal
     void print();
+
+    /// View graph from the debugger.
+    void view();
 };
 
 } // End namespace SVF

--- a/include/SVF-FE/CHG.h
+++ b/include/SVF-FE/CHG.h
@@ -216,6 +216,7 @@ public:
     const CHNodeSetTy& getCSClasses(CallSite cs);
     void getVFnsFromVtbls(CallSite cs, const VTableSet &vtbls, VFunSet &virtualFunctions) override;
     void dump(const std::string& filename);
+    void view();
     void printCH();
 
     inline s32_t getVirtualFunctionID(const SVFFunction* vfn) const

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -177,6 +177,7 @@ public:
 
     // Andersen.cpp
     static const llvm::cl::opt<bool> ConsCGDotGraph;
+    static const llvm::cl::opt<bool> BriefConsCGDotGraph;
     static const llvm::cl::opt<bool> PrintCGGraph;
     // static const llvm::cl::opt<string> WriteAnder;
     static const llvm::cl::opt<std :: string> WriteAnder;

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "Graphs/ConsG.h"
+#include "Util/Options.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -586,6 +587,13 @@ void ConstraintGraph::print()
 }
 
 /*!
+ * View dot graph of Constraint graph from debugger.
+ */
+void ConstraintGraph::view() {
+    llvm::ViewGraph(this, "Constraint Graph");
+}
+
+/*!
  * GraphTraits specialization for constraint graph
  */
 namespace llvm
@@ -616,7 +624,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<PAG*>
     static std::string getNodeLabel(NodeType *n, ConstraintGraph*)
     {
         PAGNode* node = PAG::getPAG()->getPAGNode(n->getId());
-        bool briefDisplay = true;
+        bool briefDisplay = Options::BriefConsCGDotGraph;
         bool nameDisplay = true;
         std::string str;
         raw_string_ostream rawstr(str);
@@ -637,9 +645,9 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<PAG*>
         {
             // print the whole value
             if (!SVFUtil::isa<DummyValPN>(node) && !SVFUtil::isa<DummyObjPN>(node))
-                rawstr << *node->getValue();
+                rawstr << node->getId() << ":" << value2String(node->getValue());
             else
-                rawstr << "";
+                rawstr << node->getId() << ":";
 
         }
 

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -295,7 +295,7 @@ const std::string GepPE::toString() const{
 const std::string NormalGepPE::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "VariantGepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "NormalGepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }

--- a/lib/SVF-FE/CHG.cpp
+++ b/lib/SVF-FE/CHG.cpp
@@ -886,6 +886,10 @@ void CHGraph::dump(const std::string& filename)
     printCH();
 }
 
+void CHGraph::view()
+{
+    llvm::ViewGraph(this, "Class Hierarchy Graph");
+}
 
 namespace llvm
 {

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -569,6 +569,12 @@ namespace SVF
         llvm::cl::desc("Dump dot graph of Constraint Graph")
     );
 
+    const llvm::cl::opt<bool> Options::BriefConsCGDotGraph(
+            "brief-constraint-graph",
+            llvm::cl::init(true),
+            llvm::cl::desc("Dump dot graph of Constraint Graph")
+    );
+
     const llvm::cl::opt<bool> Options::PrintCGGraph(
         "print-constraint-graph", 
         llvm::cl::init(false),


### PR DESCRIPTION
1. Added ConstraintGraph::view() which can be called from
the debugger to view the constraint graph.

2. Added option, -brief-constraint-graph (default true), to
control whether instructions are included in the dump of
the constraint graph nodes (if brief is false). Previously
the brief flag could only be manipulated by editing the
source code and rebuilding.

3. In the non-brief display, use value2String so that
if the value is a function, only the name is given rather
than dumping all of the instructions in the function.

4. In the non-brief display, provide the node Id in any
case, as it takes only a few characters and is likely
to be useful.

5. Correct NormalGepPE::toString(). Due to a presumed
cut and paste error, it was claiming to be a VariantGepPE.