### PR TITLE
Improve debugging of call graph and value flow graph

### DIFF
--- a/include/Graphs/PTACallGraph.h
+++ b/include/Graphs/PTACallGraph.h
@@ -437,6 +437,9 @@ public:
 
     /// Dump the graph
     void dump(const std::string& filename);
+
+    /// View the graph from the debugger
+    void view();
 };
 
 } // End namespace SVF

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -160,6 +160,9 @@ public:
     /// Dump graph into dot file
     void dump(const std::string& file, bool simple = false);
 
+    /// Dump graph into dot file
+    void view();
+
     /// Update VFG based on pointer analysis results
     void updateCallGraph(PointerAnalysis* pta);
 

--- a/lib/Graphs/PTACallGraph.cpp
+++ b/lib/Graphs/PTACallGraph.cpp
@@ -316,6 +316,10 @@ void PTACallGraph::dump(const std::string& filename)
       GraphPrinter::WriteGraphToFile(outs(), filename, this);
 }
 
+void PTACallGraph::view()
+{
+    llvm::ViewGraph(this, "Call Graph");
+}
 
 namespace llvm
 {

--- a/lib/Graphs/VFG.cpp
+++ b/lib/Graphs/VFG.cpp
@@ -28,6 +28,7 @@
  */
 
 
+#include <Graphs/SVFGNode.h>
 #include "Util/Options.h"
 #include "Graphs/VFG.h"
 #include "Util/SVFModule.h"
@@ -86,8 +87,7 @@ const std::string CmpVFGNode::toString() const {
         rawstr << it->second->getId() << ", ";
     rawstr << ")]\n";
     if(res->hasValue()){
-        rawstr << " " << *res->getValue();
-        rawstr << SVFUtil::getSourceLoc(res->getValue());
+        rawstr << " " << value2String(res->getValue());
     }
     return rawstr.str();
 }
@@ -102,8 +102,7 @@ const std::string BinaryOPVFGNode::toString() const {
         rawstr << it->second->getId() << ", ";
     rawstr << ")]\t";
     if(res->hasValue()){
-        rawstr << " " << *res->getValue() << " ";
-        rawstr << SVFUtil::getSourceLoc(res->getValue());
+        rawstr << " " << value2String(res->getValue());
     }
     return rawstr.str();
 }
@@ -118,8 +117,7 @@ const std::string UnaryOPVFGNode::toString() const {
         rawstr << it->second->getId() << ", ";
     rawstr << ")]\t";
     if(res->hasValue()){
-        rawstr << " " << *res->getValue() << " ";
-        rawstr << SVFUtil::getSourceLoc(res->getValue());
+        rawstr << " " << value2String(res->getValue());
     }
     return rawstr.str();
 }
@@ -143,8 +141,7 @@ const std::string PHIVFGNode::toString() const {
         rawstr << it->second->getId() << ", ";
     rawstr << ")]\t";
     if(res->hasValue()){
-        rawstr << " " << *res->getValue();
-        rawstr << SVFUtil::getSourceLoc(res->getValue());
+        rawstr << " " << value2String(res->getValue());
     }
     return rawstr.str();
 }
@@ -160,8 +157,7 @@ const std::string IntraPHIVFGNode::toString() const {
         rawstr << it->second->getId() << ", ";
     rawstr << ")]\t";
     if(res->hasValue()){
-        rawstr << " " << *res->getValue();
-        rawstr << SVFUtil::getSourceLoc(res->getValue());
+        rawstr << " " << value2String(res->getValue());
     }
     return rawstr.str();
 }
@@ -228,9 +224,9 @@ const std::string InterPHIVFGNode::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     if(isFormalParmPHI())
-        rawstr << "FormalParmPHI ID: " << getId() << " PAGNode ID: " << res->getId() << "\n" << *res->getValue();
+        rawstr << "FormalParmPHI ID: " << getId() << " PAGNode ID: " << res->getId() << "\n" << value2String(res->getValue());
     else
-        rawstr << "ActualRetPHI ID: " << getId() << " PAGNode ID: " << res->getId() << "\n" << *res->getValue();
+        rawstr << "ActualRetPHI ID: " << getId() << " PAGNode ID: " << res->getId() << "\n" << value2String(res->getValue());
     return rawstr.str();
 }
 
@@ -760,6 +756,14 @@ void VFG::dump(const std::string& file, bool simple)
     GraphPrinter::WriteGraphToFile(outs(), file, this, simple);
 }
 
+/*!
+ * View VFG from the debugger.
+ */
+void VFG::view()
+{
+    llvm::ViewGraph(this, "Value Flow Graph");
+}
+
 
 void VFG::updateCallGraph(PointerAnalysis* pta)
 {
@@ -1013,6 +1017,10 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<PAG*>
         {
             rawstr << fr->toString();
         }
+        else if (MRSVFGNode* mr = SVFUtil::dyn_cast<MRSVFGNode>(node))
+        {
+            rawstr << mr->toString();
+        }
         else
             assert(false && "what else kinds of nodes do we have??");
 
@@ -1093,6 +1101,10 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<PAG*>
         {
             rawstr <<  "color=yellow,style=double";
         }
+        else if (SVFUtil::isa<MRSVFGNode>(node))
+        {
+            rawstr <<  "color=orange,style=double";
+        }
         else
             assert(false && "no such kind of node!!");
 
@@ -1114,6 +1126,15 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<PAG*>
                 return "style=solid,color=blue";
             else
                 return "style=solid";
+        }
+        else if (SVFUtil::isa<IndirectSVFGEdge>(edge))
+        {
+            if (SVFUtil::isa<CallIndSVFGEdge>(edge))
+                return "style=dashed,color=red";
+            else if (SVFUtil::isa<RetIndSVFGEdge>(edge))
+                return "style=dashed,color=blue";
+            else
+                return "style=dashed";
         }
         else
         {

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -600,9 +600,6 @@ u32_t MemSSA::getBBPhiNum() const
  */
 void MemSSA::dumpMSSA(raw_ostream& Out)
 {
-    if (!Options::DumpMSSA)
-        return;
-
     PAG* pag = pta->getPAG();
 
     for (SVFModule::iterator fit = pta->getModule()->begin(), efit = pta->getModule()->end();

--- a/lib/MSSA/SVFGBuilder.cpp
+++ b/lib/MSSA/SVFGBuilder.cpp
@@ -145,7 +145,10 @@ MemSSA* SVFGBuilder::buildMSSA(BVDataPTAImpl* pta, bool ptrOnlyMSSA)
     }
 
     mssa->performStat();
-    mssa->dumpMSSA();
+    if (Options::DumpMSSA)
+    {
+        mssa->dumpMSSA();
+    }
 
     return mssa;
 }


### PR DESCRIPTION
1. Added PTACallGraph::view(), callable from debugger,
to display the call graph while debugging.

2. Added VFG::view(), callable from debugger,
to display the [sparse] value flow graph while debugging.

3. Use value2String in a few places to get the special
treatment for functions that it gives (instead of dumping the
IR for the whole function).

4. There were missing cases when dumping a sparse value flow
graph, resulting in assertion violations. I added code to
cover the misssing cases. You may want to check that
the colors and styles I selected are what you want.

5. I modified dumpMSSA() so it unconditionally dumps the
memory SSA without checking for Options::DumpMSSA.
In the sole place where it had been called I put the
Options::DumpMSSA check. This will allow dumpMSSA() to
be called from the debugger if desired without concern
for the setting of Options::DumpMSSA.