### PR TITLE
Clear confusion regarding --opt-svfg option.

### DIFF
--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -198,6 +198,7 @@ public:
 
     //WPAPass.cpp
     static const llvm::cl::opt<bool> AnderSVFG;
+    static const llvm::cl::opt<bool> WPAOPTSVFG;
     static const llvm::cl::opt<bool> PrintAliases;
     static llvm::cl::bits<PointerAnalysis::PTATY> PASelected;
     static llvm::cl::bits<WPAPass::AliasCheckRule> AliasRule;

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -362,7 +362,7 @@ namespace SVF
     llvm::cl::opt<bool> Options::OPTSVFG(
         "opt-svfg", 
         llvm::cl::init(true),
-        llvm::cl::desc("unoptimized SVFG with formal-in and actual-out")
+        llvm::cl::desc("Optimize SVFG to eliminate formal-in and actual-out")
     );
 
     
@@ -642,6 +642,12 @@ namespace SVF
         "svfg", 
         llvm::cl::init(false),
         llvm::cl::desc("Generate SVFG after Andersen's Analysis")
+    );
+
+    const llvm::cl::opt<bool> Options::WPAOPTSVFG(
+            "wpa-opt-svfg",
+            llvm::cl::init(false),
+            llvm::cl::desc("When using WPA pass, optimize SVFG to eliminate formal-in and actual-out (default false)")
     );
 
     const llvm::cl::opt<bool> Options::PrintAliases(

--- a/lib/WPA/WPAPass.cpp
+++ b/lib/WPA/WPAPass.cpp
@@ -154,14 +154,14 @@ void WPAPass::runPointerAnalysis(SVFModule* svfModule, u32_t kind)
         SVFGBuilder memSSA(true);
         assert(SVFUtil::isa<AndersenBase>(_pta) && "supports only andersen/steensgaard for pre-computed SVFG");
         SVFG *svfg;
-        if (Options::OPTSVFG)
-        {
-            // This seems backward, but the description says if true, then unoptimized.
-            svfg = memSSA.buildFullSVFGWithoutOPT((BVDataPTAImpl*)_pta);
-        } else
+        if (Options::WPAOPTSVFG)
         {
             svfg = memSSA.buildFullSVFG((BVDataPTAImpl*)_pta);
+        } else
+        {
+            svfg = memSSA.buildFullSVFGWithoutOPT((BVDataPTAImpl*)_pta);
         }
+
         /// support mod-ref queries only for -ander
         if (Options::PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA))
             _svfg = svfg;


### PR DESCRIPTION
1. Change description of --opt-svfg option to describe what
it really does.

2. Create a new option, ---wpa-opt-svfg, to control whether the
WPAPass uses optimized SVFG. It could have used the same option,
except the old behavior has the opposite default--WPA was
using the unoptimized SVFG but Flow Sensitive was using
optimized by default.