### PR TITLE
Support LLVM 12.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,20 @@ matrix:
         dist: bionic
         sudo: required
       - os: osx
-        osx_image: xcode7.2
+        osx_image: xcode11.1
+        sudo: required
 
 env:
   - SVF_CTIR=1 SVF_Z3=1
 
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update       ; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install cmake gcc g++ nodejs; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test       ; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update       ; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install cmake gcc-9 g++-9 nodejs; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo ln -s /Applications/Xcode-11.1.app /Applications/Xcode.app ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo ln -s /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk ; fi
 
 script:
   - git stash --all

--- a/build.sh
+++ b/build.sh
@@ -11,13 +11,13 @@
 ########
 SVFHOME=$(pwd)
 sysOS=`uname -s`
-MacLLVM="https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz"
-UbuntuLLVM="https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
+MacLLVM="https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-apple-darwin.tar.xz"
+UbuntuLLVM="https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.0/clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
 MacZ3="https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-osx-10.14.6.zip"
 UbuntuZ3="https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip"
 MacCTIR="https://github.com/mbarbar/ctir/releases/download/ctir-10.c3/ctir-clang-v10.c3-macos10.15.zip"
 UbuntuCTIR="https://github.com/mbarbar/ctir/releases/download/ctir-10.c3/ctir-clang-v10.c3-ubuntu18.04.zip"
-LLVMHome="llvm-10.0.0.obj"
+LLVMHome="llvm-12.0.0.obj"
 Z3Home="z3.obj"
 CTIRHome="ctir.obj"
 

--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -95,7 +95,7 @@ public:
     /// Add the hash function for std::set (we also can overload operator< to implement this)
     //  and duplicated elements in the set are not inserted (binary tree comparison)
     //@{
