### PR TITLE
Improve VSFS performance

### DIFF
--- a/include/Graphs/SVFG.h
+++ b/include/Graphs/SVFG.h
@@ -250,6 +250,14 @@ public:
         return nodeNum;
     }
 
+    inline const DummyVersionPropSVFGNode *addDummyVersionPropSVFGNode(const NodeID object, const NodeID version)
+    {
+        DummyVersionPropSVFGNode *dvpNode = new DummyVersionPropSVFGNode(totalVFGNode++, object, version);
+        // Not going through add[S]VFGNode because we have no ICFG edge.
+        addGNode(dvpNode->getId(), dvpNode);
+        return dvpNode;
+    }
+
 protected:
     /// Add indirect def-use edges of a memory region between two statements,
     //@{

--- a/include/Graphs/SVFG.h
+++ b/include/Graphs/SVFG.h
@@ -250,6 +250,9 @@ public:
         return nodeNum;
     }
 
+    /// Used *only* for Versioned FSPTA to encode propagation of versions
+    /// in the worklist (allowing for breadth-first propagation).
+    /// Returns the created node.
     inline const DummyVersionPropSVFGNode *addDummyVersionPropSVFGNode(const NodeID object, const NodeID version)
     {
         DummyVersionPropSVFGNode *dvpNode = new DummyVersionPropSVFGNode(totalVFGNode++, object, version);

--- a/include/Graphs/SVFGNode.h
+++ b/include/Graphs/SVFGNode.h
@@ -434,6 +434,7 @@ private:
  */
 class DummyVersionPropSVFGNode : public VFGNode
 {
+public:
     DummyVersionPropSVFGNode(NodeID id, NodeID object, Version version)
         : VFGNode(id, DummyVProp), object(object), version(version)
     { }

--- a/include/Graphs/SVFGNode.h
+++ b/include/Graphs/SVFGNode.h
@@ -429,6 +429,42 @@ private:
     const CallBlockNode* callInst;
 };
 
+/*
+ * Dummy node which encodes propagation of an object/version pair.
+ */
+class DummyVersionPropSVFGNode : public VFGNode
+{
+    DummyVersionPropSVFGNode(NodeID id, NodeID object, Version version)
+        : VFGNode(id, DummyVProp), object(object), version(version)
+    { }
+
+    NodeID getObject(void) const { return object; }
+    Version getVersion(void) const { return version; }
+
+    /// Methods to support type inquiry through isa, cast, and dyn_cast:
+    //@{
+    static inline bool classof(const DummyVersionPropSVFGNode *)
+    {
+        return true;
+    }
+
+    static inline bool classof(const VFGNode *node)
+    {
+        return node->getNodeKind() == DummyVProp;
+    }
+
+    static inline bool classof(const GenericVFGNodeTy *node)
+    {
+        return node->getNodeKind() == DummyVProp;
+    }
+    //@}
+
+private:
+    const NodeID object;
+    const Version version;
+};
+
+
 } // End namespace SVF
 
 #endif /* INCLUDE_MSSA_SVFGNODE_H_ */

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -55,7 +55,7 @@ public:
     {
         Addr, Copy, Gep, Store, Load, Cmp, BinaryOp, UnaryOp, TPhi, TIntraPhi, TInterPhi,
         MPhi, MIntraPhi, MInterPhi, FRet, ARet, AParm, FParm,
-        FunRet, APIN, APOUT, FPIN, FPOUT, NPtr
+        FunRet, APIN, APOUT, FPIN, FPOUT, NPtr, DummyVProp
     };
 
     typedef VFGEdge::VFGEdgeSetTy::iterator iterator;

--- a/include/WPA/VersionedFlowSensitive.h
+++ b/include/WPA/VersionedFlowSensitive.h
@@ -34,6 +34,7 @@ private:
 public:
     typedef Map<NodeID, Version> ObjToVersionMap;
     typedef Map<NodeID, MeldVersion> ObjToMeldVersionMap;
+    typedef Map<VersionedVar, const DummyVersionPropSVFGNode *> VarToPropNodeMap;
 
     typedef Map<NodeID, ObjToVersionMap> LocVersionMap;
     /// Maps locations to all versions it sees (through objects).
@@ -134,8 +135,7 @@ private:
     /// Propagates version v of o to any version of o which relies on v when o/v is changed.
     /// Recursively applies to reliant versions till no new changes are made.
     /// Adds any statements which rely on any changes made to the worklist.
-    /// recurse is used internally to keep recursive calls from messing up timing.
-    void propagateVersion(NodeID o, Version v, bool recurse=false);
+    void propagateVersion(NodeID o, Version v);
 
     /// Dumps versionReliance and stmtReliance.
     void dumpReliances(void) const;
@@ -167,6 +167,10 @@ private:
     VersionRelianceMap versionReliance;
     /// o x version -> statement nodes which rely on that o/version.
     Map<NodeID, Map<Version, NodeBS>> stmtReliance;
+
+    /// Maps an <object, version> pair to the SVFG node indicating that pair
+    /// needs to be propagated.
+    VarToPropNodeMap versionedVarToPropNode;
 
     /// Worklist for performing meld labeling, takes SVFG node l.
     /// Nodes are added when the version they yield is changed.

--- a/lib/WPA/FlowSensitiveTBHC.cpp
+++ b/lib/WPA/FlowSensitiveTBHC.cpp
@@ -53,7 +53,8 @@ void FlowSensitiveTBHC::finalize(void)
     FlowSensitive::finalize();
     // ^ Will print call graph and alias stats.
 
-    dumpStats();
+    if(print_stat)
+        dumpStats();
     // getDFPTDataTy()->dumpPTData();
 
     validateTBHCTests(svfMod);

