### PR TITLE
Replace std::hash<std::pair> with SVF::svf_hash

### DIFF
--- a/include/MemoryModel/LocationSet.h
+++ b/include/MemoryModel/LocationSet.h
@@ -290,7 +290,7 @@ private:
 
 template <> struct std::hash<SVF::LocationSet> {
     size_t operator()(const SVF::LocationSet &ls) const {
-        std::hash<std::pair<SVF::Size_t, SVF::Size_t>> h;
+        SVF::Hash<std::pair<SVF::Size_t, SVF::Size_t>> h;
         return h(std::make_pair(ls.getOffset(), ls.getByteOffset()));
     }
 };

--- a/include/Util/BasicTypes.h
+++ b/include/Util/BasicTypes.h
@@ -312,7 +312,7 @@ template <> struct std::hash<SVF::CallSite> {
 template <> struct std::hash<llvm::SparseBitVector<>>
 {
     size_t operator()(const llvm::SparseBitVector<> &sbv) const {
-        std::hash<std::pair<std::pair<size_t, size_t>, size_t>> h;
+        SVF::Hash<std::pair<std::pair<size_t, size_t>, size_t>> h;
         return h(std::make_pair(std::make_pair(sbv.count(), sbv.find_first()), sbv.find_last()));
     }
 };

--- a/include/Util/DPItem.h
+++ b/include/Util/DPItem.h
@@ -799,7 +799,7 @@ struct std::hash<SVF::CxtDPItem>
 {
     size_t operator()(const SVF::CxtDPItem &cdpi) const
     {
-        std::hash<std::pair<SVF::NodeID, SVF::ContextCond>> h;
+        SVF::Hash<std::pair<SVF::NodeID, SVF::ContextCond>> h;
         return h(std::make_pair(cdpi.getCurNodeID(), cdpi.getContexts()));
     }
 };
@@ -810,7 +810,7 @@ struct std::hash<SVF::StmtDPItem<LocCond>>
 {
     size_t operator()(const SVF::StmtDPItem<LocCond> &sdpi) const
     {
-        std::hash<std::pair<SVF::NodeID, const LocCond *>> h;
+        SVF::Hash<std::pair<SVF::NodeID, const LocCond *>> h;
         return h(std::make_pair(sdpi.getCurNodeID(), sdpi.getLoc()));
     }
 };
@@ -821,7 +821,7 @@ struct std::hash<SVF::CxtStmtDPItem<LocCond>>
 {
     size_t operator()(const SVF::CxtStmtDPItem<LocCond> &csdpi) const
     {
-        std::hash<std::pair<SVF::NodeID, std::pair<const LocCond *, SVF::ContextCond>>> h;
+        SVF::Hash<std::pair<SVF::NodeID, std::pair<const LocCond *, SVF::ContextCond>>> h;
         return h(std::make_pair(csdpi.getCurNodeID(),
                                 std::make_pair(csdpi.getLoc(), csdpi.getCond())));
     }


### PR DESCRIPTION
Overloading std::hash for the usage of std::pair (or more generally
another STL class) can conflict when used with other libraries that
do the same.

This commit workarounds this with a special class that fallbacks to
std::hash for all classes except std::pair and uses a special
implementation otherwise.

Since I have used `if constexpr`, this commit raises the C++ standard to C++17.
`if constexpr` is not needed (technically) and can be workarounded with
standard template metaprogramming. However, I find it more readable as is.

In my case the overloading of `std::hash<std::pair>` conflicts with [graph-tool](https://git.skewed.de/count0/graph-tool/-/blob/master/src/graph/graph_util.hh#L451)
but of course, this is only an example.