-    typedef struct
+    typedef struct equalGEdge
     {
         bool operator()(const GenericEdge<NodeType>* lhs, const GenericEdge<NodeType>* rhs) const
         {

--- a/include/Graphs/PAGNode.h
+++ b/include/Graphs/PAGNode.h
@@ -305,7 +305,7 @@ public:
     inline const std::string getValueName() const
     {
         if (value && value->hasName())
-            return value->getName();
+            return value->getName().str();
         return "";
     }
 
@@ -365,7 +365,7 @@ public:
     virtual const std::string getValueName() const
     {
         if (value && value->hasName())
-            return value->getName();
+            return value->getName().str();
         return "";
     }
     /// Return type of the value

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -545,7 +545,7 @@ protected:
 		/// we will set this phi node's def later
 		/// Ideally, every function uniqueFunRet should be a PhiNode (PAGBuilder.cpp), unless it does not have ret instruction
 		if (!pag->isPhiNode(uniqueFunRet)){
-			std::string warn = fun->getName();
+			std::string warn = fun->getName().str();
 			SVFUtil::writeWrnMsg(warn + " does not have any ret instruction!");
 			setDef(uniqueFunRet, sNode);
 		}

--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -102,7 +102,7 @@ public:
     /// add the hash function here to sort elements and remove
     /// and remove duplicated element in the set (binary tree comparision)
     //@{
-    typedef struct
+    typedef struct equalMemRegion
     {
         bool operator()(const MemRegion* lhs, const MemRegion* rhs) const
         {
@@ -110,7 +110,7 @@ public:
         }
     } equalMemRegion;
 
-    typedef struct
+    typedef struct equalPointsTo
     {
         bool operator()(const PointsTo& lhs, const PointsTo& rhs) const
         {

--- a/include/SVF-FE/DCHG.h
+++ b/include/SVF-FE/DCHG.h
@@ -83,7 +83,7 @@ public:
         }
         else if (diType->getRawName() != nullptr)
         {
-            typeName = diType->getName();
+            typeName = diType->getName().str();
         }
         else
         {

--- a/include/SVF-FE/GEPTypeBridgeIterator.h
+++ b/include/SVF-FE/GEPTypeBridgeIterator.h
@@ -71,8 +71,13 @@ public:
     {
         if ( CurTy.getInt() )
             return CurTy.getPointer();
+#if LLVM_VERSION_MAJOR >= 11
+        Type *CT = CurTy.getPointer();
+        return CT;
+#else
         CompositeType *CT = llvm::cast<CompositeType>( CurTy.getPointer() );
         return CT->getTypeAtIndex(getOperand());
+#endif
     }
 
     // non-standard operators, these may not need be bridged but seems it's
@@ -94,10 +99,17 @@ public:
         {
             CurTy.setInt(false);
         }
+#if LLVM_VERSION_MAJOR >= 11
+        else if ( Type * CT = CurTy.getPointer() )
+        {
+            CurTy.setPointer(CT);
+        }
+#else
         else if ( CompositeType * CT = dyn_cast<CompositeType>(CurTy.getPointer()) )
         {
             CurTy.setPointer(CT->getTypeAtIndex(getOperand()));
         }
+#endif
         else
         {
             CurTy.setPointer(nullptr);

--- a/include/Util/SVFBasicTypes.h
+++ b/include/Util/SVFBasicTypes.h
@@ -175,7 +175,7 @@ private:
     GNodeK kind;	///< Type of this SVFValue
 public:
     /// Constructor
-    SVFValue(const std::string& val, SVFValKind k): value(val), kind(k)
+    SVFValue(const llvm::StringRef& val, SVFValKind k): value(val), kind(k)
     {
     }
 

--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -117,7 +117,7 @@ inline bool cmpPts (const PointsTo& lpts,const PointsTo& rpts)
     }
 }
 
-typedef struct
+typedef struct equalPointsTo
 {
     bool operator()(const PointsTo& lhs, const PointsTo& rhs) const
     {

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -614,7 +614,11 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<PAG*>
         return "ConstraintG";
     }
 
+#if LLVM_VERSION_MAJOR >= 12
+    static bool isNodeHidden(NodeType *n, ConstraintGraph*) {
+#else
     static bool isNodeHidden(NodeType *n) {
+#endif
         PAGNode* node = PAG::getPAG()->getPAGNode(n->getId());
         return node->isIsolatedNode();
     }

--- a/lib/Graphs/ExternalPAG.cpp
+++ b/lib/Graphs/ExternalPAG.cpp
@@ -74,7 +74,8 @@ bool ExternalPAG::connectCallsiteToExternalPAG(CallSite *cs)
     PAG *pag = PAG::getPAG();
 
     Function* function = cs->getCalledFunction();
-    std::string functionName = function->getName();
+    std::string functionName = function->getName().str();
+
     const SVFFunction* svfFun = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(function);
     if (!hasExternalPAG(svfFun)) return false;
 
@@ -278,7 +279,7 @@ void ExternalPAG::dumpFunctions(std::vector<std::string> functions)
             if (currFunction != nullptr)
             {
                 // Otherwise, it would be an indirect call which we don't want.
-                std::string currFunctionName = currFunction->getName();
+                std::string currFunctionName = currFunction->getName().str();
 
                 if (std::find(functions.begin(), functions.end(),
                               currFunctionName) != functions.end())
@@ -300,7 +301,7 @@ void ExternalPAG::dumpFunctions(std::vector<std::string> functions)
             ++it)
     {
         const SVFFunction* function = it->first;
-        std::string functionName = it->first->getName();
+        std::string functionName = it->first->getName().str();
 
         // The final nodes and edges we will print.
         Set<PAGNode *> nodes;

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -1123,7 +1123,11 @@ struct DOTGraphTraits<PAG*> : public DefaultDOTGraphTraits
 
     /// isNodeHidden - If the function returns true, the given node is not
     /// displayed in the graph
-	static bool isNodeHidden(PAGNode *node) {
+#if LLVM_VERSION_MAJOR >= 12
+	static bool isNodeHidden(PAGNode *node, PAG*) {
+#else
+    static bool isNodeHidden(PAGNode *node) {
+#endif
 		return node->isIsolatedNode();
 	}
 

--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -729,7 +729,11 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<PAG*>
 
     /// isNodeHidden - If the function returns true, the given node is not
     /// displayed in the graph
+#if LLVM_VERSION_MAJOR >= 12
+    static bool isNodeHidden(SVFGNode *node, SVFG*) {
+#else
     static bool isNodeHidden(SVFGNode *node) {
+#endif
         return node->getInEdges().empty() && node->getOutEdges().empty();
     }
 

--- a/lib/SABER/LeakChecker.cpp
+++ b/lib/SABER/LeakChecker.cpp
@@ -222,7 +222,7 @@ void LeakChecker::validateSuccessTests(const SVFGNode* source, const SVFFunction
         return;
     }
 
-    std::string funName = source->getFun()->getName();
+    std::string funName = source->getFun()->getName().str();
 
     if (success)
         outs() << sucMsg("\t SUCCESS :") << funName << " check <src id:" << source->getId()
@@ -270,7 +270,7 @@ void LeakChecker::validateExpectedFailureTests(const SVFGNode* source, const SVF
         return;
     }
 
-    std::string funName = source->getFun()->getName();
+    std::string funName = source->getFun()->getName().str();
 
     if (expectedFailure)
         outs() << sucMsg("\t EXPECTED-FAILURE :") << funName << " check <src id:" << source->getId()

--- a/lib/SVF-FE/CPPUtil.cpp
+++ b/lib/SVF-FE/CPPUtil.cpp
@@ -286,7 +286,7 @@ bool cppUtil::isVirtualCallSite(CallSite cs)
 }
 
 bool cppUtil::isCPPThunkFunction(const Function *F) {
-    cppUtil::DemangledName dname = cppUtil::demangle(F->getName());
+    cppUtil::DemangledName dname = cppUtil::demangle(F->getName().str());
     return dname.isThunkFunc;
 }
 
@@ -297,7 +297,7 @@ const Function *cppUtil::getThunkTarget(const Function *F) {
         for (auto &inst: bb) {
             if (llvm::isa<CallInst>(inst) || llvm::isa<InvokeInst>(inst)
                 || llvm::isa<CallBrInst>(inst)) {
-                llvm::ImmutableCallSite cs(&inst);
+                CallSite cs(const_cast<Instruction*>(&inst));
                 assert(cs.getCalledFunction() &&
                        "Indirect call detected in thunk func");
                 assert(ret == nullptr && "multiple callsites in thunk func");

--- a/lib/SVF-FE/DCHG.cpp
+++ b/lib/SVF-FE/DCHG.cpp
@@ -1236,7 +1236,7 @@ void DCHGraph::print(void)
             std::string typedefName = "void";
             if (tdef != nullptr)
             {
-                typedefName = tdef->getName();
+                typedefName = tdef->getName().str();
             }
 
             SVFUtil::outs() << indent(currIndent) << typedefName << "\n";

--- a/lib/SVF-FE/SymbolTableInfo.cpp
+++ b/lib/SVF-FE/SymbolTableInfo.cpp
@@ -77,7 +77,7 @@ void MemObj::init(const Value *val)
     else
     {
         writeWrnMsg("try to create an object with a non-pointer type.");
-        writeWrnMsg(val->getName());
+        writeWrnMsg(val->getName().str());
         writeWrnMsg("(" + getSourceLoc(val) + ")");
         assert(false && "Memory object must be held by a pointer-typed ref value.");
     }

--- a/lib/Util/ThreadAPI.cpp
+++ b/lib/Util/ThreadAPI.cpp
@@ -325,7 +325,7 @@ void ThreadAPI::performAPIStat(SVFModule* module)
     for (llvm::StringMap<u32_t>::iterator it = tdAPIStatMap.begin(), eit =
                 tdAPIStatMap.end(); it != eit; ++it)
     {
-        std::string apiName = it->first();
+        std::string apiName = it->first().str();
         // format out put with width 20 space
         std::cout << std::setw(field_width) << apiName << " : " << it->second
                   << "\n";

--- a/lib/Util/TypeBasedHeapCloning.cpp
+++ b/lib/Util/TypeBasedHeapCloning.cpp
@@ -569,7 +569,7 @@ void TypeBasedHeapCloning::validateTBHCTests(SVFModule*)
         {
             const CallSite &cs = SVFUtil::getLLVMCallSite(cbn->getCallSite());
             const Function *fn = cs.getCalledFunction();
-            if (fn == nullptr || !isAliasTestFunction(fn->getName()))
+            if (fn == nullptr || !isAliasTestFunction(fn->getName().str()))
             {
                 continue;
             }


### PR DESCRIPTION
1. Replace deprecated Callsite/ImmutableCallSite with SVF::CallSite class
2. Fix isNodeHidden() method, which requires two arguments now
3. Fix StringRef to string type conversion
4. Update .travis.yml/build.sh