### PR TITLE
Enable DOT dumping of connected subgraphs

### DIFF
--- a/include/SVF-FE/DCHG.h
+++ b/include/SVF-FE/DCHG.h
@@ -242,10 +242,7 @@ public:
     /// whether to extend the CHG with first field edges.
     virtual void buildCHG(bool extend);
 
-    void dump(const std::string& filename)
-    {
-        GraphPrinter::WriteGraphToFile(SVFUtil::outs(), filename, this);
-    }
+    void dump(const std::string& filename);
 
     void print(void);
 

--- a/include/Util/BasicTypes.h
+++ b/include/Util/BasicTypes.h
@@ -32,7 +32,7 @@
 
 #include "Util/SVFBasicTypes.h"
 #include "SVF-FE/GEPTypeBridgeIterator.h"
-#include "Graphs/GraphPrinter.h"
+#include <llvm/Support/ToolOutputFile.h>
 #include "Util/Casting.h"
 #include <llvm/ADT/SmallVector.h>		// for small vector
 #include <llvm/ADT/SparseBitVector.h>
@@ -193,7 +193,6 @@ typedef llvm::const_inst_iterator const_inst_iterator;
 typedef llvm::const_pred_iterator const_pred_iterator;
 typedef llvm::gep_type_iterator gep_type_iterator;
 typedef llvm::bridge_gep_iterator bridge_gep_iterator;
-typedef llvm::GraphPrinter GraphPrinter;
 typedef llvm::IRBuilder<> IRBuilder;
 typedef llvm::IntegerType IntegerType;
 

--- a/include/Util/SimpleOptions.h
+++ b/include/Util/SimpleOptions.h
@@ -1,0 +1,30 @@
+//
+// Created by fordrl on 4/27/21.
+//
+
+#ifndef SVF_SIMPLEOPTIONS_H
+#define SVF_SIMPLEOPTIONS_H
+#include "llvm/Support/CommandLine.h"
+
+namespace SVF {
+
+    class SimpleOptions {
+    public:
+        // Options that affect dot file dumping.
+
+        /// When dumping dot files, show all nodes, even those ordinarily hidden.
+        static const llvm::cl::opt<bool> DotShowAll;
+
+        /// Dump only the nodes in the largest connected subgraph
+        static const llvm::cl::opt<bool> DotLargestSubgraph;
+
+        /// Dump each connected subgraph in a separate dot file.
+        static const llvm::cl::opt<bool> DotSeparateSubgraphs;
+
+        // End of options affecting dot file dumping.
+
+    };
+
+}; // Namespace SVF
+
+#endif //SVF_SIMPLEOPTIONS_H

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -29,6 +29,7 @@
 
 #include "Graphs/ConsG.h"
 #include "Util/Options.h"
