### PR TITLE
Move tests to cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then npm version patch; fi
   - git clone "https://github.com/SVF-tools/Test-Suite.git"
   - . ./build.sh
+  - cd ./Release-build
+  - ctest
   - cd $TRAVIS_BUILD_DIR
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,8 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then git add .; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then git commit -m'update version'; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then npm version patch; fi
-  # Perform tests  
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sed -i "57i include_directories(\$\{CMAKE_CURRENT_SOURCE_DIR\}/Test-Suite)" CMakeLists.txt && 
-      sed -i -e '$a enable_testing()\nadd_subdirectory(Test-Suite)\ninclude(CTest)' CMakeLists.txt &&
-        git clone "https://github.com/SVF-tools/Test-Suite.git" &&
-          cd ./Test-Suite && ./generate_bc.sh &&
-            cd ..; fi
+  - git clone "https://github.com/SVF-tools/Test-Suite.git"
   - . ./build.sh
-  - cd ./Release-build
-  - ctest --v
   - cd $TRAVIS_BUILD_DIR
 
 after_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,19 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
                     ${CMAKE_CURRENT_BINARY_DIR}/include
                     ${Z3_DIR}/include/)
 
+# checks if the test-suite is present, if it is then build bc files and add testing to cmake build
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite")
+    add_custom_target(
+        generatebc ALL
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite/generate_bc.sh
+    )
+    add_dependencies(generatebc SVF)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite)
+    enable_testing()
+    add_subdirectory(Test-Suite)
+    include(CTest)
+endif()
+
 LINK_DIRECTORIES(${Z3_DIR}/bin)
 add_subdirectory(lib)
 add_subdirectory(tools)


### PR DESCRIPTION
Moved tests from travis to cmake. When building the project cmake will check if the Test-suite folder exists. if it does it will build the test bc files and add testing to cmake.