### PR TITLE
WPAPass: Used -opt-svfg to control creation of optimized SVFG.

### DIFF
--- a/lib/WPA/WPAPass.cpp
+++ b/lib/WPA/WPAPass.cpp
@@ -153,7 +153,15 @@ void WPAPass::runPointerAnalysis(SVFModule* svfModule, u32_t kind)
     {
         SVFGBuilder memSSA(true);
         assert(SVFUtil::isa<AndersenBase>(_pta) && "supports only andersen/steensgaard for pre-computed SVFG");
-        SVFG *svfg = memSSA.buildFullSVFGWithoutOPT((BVDataPTAImpl*)_pta);
+        SVFG *svfg;
+        if (Options::OPTSVFG)
+        {
+            // This seems backward, but the description says if true, then unoptimized.
+            svfg = memSSA.buildFullSVFGWithoutOPT((BVDataPTAImpl*)_pta);
+        } else
+        {
+            svfg = memSSA.buildFullSVFG((BVDataPTAImpl*)_pta);
+        }
         /// support mod-ref queries only for -ander
         if (Options::PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA))
             _svfg = svfg;


### PR DESCRIPTION
Currently a command like

```
wpa -ander -svfg -dump-svfg swap.ll
```

produces an unoptimized SVFG. With this change, a command like this:

```
wpa -ander -svfg --dump-vfg -opt-svfg=false swap.ll
```

will produce an optimized SVFG. Note that the sense of
-opt-svfg seems backward. Should we change this?

This was needed to produced the optimized dot graph of the SVFG
for the wiki.