### PR TITLE
Add assertions when creating a clashed node (guard the DEBUG strategy in NodeIDAllocator)

### DIFF
--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -771,15 +771,13 @@ public:
     /// Add a value (pointer) node
     inline NodeID addValNode(const Value*, PAGNode *node, NodeID i)
     {
-        assert(hasGNode(i) == false && "This NodeID has been used and clashing here, Please check NodeIDAllocator");
-        assert(i < UINT_MAX && "exceeding the maximum node limits");
+        assert(hasGNode(i) == false && "This NodeID clashes here. Please check NodeIDAllocator. Switch Strategy::DEBUG to SEQ or DENSE");
         return addNode(node,i);
     }
     /// Add a memory obj node
     inline NodeID addObjNode(const Value*, PAGNode *node, NodeID i)
     {
-        assert(hasGNode(i) == false && "This NodeID has been used and clashing here. Please check NodeIDAllocator");
-        assert(i < UINT_MAX && "exceeding the maximum node limits");
+        assert(hasGNode(i) == false && "This NodeID clashes here. Please check NodeIDAllocator. Switch Strategy::DEBUG to SEQ or DENSE");
         return addNode(node,i);
     }
     /// Add a unique return node for a procedure

--- a/include/Graphs/PAG.h
+++ b/include/Graphs/PAG.h
@@ -771,13 +771,15 @@ public:
     /// Add a value (pointer) node
     inline NodeID addValNode(const Value*, PAGNode *node, NodeID i)
     {
-		assert(i<UINT_MAX && "exceeding the maximum node limits");
+        assert(hasGNode(i) == false && "This NodeID has been used and clashing here, Please check NodeIDAllocator");
+        assert(i < UINT_MAX && "exceeding the maximum node limits");
         return addNode(node,i);
     }
     /// Add a memory obj node
     inline NodeID addObjNode(const Value*, PAGNode *node, NodeID i)
     {
-		assert(i<UINT_MAX && "exceeding the maximum node limits");
+        assert(hasGNode(i) == false && "This NodeID has been used and clashing here. Please check NodeIDAllocator");
+        assert(i < UINT_MAX && "exceeding the maximum node limits");
         return addNode(node,i);
     }
     /// Add a unique return node for a procedure


### PR DESCRIPTION
@mbarbar @pietroborrello 

This is a quick solution to make sure that if we creating clashed nodes in the DEBUG strategy, the program will crash.

Please let me know any comments or suggestions.