### PR TITLE
Account for reverse points-to sets when removing objects

### DIFF
--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -59,19 +59,19 @@ public:
 
     virtual inline bool addPts(const Key &dstKey, const Data& element) override
     {
-        addSingleRevPts(revPtsMap[element], dstKey);
+        if (this->rev) addSingleRevPts(revPtsMap[element], dstKey);
         return addPts(ptsMap[dstKey], element);
     }
 
     virtual inline bool unionPts(const Key& dstKey, const Key& srcKey) override
     {
-        addRevPts(ptsMap[srcKey], dstKey);
+        if (this->rev) addRevPts(ptsMap[srcKey], dstKey);
         return unionPts(ptsMap[dstKey], getPts(srcKey));
     }
 
     virtual inline bool unionPts(const Key& dstKey, const DataSet& srcDataSet) override
     {
-        addRevPts(srcDataSet,dstKey);
+        if (this->rev) addRevPts(srcDataSet,dstKey);
         return unionPts(ptsMap[dstKey], srcDataSet);
     }
 
@@ -82,14 +82,14 @@ public:
 
     virtual void clearPts(const Key& var, const Data& element) override
     {
-        clearSingleRevPts(revPtsMap[element], var);
+        if (this->rev) clearSingleRevPts(revPtsMap[element], var);
         ptsMap[var].reset(element);
     }
 
     virtual void clearFullPts(const Key& var) override
     {
         DataSet &pts = ptsMap[var];
-        clearRevPts(pts, var);
+        if (this->rev) clearRevPts(pts, var);
         pts.clear();
     }
 
@@ -137,26 +137,20 @@ private:
     }
     inline void addSingleRevPts(KeySet &revData, const Key& tgr)
     {
-        if (this->rev) SVFUtil::insertKey(tgr, revData);
+        SVFUtil::insertKey(tgr, revData);
     }
     inline void addRevPts(const DataSet &ptsData, const Key& tgr)
     {
-        if (this->rev)
-        {
-            for(iterator it = ptsData.begin(), eit = ptsData.end(); it!=eit; ++it)
-                addSingleRevPts(revPtsMap[*it], tgr);
-        }
+        for(iterator it = ptsData.begin(), eit = ptsData.end(); it!=eit; ++it)
+            addSingleRevPts(revPtsMap[*it], tgr);
     }
     inline void clearSingleRevPts(KeySet &revSet, const Key &k)
     {
-        if (this->rev) SVFUtil::removeKey(k, revSet);
+        SVFUtil::removeKey(k, revSet);
     }
     inline void clearRevPts(const DataSet &pts, const Key &k)
     {
-        if (this->rev)
-        {
-            for (const Data &d : pts) clearSingleRevPts(revPtsMap[d], k);
-        }
+        for (const Data &d : pts) clearSingleRevPts(revPtsMap[d], k);
     }
     ///@}
 

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -82,14 +82,14 @@ public:
 
     virtual void clearPts(const Key& var, const Data& element) override
     {
-        clearRevPts(revPtsMap[element], var);
+        clearSingleRevPts(revPtsMap[element], var);
         ptsMap[var].reset(element);
     }
 
     virtual void clearFullPts(const Key& var) override
     {
         DataSet &pts = ptsMap[var];
-        for (const Data &d : pts) clearRevPts(revPtsMap[d], var);
+        clearRevPts(pts, var);
         pts.clear();
     }
 
@@ -147,9 +147,16 @@ private:
                 addSingleRevPts(revPtsMap[*it], tgr);
         }
     }
-    inline void clearRevPts(KeySet &revSet, const Key &k)
+    inline void clearSingleRevPts(KeySet &revSet, const Key &k)
     {
         if (this->rev) SVFUtil::removeKey(k, revSet);
+    }
+    inline void clearRevPts(const DataSet &pts, const Key &k)
+    {
+        if (this->rev)
+        {
+            for (const Data &d : pts) clearSingleRevPts(revPtsMap[d], k);
+        }
     }
     ///@}
 

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -98,12 +98,15 @@ public:
 
     virtual void clearPts(const Key& var, const Data& element) override
     {
+        clearRevPts(revPtsMap[element], var);
         ptsMap[var].reset(element);
     }
 
     virtual void clearFullPts(const Key& var) override
     {
-        ptsMap[var].clear();
+        DataSet &pts = ptsMap[var];
+        for (const Data &d : pts) clearRevPts(revPtsMap[d], var);
+        pts.clear();
     }
 
     /// Methods to support type inquiry through isa, cast, and dyn_cast:
@@ -159,6 +162,10 @@ private:
             for(iterator it = ptsData.begin(), eit = ptsData.end(); it!=eit; ++it)
                 addSingleRevPts(revPtsMap[*it], tgr);
         }
+    }
+    inline void clearRevPts(KeySet &revSet, const Key &k)
+    {
+        if (this->rev) SVFUtil::removeKey(k, revSet);
     }
     ///@}
 

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -59,19 +59,19 @@ public:
 
     virtual inline bool addPts(const Key &dstKey, const Data& element) override
     {
-        if (this->rev) addSingleRevPts(revPtsMap[element], dstKey);
+        addSingleRevPts(revPtsMap[element], dstKey);
         return addPts(ptsMap[dstKey], element);
     }
 
     virtual inline bool unionPts(const Key& dstKey, const Key& srcKey) override
     {
-        if (this->rev) addRevPts(ptsMap[srcKey], dstKey);
+        addRevPts(ptsMap[srcKey], dstKey);
         return unionPts(ptsMap[dstKey], getPts(srcKey));
     }
 
     virtual inline bool unionPts(const Key& dstKey, const DataSet& srcDataSet) override
     {
-        if (this->rev) addRevPts(srcDataSet,dstKey);
+        addRevPts(srcDataSet,dstKey);
         return unionPts(ptsMap[dstKey], srcDataSet);
     }
 
