### PR TITLE
Fix DOT graphs, debugging aids

### DIFF
--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -141,9 +141,9 @@ public:
     ///Define mem region set
     typedef OrderedSet<const MemRegion*, MemRegion::equalMemRegion> MRSet;
     typedef Map<const PAGEdge*, const SVFFunction*> PAGEdgeToFunMap;
-    typedef OrderedSet<PointsTo, MemRegion::equalPointsTo> PointsToList;
+    typedef OrderedSet<PointsTo, SVFUtil::equalPointsTo> PointsToList;
     typedef Map<const SVFFunction*, PointsToList > FunToPointsToMap;
-    typedef OrderedMap<PointsTo, PointsTo, MemRegion::equalPointsTo > PtsToRepPtsSetMap;
+    typedef OrderedMap<PointsTo, PointsTo, SVFUtil::equalPointsTo > PtsToRepPtsSetMap;
 
     /// Map a function to its region set
     typedef Map<const SVFFunction*, MRSet> FunToMRsMap;

--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -60,6 +60,7 @@ void dumpSet(NodeBS To, raw_ostream & O = SVFUtil::outs());
 
 /// Dump points-to set
 void dumpPointsToSet(unsigned node, NodeBS To) ;
+void dumpSparseSet(const NodeBS& To);
 
 /// Dump alias set
 void dumpAliasSet(unsigned node, NodeBS To) ;
@@ -116,6 +117,16 @@ inline bool cmpPts (const PointsTo& lpts,const PointsTo& rpts)
     }
 }
 
+typedef struct
+{
+    bool operator()(const PointsTo& lhs, const PointsTo& rhs) const
+    {
+        return SVFUtil::cmpPts(lhs, rhs);
+    }
+} equalPointsTo;
+
+typedef OrderedSet<PointsTo, equalPointsTo> PointsToList;
+void dumpPointsToList(const PointsToList& ptl);
 
 inline bool isIntrinsicFun(const Function* func)
 {

--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -727,6 +727,12 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<PAG*>
         return "SVFG";
     }
 
+    /// isNodeHidden - If the function returns true, the given node is not
+    /// displayed in the graph
+    static bool isNodeHidden(SVFGNode *node) {
+        return node->getInEdges().empty() && node->getOutEdges().empty();
+    }
+
     std::string getNodeLabel(NodeType *node, SVFG *graph)
     {
         if (isSimple())
@@ -930,47 +936,47 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<PAG*>
         }
         else if(SVFUtil::isa<FormalINSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<FormalOUTSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<FormalParmSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<ActualINSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<ActualOUTSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<ActualParmSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<ActualRetSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<FormalRetSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<BinaryOPVFGNode>(node))
         {
-            rawstr <<  "color=black,style=double";
+            rawstr <<  "color=black,penwidth=2";
         }
         else if (SVFUtil::isa<CmpVFGNode>(node))
         {
-            rawstr <<  "color=black,style=double";
+            rawstr <<  "color=black,penwidth=2";
         }
         else if (SVFUtil::isa<UnaryOPVFGNode>(node))
         {
-            rawstr <<  "color=black,style=double";
+            rawstr <<  "color=black,penwidth=2";
         }
         else
             assert(false && "no such kind of node!!");

--- a/lib/Graphs/VFG.cpp
+++ b/lib/Graphs/VFG.cpp
@@ -1087,23 +1087,23 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<PAG*>
         }
         else if(SVFUtil::isa<FormalParmVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<ActualParmVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<ActualRetVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<FormalRetVFGNode>(node))
         {
-            rawstr <<  "color=yellow,style=double";
+            rawstr <<  "color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<MRSVFGNode>(node))
         {
-            rawstr <<  "color=orange,style=double";
+            rawstr <<  "color=orange,penwidth=2";
         }
         else
             assert(false && "no such kind of node!!");

--- a/lib/Util/SVFUtil.cpp
+++ b/lib/Util/SVFUtil.cpp
@@ -111,6 +111,25 @@ void SVFUtil::dumpPointsToSet(unsigned node, NodeBS bs)
     outs() << "}\n";
 }
 
+// For use from the debugger.
+void SVFUtil::dumpSparseSet(const NodeBS& bs)
+{
+    outs() << "{";
+    dumpSet(bs);
+    outs() << "}\n";
+}
+
+void SVFUtil::dumpPointsToList(const PointsToList& ptl)
+{
+    outs() << "{";
+    for (PointsToList::const_iterator ii = ptl.begin(), ie = ptl.end();
+         ii != ie; ii++)
+    {
+        auto bs = *ii;
+        dumpSparseSet(bs);
+    }
+    outs() << "}\n";
+}
 
 /*!
  * Dump alias set


### PR DESCRIPTION
1. Some of the DOT graph writers were using "style=double" which the dot program says is invalid. I replaced this with "penwidth=2" which I believe gives the desired effect.
2. I added an "isNodeHidden" dot trait function for the SVFG dot graphs to inhibit outputting nodes which no input or output edges. These are uninteresting and just end up compressing the rest of the graph.
3. While studying the pointer analysis in the debugger, I wanted to get a dump of the pointed-to sets, and also, lists of such. I added SVFUtil::dumpSparseSet and SVFUtil::dumpPointsToList. These needed to take a reference as parameter as gdb was not able to construct a copy. To avoid type-mismatch errors for this I added SVFUtil::equalPointsTo and use in MemRegion.h when declaring sets or maps of Points-to sets.