+#include "Graphs/GraphPrinter.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -523,7 +524,7 @@ bool ConstraintGraph::moveOutEdgesToRepNode(ConstraintNode*node, ConstraintNode*
  */
 void ConstraintGraph::dump(std::string name)
 {
-     GraphPrinter::WriteGraphToFile(outs(), name, this);
+     GraphPrinter::SelectiveWriteGraphToFile(outs(), name, this);
 }
 
 /*!
@@ -590,7 +591,7 @@ void ConstraintGraph::print()
  * View dot graph of Constraint graph from debugger.
  */
 void ConstraintGraph::view() {
-    llvm::ViewGraph(this, "Constraint Graph");
+    GraphPrinter::SelectiveWriteGraphToFile(outs(), "ConstraintGraph", this, false, true);
 }
 
 /*!
@@ -616,7 +617,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<PAG*>
 
     static bool isNodeHidden(NodeType *n) {
         PAGNode* node = PAG::getPAG()->getPAGNode(n->getId());
-        return node->isIsolatedNode();
+        return n->reallyHideNode(node->isIsolatedNode());
     }
 
     /// Return label of a VFG node with two display mode

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -33,6 +33,7 @@
 #include "Graphs/ICFG.h"
 #include "Graphs/PAG.h"
 #include "Graphs/PTACallGraph.h"
+#include "Graphs/GraphPrinter.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -397,7 +398,7 @@ ICFGEdge* ICFG::addRetEdge(ICFGNode* srcNode, ICFGNode* dstNode, const Instructi
  */
 void ICFG::dump(const std::string& file, bool simple)
 {
-    GraphPrinter::WriteGraphToFile(outs(), file, this, simple);
+    GraphPrinter::SelectiveWriteGraphToFile(outs(), file, this, simple);
 }
 
 /*!
@@ -405,7 +406,7 @@ void ICFG::dump(const std::string& file, bool simple)
  */
 void ICFG::view()
 {
-    llvm::ViewGraph(this, "Interprocedural Control-Flow Graph");
+    GraphPrinter::SelectiveWriteGraphToFile(outs(), "ICFG", this, false, true);
 }
 
 /*!
@@ -456,6 +457,12 @@ struct DOTGraphTraits<ICFG*> : public DOTGraphTraits<PAG*>
     static std::string getGraphName(ICFG*)
     {
         return "ICFG";
+    }
+
+    /// isNodeHidden - If the function returns true, the given node is not
+    /// displayed in the graph
+    static bool isNodeHidden(NodeType *node) {
+        return node->reallyHideNode(false);
     }
 
     std::string getNodeLabel(NodeType *node, ICFG *graph)

--- a/lib/Graphs/OfflineConsG.cpp
+++ b/lib/Graphs/OfflineConsG.cpp
@@ -29,6 +29,7 @@
 
 #include "Util/Options.h"
 #include "Graphs/OfflineConsG.h"
+#include "Graphs/GraphPrinter.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -169,7 +170,7 @@ NodeID OfflineConsG::solveRep(OSCC* oscc, NodeID rep)
 void OfflineConsG::dump(std::string name)
 {
     if (Options::OCGDotGraph)
-        GraphPrinter::WriteGraphToFile(outs(), name, this);
+        GraphPrinter::SelectiveWriteGraphToFile(outs(), name, this);
 }
 
 
@@ -192,6 +193,12 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<PAG*>
     static std::string getGraphName(OfflineConsG*)
     {
         return "Offline Constraint Graph";
+    }
+
+    /// isNodeHidden - If the function returns true, the given node is not
+    /// displayed in the graph
+    static bool isNodeHidden(NodeType *node) {
+        return node->reallyHideNode(false);
     }
 
     /// Return label of a VFG node with two display mode

--- a/lib/Graphs/PTACallGraph.cpp
+++ b/lib/Graphs/PTACallGraph.cpp
@@ -31,6 +31,7 @@
 #include "Util/SVFModule.h"
 #include "SVF-FE/LLVMUtil.h"
 #include "Graphs/PTACallGraph.h"
+#include "Graphs/GraphPrinter.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -313,7 +314,7 @@ bool PTACallGraph::isReachableBetweenFunctions(const SVFFunction* srcFn, const S
  */
 void PTACallGraph::dump(const std::string& filename)
 {
-      GraphPrinter::WriteGraphToFile(outs(), filename, this);
+      GraphPrinter::SelectiveWriteGraphToFile(outs(), filename, this);
 }
 
 void PTACallGraph::view()

--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -32,6 +32,7 @@
 #include "Graphs/SVFG.h"
 #include "Graphs/SVFGOPT.h"
 #include "Graphs/SVFGStat.h"
+#include "Graphs/GraphPrinter.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -521,7 +522,7 @@ SVFGEdge* SVFG::addInterIndirectVFRetEdge(const FormalOUTSVFGNode* src, const Ac
  */
 void SVFG::dump(const std::string& file, bool simple)
 {
-    GraphPrinter::WriteGraphToFile(outs(), file, this, simple);
+    GraphPrinter::SelectiveWriteGraphToFile(outs(), file, this, simple);
 }
 
 /**
@@ -730,7 +731,8 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<PAG*>
     /// isNodeHidden - If the function returns true, the given node is not
     /// displayed in the graph
     static bool isNodeHidden(SVFGNode *node) {
-        return node->getInEdges().empty() && node->getOutEdges().empty();
+        bool hide_suggestion = node->getInEdges().empty() && node->getOutEdges().empty();
+        return node->reallyHideNode(hide_suggestion);
     }
 
     std::string getNodeLabel(NodeType *node, SVFG *graph)

--- a/lib/Graphs/VFG.cpp
+++ b/lib/Graphs/VFG.cpp
@@ -33,6 +33,7 @@
 #include "Graphs/VFG.h"
 #include "Util/SVFModule.h"
 #include "SVF-FE/LLVMUtil.h"
+#include "Graphs/GraphPrinter.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -753,7 +754,7 @@ VFGEdge* VFG::getIntraVFGEdge(const VFGNode* src, const VFGNode* dst, VFGEdge::V
  */
 void VFG::dump(const std::string& file, bool simple)
 {
-    GraphPrinter::WriteGraphToFile(outs(), file, this, simple);
+    GraphPrinter::SelectiveWriteGraphToFile(outs(), file, this, simple);
 }
 
 /*!
@@ -761,7 +762,7 @@ void VFG::dump(const std::string& file, bool simple)
  */
 void VFG::view()
 {
-    llvm::ViewGraph(this, "Value Flow Graph");
+    GraphPrinter::SelectiveWriteGraphToFile(outs(), "ValueFlowGraph", this, false, true);
 }
 
 
