### PR TITLE
Include JSON headers only where required

### DIFF
--- a/include/SVF-FE/LLVMUtil.h
+++ b/include/SVF-FE/LLVMUtil.h
@@ -34,7 +34,6 @@
 #include "Util/BasicTypes.h"
 #include "Util/ExtAPI.h"
 #include "Util/ThreadAPI.h"
-#include "llvm/Support/JSON.h"
 
 namespace SVF
 {

--- a/lib/SVF-FE/Graph2Json.cpp
+++ b/lib/SVF-FE/Graph2Json.cpp
@@ -1,4 +1,7 @@
+#include "llvm/Support/JSON.h"
+
 #include "SVF-FE/Graph2Json.h"
+
 #include <fstream>	// for ICFGBuilderFromFile
 #include <string>	// for ICFGBuilderFromFile
 #include <sstream>	// for ICFGBuilderFromFile

--- a/lib/SVF-FE/LLVMUtil.cpp
+++ b/lib/SVF-FE/LLVMUtil.cpp
@@ -28,7 +28,6 @@
  */
 
 #include "SVF-FE/LLVMUtil.h"
-#include "llvm/Support/JSON.h"
 
 using namespace SVF;
 


### PR DESCRIPTION
This can cause namespace collisions when trying to include SVF as an external project.