### PR TITLE
Document debug node allocation as default

### DIFF
--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -15,9 +15,9 @@ namespace SVF
         llvm::cl::init(NodeIDAllocator::Strategy::DEBUG),
         llvm::cl::desc("Method of allocating (LLVM) values and memory objects as node IDs"),
         llvm::cl::values(
-            clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately (default)"),
+            clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately"),
             clEnumValN(NodeIDAllocator::Strategy::SEQ, "seq", "allocate values and objects sequentially, intermixed"),
-            clEnumValN(NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets")));
+            clEnumValN(NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets (default)")));
 
     const llvm::cl::opt<unsigned> Options::MaxFieldLimit(
         "field-limit",


### PR DESCRIPTION
This fell through the cracks when the default returned to debug (thanks @pietroborrello for pointing out).