@@ -912,6 +913,11 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<PAG*>
         return "VFG";
     }
 
+    /// isNodeHidden - If the function returns true, the given node is not
+    /// displayed in the graph
+    static bool isNodeHidden(NodeType *node) {
+        return node->reallyHideNode(false);
+    }
     std::string getNodeLabel(NodeType *node, VFG *graph)
     {
         if (isSimple())

--- a/lib/MTA/TCT.cpp
+++ b/lib/MTA/TCT.cpp
@@ -607,6 +607,11 @@ struct DOTGraphTraits<TCT*> : public DefaultDOTGraphTraits
     {
         return "Thread Create Tree";
     }
+    /// isNodeHidden - If the function returns true, the given node is not
+    /// displayed in the graph
+    static bool isNodeHidden(TCTNode *node) {
+        return node->reallyHideNode(false);
+    }
     /// Return function name;
     static std::string getNodeLabel(TCTNode *node, TCT *graph)
     {

--- a/lib/SVF-FE/CHG.cpp
+++ b/lib/SVF-FE/CHG.cpp
@@ -43,6 +43,7 @@
 #include "Util/SVFUtil.h"
 #include "SVF-FE/LLVMUtil.h"
 #include "Util/SVFModule.h"
+#include "Graphs/GraphPrinter.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -882,13 +883,13 @@ void CHGraph::printCH()
  */
 void CHGraph::dump(const std::string& filename)
 {
-    GraphPrinter::WriteGraphToFile(outs(), filename, this);
+    GraphPrinter::SelectiveWriteGraphToFile(outs(), filename, this);
     printCH();
 }
 
 void CHGraph::view()
 {
-    llvm::ViewGraph(this, "Class Hierarchy Graph");
+    GraphPrinter::SelectiveWriteGraphToFile(outs(), "ClassHierarchy", this, false, true);
 }
 
 namespace llvm
@@ -911,6 +912,11 @@ struct DOTGraphTraits<CHGraph*> : public DefaultDOTGraphTraits
     static std::string getGraphName(CHGraph*)
     {
         return "Class Hierarchy Graph";
+    }
+    /// isNodeHidden - If the function returns true, the given node is not
+    /// displayed in the graph
+    static bool isNodeHidden(CHNode *node) {
+        return node->reallyHideNode(false);
     }
     /// Return function name;
     static std::string getNodeLabel(CHNode *node, CHGraph*)

--- a/lib/SVF-FE/DCHG.cpp
+++ b/lib/SVF-FE/DCHG.cpp
@@ -13,8 +13,8 @@
 #include "SVF-FE/DCHG.h"
 #include "SVF-FE/CPPUtil.h"
 #include "Util/SVFUtil.h"
-
 #include "llvm/IR/DebugInfo.h"
+#include "Graphs/GraphPrinter.h"
 
 using namespace SVF;
 
@@ -1126,6 +1126,11 @@ std::string DCHGraph::diTypeToStr(const DIType *t)
 static std::string indent(size_t n)
 {
     return std::string(n, ' ');
+}
+
+void DCHGraph::dump(const std::string& filename)
+{
+    GraphPrinter::SelectiveWriteGraphToFile(SVFUtil::outs(), filename, this);
 }
 
 void DCHGraph::print(void)

--- a/lib/Util/SVFUtil.cpp
+++ b/lib/Util/SVFUtil.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "Util/Options.h"
+#include "Util/SimpleOptions.h"
 #include "Util/SVFUtil.h"
 #include "SVF-FE/LLVMUtil.h"
 
@@ -379,4 +380,36 @@ void SVFFunction::viewCFGOnly() {
     if (fun != nullptr) {
         fun->viewCFGOnly();
     }
+}
+
+/// Decide whether to hide a node in a dot graph.
+/// Based on command line options, decide whether a node
+/// should be hidden. This is used to implement dumping of
+/// connected subgraphs by ignoring nodes not in the selected
+/// connected subgraph. The maybe_hide parameter tells if this
+/// node is of a sort that is not important and need not be
+/// displayed ordinarily. However, if --dot-show-all is
+/// specified then even these are shown.
+bool GenericNodeBase::reallyHideNode(bool maybe_hide)
+{
+    assert(graph && "Node not in graph");
+    SubgraphIdTy current_subgraph = graph->currentSubgraphId;
+    if (SimpleOptions::DotLargestSubgraph || SimpleOptions::DotSeparateSubgraphs)
+    {
+        // In these cases, the graph's current_subgraph will have been
+        // set to the desired subgraph, and nodes not in that
+        // subgraph should be hidden.
+        if (subgraphID != current_subgraph)
+        {
+            return true;
+        }
+    }
+    if (SimpleOptions::DotShowAll)
+    {
+        // If this option, we want to see all of the nodes of the
+        // graph (or the selected subgraph).
+        return false;
+    }
+    // Otherwise, use the judgement of the caller whether to hide.
+    return maybe_hide;
 }

--- a/lib/Util/SimpleOptions.cpp
+++ b/lib/Util/SimpleOptions.cpp
@@ -1,0 +1,28 @@
+//
+// Created by fordrl on 4/27/21.
+//
+
+#include <llvm/Support/CommandLine.h>
+#include "Util/SimpleOptions.h"
+
+namespace SVF {
+
+    /// When dumping dot files, show all nodes, even those ordinarily hidden.
+    const llvm::cl::opt<bool> SimpleOptions::DotShowAll(
+            "dot-show-all",
+            llvm::cl::init(false),
+            llvm::cl::desc("In .dot file, show all nodes, even hidden."));
+
+    /// Dump only the nodes in the largest connected subgraph
+    const llvm::cl::opt<bool> SimpleOptions::DotLargestSubgraph(
+            "dot-largest-subgraph",
+            llvm::cl::init(false),
+            llvm::cl::desc("Dump only nodes in largest connected subgraph"));
+
+    /// Dump each connected subgraph in a separate dot file.
+    const llvm::cl::opt<bool> SimpleOptions::DotSeparateSubgraphs(
+            "dot-separate-subgraphs",
+            llvm::cl::init(false),
+            llvm::cl::desc("Dump each connected subgraph in a separate .dot file"));
+
+};


### PR DESCRIPTION
Sometimes SVF graphs contain a main part that is connected
and other parts that are not. The other parts might be part
of the testing infrastructure that are not used by the
current test. When a DOT dump of the graph is produced, these
other unconnected parts make the overall graph harder to
read as they typically make the dump very wide and the
nodes small. In order to focus on what is important,
this change enables dumping of connected subgraphs.

If --dot-largest-subgraph is specified, then only the nodes
in the largest connected subgraph will be dumped and the
other nodes will be ignored. Often this is what you will want.

If --dot-separate-subgraphs is specified, then each connected
subgraph will be dumped in a different file. The files will
have names like, e.g., pag_final_size48_id4.dot. This means
that this is the dump of the program assignment graph in its
final form, and that subgraph 4 has 48 nodes in it. We include
the size in the name so you can pick out the subgraphs most
likely to be interesting.

Sometimes the dump of a connected subgraph will appear not
to be connected. That is because some of the nodes have been
requested to be hidden. If you want to see them, use the
--dot-show-all option.

In order to implement the above the GenericGraph was
augmented and restructured somewhat. We needed to create
the connected subgraphs and track their sizes (so we
can pick the largest, and also use their size in the
names of the dump files). We also needed to track the
_current subgraph_ of a graph so that when dumping we
can ignore the nodes not in the current subgraph.

The ignoring is implemented using isNodeHidden method in
the DOTGraphTraits. Because this method only has access to
the node and we also needed access to the graph, we
added a pointer to the containing graph in each graph node.
This pointer is filled in when the node is added to the graph
and cleared if the node is removed from the graph.

In particular, to make the subgraph information accessible, the fields
of GenericNodes and GenericGraphs that do not depend on the generic
parameters are factored out into GenericGraphBase and
GenericNodeBase. I also gave a name (equalGEdge_struct) to one
anonymous struct since CLION was complaining that it was not
compliant.

The logic of checking the --dot-* options when deciding whether to
hide a node is centralized in the GenericNodeBase::reallyHideNode
method (defined in SVFUtil.cpp).

The logic to actually produce the selective dot dumps is in the new
GraphPrinter::SelectiveWriteGraphToFile method. This now also includes
the option to immediate view the dot file. This feature is now used by
the view() methods.  One problem I encountered was that I hit
compilation errors when I tried to include Options.h into
GraphPrinter.h because of the fact that Options.h includes
PointerAnalysis.h and WPAPass.h in order to access their enumeration
types and the result is a tangle of includes. To solve this for the
present, I've introduced SimpleOptions.{h,cpp} for options that do not
need to include any other complicating include files. I've placed the
new options in those files. We could consider moving other simple
options there. Alternately, if the enumeration types in
PointerAnalysis and WPAPass were in separate header files we might be
able to avoid these problems.

The GraphPrinter::WriteGraphToFile now returns the name of the file if
it was successful so that it can be immediately displayed if
requested.

GraphPrinter.h is no longer included in BasicTypes.h as that was
leading to some compilation errors. Now it is only included by
clients that need it.

The dump and view methods of the various graphs were modified to use
the above facilities, and graphs missing an isNodeHidden methods were
given one so that the subgraph facility would work for them.