--- a/lib/WPA/VersionedFlowSensitive.cpp
+++ b/lib/WPA/VersionedFlowSensitive.cpp
@@ -305,36 +305,55 @@ void VersionedFlowSensitive::determineReliance(void)
     relianceTime = (end - start) / TIMEINTERVAL;
 }
 
-void VersionedFlowSensitive::propagateVersion(NodeID o, Version v, bool recurse)
+void VersionedFlowSensitive::propagateVersion(NodeID o, Version v)
 {
     double start = stat->getClk();
 
     Map<Version, Set<Version>>::iterator relyingVersions = versionReliance[o].find(v);
     if (relyingVersions != versionReliance[o].end())
     {
+        const VersionedVar srcVar = atKey(o, v);
         for (Version r : relyingVersions->second)
         {
-            if (vPtD->unionPts(atKey(o, r), atKey(o, v)))
+            const VersionedVar dstVar = atKey(o, r);
+            if (vPtD->unionPts(dstVar, srcVar))
             {
-                propagateVersion(o, r, true);
+                // o/r has changed.
+                // Add the dummy node to propagate it.
+                VarToPropNodeMap::const_iterator dvpIt = versionedVarToPropNode.find(dstVar);
+                const DummyVersionPropSVFGNode *dvp = nullptr;
+                if (dvpIt == versionedVarToPropNode.end())
+                {
+                    dvp = svfg->addDummyVersionPropSVFGNode(o, r);
+                    versionedVarToPropNode[dstVar] = dvp;
+                } else dvp = dvpIt->second;
+
+                assert(dvp != nullptr && "VFS::propagateVersion: propagation dummy node not found?");
+                pushIntoWorklist(dvp->getId());
+
+                // Notify nodes which rely on o/r that it changed.
+                for (NodeID s : stmtReliance[o][r])
+                {
+                    pushIntoWorklist(s);
+                }
             }
         }
     }
 
-    // Notify nodes which rely on o/v that it changed.
-    for (NodeID s : stmtReliance[o][v])
-    {
-        pushIntoWorklist(s);
-    }
-
     double end = stat->getClk();
-    if (!recurse) versionPropTime += (end - start) / TIMEINTERVAL;
+    versionPropTime += (end - start) / TIMEINTERVAL;
 }
 
 void VersionedFlowSensitive::processNode(NodeID n)
 {
     SVFGNode* sn = svfg->getSVFGNode(n);
-    if (processSVFGNode(sn)) propagate(&sn);
+    // Handle DummyVersPropSVFGNode here so we don't have to override the long
+    // processSVFGNode. We also don't call propagate based on its result.
+    if (const DummyVersionPropSVFGNode *dvp = SVFUtil::dyn_cast<DummyVersionPropSVFGNode>(sn))
+    {
+        propagateVersion(dvp->getObject(), dvp->getVersion());
+    }
+    else if (processSVFGNode(sn)) propagate(&sn);
 }
 
 void VersionedFlowSensitive::updateConnectedNodes(const SVFGEdgeSetTy& newEdges)
@@ -489,7 +508,14 @@ bool VersionedFlowSensitive::processStore(const StoreSVFGNode* store)
         {
             // Definitely has a yielded version (came from prelabelling) as these are
             // the changed objects which must've been pointed to in Andersen's too.
-            propagateVersion(o, yieldl[o]);
+            const Version y = yieldl[o];
+            propagateVersion(o, y);
+
+            // Some o/v pairs changed: statements need to know.
+            for (NodeID s : stmtReliance[o][y])
+            {
+                pushIntoWorklist(s);
+            }
         }
     }
 

--- a/lib/WPA/VersionedFlowSensitive.cpp
+++ b/lib/WPA/VersionedFlowSensitive.cpp
@@ -384,13 +384,11 @@ void VersionedFlowSensitive::updateConnectedNodes(const SVFGEdgeSetTy& newEdges)
                 Version &dstC = consume[dst][o];
 
                 Set<Version> &versionsRelyingOnSrcY = versionReliance[o][srcY];
-                if (versionsRelyingOnSrcY.find(dstC) != versionsRelyingOnSrcY.end())
+                if (versionsRelyingOnSrcY.find(dstC) == versionsRelyingOnSrcY.end())
                 {
-                    continue;
+                    versionsRelyingOnSrcY.insert(dstC);
+                    propagateVersion(o, srcY);
                 }
-
-                versionsRelyingOnSrcY.insert(dstC);
-                propagateVersion(o, srcY);
             }
 
             if (changed) pushIntoWorklist(dst);


### PR DESCRIPTION
This PR introduces two changes:

**BFS instead of DFS for address-taken propagation**
As discussed, propagation is now breadth-first. Since there is no way to add a _propagate o:v to o:v'_ constraint to the solver, I encode this as a dummy node, which holds this information and is pushed into the worklist as required. Otherwise, `propagateVersion` is no longer recursive and some `stmtReliance` stuff is pushed out to `processStore` (previously implied by `propagateVersion`).

**Ignoring existing constraints for call-graph updates**
The changes in `updateConnectedNode` ensure that we don't propagate `o:v` to `o:v'` if it has been done before. `o:v` is not necessarily new to require propagation if a reliance on `o:v` has previously been established.

`vis` is the smallest bitcode I noticed the regression in. It has (dense):
Old vfspta: 25s, new vfspta: 5s-6s, fspta: 15s
`bash` is the largest BC I have on hand that I could run on my 8 GB machine. It has (dense):
Old vfspta: 130s, new vfspta: 65s, fspta: starts swapping too much
A lot of smaller bitcode which I tested didn't really see any significant difference.

Unfortunately, with the server still down I can't test on larger bitcode.