@@ -82,14 +82,14 @@ public:
 
     virtual void clearPts(const Key& var, const Data& element) override
     {
-        if (this->rev) clearSingleRevPts(revPtsMap[element], var);
+        clearSingleRevPts(revPtsMap[element], var);
         ptsMap[var].reset(element);
     }
 
     virtual void clearFullPts(const Key& var) override
     {
         DataSet &pts = ptsMap[var];
-        if (this->rev) clearRevPts(pts, var);
+        clearRevPts(pts, var);
         pts.clear();
     }
 
@@ -137,20 +137,32 @@ private:
     }
     inline void addSingleRevPts(KeySet &revData, const Key& tgr)
     {
-        SVFUtil::insertKey(tgr, revData);
+        if (this->rev)
+        {
+            SVFUtil::insertKey(tgr, revData);
+        }
     }
     inline void addRevPts(const DataSet &ptsData, const Key& tgr)
     {
-        for(iterator it = ptsData.begin(), eit = ptsData.end(); it!=eit; ++it)
-            addSingleRevPts(revPtsMap[*it], tgr);
+        if (this->rev)
+        {
+            for(iterator it = ptsData.begin(), eit = ptsData.end(); it!=eit; ++it)
+                addSingleRevPts(revPtsMap[*it], tgr);
+        }
     }
     inline void clearSingleRevPts(KeySet &revSet, const Key &k)
     {
-        SVFUtil::removeKey(k, revSet);
+        if (this->rev)
+        {
+            SVFUtil::removeKey(k, revSet);
+        }
     }
     inline void clearRevPts(const DataSet &pts, const Key &k)
     {
-        for (const Data &d : pts) clearSingleRevPts(revPtsMap[d], k);
+        if (this->rev)
+        {
+            for (const Data &d : pts) clearSingleRevPts(revPtsMap[d], k);
+        }
     }
     ///@}
 

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -11,22 +11,6 @@
 namespace SVF
 {
 
-/// Templated function to insert an element into a Set, CondSet, or NodeBS.
-template <typename Key, typename KeySet>
-void insertKey(const Key &key, KeySet &keySet)
-{
-    keySet.insert(key);
-}
-
-// The template parameters are unnecessary, obviously, but removing it would
-// require us to create a .cpp. For one function, that seems to add more
-// than this hack.
-template <typename Key, typename KeySet>
-void insertKey(const NodeID &key, NodeBS &keySet)
-{
-    keySet.set(key);
-}
-
 template <typename Key, typename KeySet, typename Data, typename DataSet>
 class MutableDFPTData;
 
@@ -153,7 +137,7 @@ private:
     }
     inline void addSingleRevPts(KeySet &revData, const Key& tgr)
     {
-        if (this->rev) insertKey<Key, KeySet>(tgr, revData);
+        if (this->rev) SVFUtil::insertKey(tgr, revData);
     }
     inline void addRevPts(const DataSet &ptsData, const Key& tgr)
     {

--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -241,6 +241,19 @@ std::string  getSourceLocOfFunction(const Function *F);
 const std::string value2String(const Value* value);
 //@}
 
+/// Removes an element from a Set/CondSet (or anything implementing ::erase).
+template <typename Key, typename KeySet>
+inline void removeKey(const Key &key, KeySet &keySet)
+{
+    keySet.erase(key);
+}
+
+/// Removes a NodeID from a NodeBS.
+inline void removeKey(const NodeID &key, NodeBS &keySet)
+{
+    keySet.reset(key);
+}
+
 } // End namespace SVFUtil
 
 } // End namespace SVF

--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -241,6 +241,19 @@ std::string  getSourceLocOfFunction(const Function *F);
 const std::string value2String(const Value* value);
 //@}
 
+/// Inserts an element into a Set/CondSet (with ::insert).
+template <typename Key, typename KeySet>
+inline void insertKey(const Key &key, KeySet &keySet)
+{
+    keySet.insert(key);
+}
+
+/// Inserts a NodeID into a NodeBS.
+inline void insertKey(const NodeID &key, NodeBS &keySet)
+{
+    keySet.set(key);
+}
+
 /// Removes an element from a Set/CondSet (or anything implementing ::erase).
 template <typename Key, typename KeySet>
 inline void removeKey(const Key &key, KeySet &keySet)

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -505,7 +505,7 @@ bool Andersen::collapseField(NodeID nodeId)
         if (fieldId != baseId)
         {
             // use the reverse pts of this field node to find all pointers point to it
-            const NodeBS &revPts = getRevPts(fieldId);
+            const NodeBS revPts = getRevPts(fieldId);
             for (const NodeID o : revPts)
             {
                 // change the points-to target from field to base node


### PR DESCRIPTION
As discussed, this updates reverse points-to sets when calling functions like `clearPts`. It appears to me that changes only need to be done to the base mutable `PTData`, because no other `PTData` handles reverse points-to sets on their own.

I also moved the `insertKey` function to `SVFUtil` (makes more sense to belong there).

I've moved the test for `this->rev` to the caller, not the callee. In theory, this should have a performance impact for long running analyses since the arguments don't need to be processed (though inline, the arguments need to be processed before the test because some have side effects, though I haven't checked the assembly).

In Andersen's, I made the caller to `getRevPts` not take a reference because that looped-over reverse points-to set has iterators invalidated due to the calls to `clearPts` in the loop. There's obviously a small performance hit there. I do feel it is a bit unsafe though, if someone was to change it back to a reference without realising. Any suggestions?