### PR TITLE
cmake: Fix incorrect target name in dependency in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite")
         generatebc ALL
         COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite/generate_bc.sh
     )
-    add_dependencies(generatebc SVF)
+    add_dependencies(generatebc Svf)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite)
     enable_testing()
     add_subdirectory(Test-Suite)


### PR DESCRIPTION
Fixes problem introduced in a8c9039:
```
CMake Error at CMakeLists.txt:64 (add_dependencies):

  The dependency target "SVF" of target "generatebc" does not exist.
```
To be honest, I have no idea how the CI was able to pass with this error.