### PR TITLE
SABER: add default implementations for some virtual funcs

### DIFF
--- a/include/SABER/LeakChecker.h
+++ b/include/SABER/LeakChecker.h
@@ -75,34 +75,24 @@ public:
     /// Initialize sources and sinks
     //@{
     /// Initialize sources and sinks
-    virtual void initSrcs();
-    virtual void initSnks();
+    virtual void initSrcs() override;
+    virtual void initSnks() override;
     /// Whether the function is a heap allocator/reallocator (allocate memory)
-    virtual inline bool isSourceLikeFun(const SVFFunction* fun)
+    virtual inline bool isSourceLikeFun(const SVFFunction* fun) override
     {
         return SaberCheckerAPI::getCheckerAPI()->isMemAlloc(fun);
     }
     /// Whether the function is a heap deallocator (free/release memory)
-    virtual inline bool isSinkLikeFun(const SVFFunction* fun)
+    virtual inline bool isSinkLikeFun(const SVFFunction* fun) override
     {
         return SaberCheckerAPI::getCheckerAPI()->isMemDealloc(fun);
-    }
-    /// A SVFG node is source if it is an actualRet at malloc site
-    inline bool isSource(const SVFGNode* node)
-    {
-        return getSources().find(node)!=getSources().end();
-    }
-    /// A SVFG node is source if it is an actual parameter at dealloca site
-    inline bool isSink(const SVFGNode* node)
-    {
-        return getSinks().find(node)!=getSinks().end();
     }
     //@}
 
 protected:
     /// Report leaks
     //@{
-    virtual void reportBug(ProgSlice* slice);
+    virtual void reportBug(ProgSlice* slice) override;
     void reportNeverFree(const SVFGNode* src);
     void reportPartialLeak(const SVFGNode* src);
     //@}

--- a/include/SABER/SrcSnkDDA.h
+++ b/include/SABER/SrcSnkDDA.h
@@ -169,10 +169,21 @@ public:
     ///@{
     virtual void initSrcs() = 0;
     virtual void initSnks() = 0;
-    virtual bool isSourceLikeFun(const SVFFunction* fun) = 0;
-    virtual bool isSinkLikeFun(const SVFFunction* fun) = 0;
-    virtual bool isSource(const SVFGNode* node) = 0;
-    virtual bool isSink(const SVFGNode* node) = 0;
+    virtual bool isSourceLikeFun(const SVFFunction* fun) {
+        return false;
+    }
+
+    virtual bool isSinkLikeFun(const SVFFunction* fun) {
+        return false;
+    }
+
+    bool isSource(const SVFGNode* node) const {
+        return getSources().find(node)!=getSources().end();
+    }
+
+    bool isSink(const SVFGNode* node) const {
+        return getSinks().find(node)!=getSinks().end();
+    }
     ///@}
 
     /// Identify allocation wrappers


### PR DESCRIPTION
Hey SVF devs!

Some small mods to the `SrcSnkDDA` class to provide default implementations for some of the virtual methods.

I am trying to extend `SrcSnkDDA` to build my own taint analyzer, and it seems that I have to provide implementations for methods that I don't particularly need. For example, I can implement `initSrcs` and `initSnks` without ever needing to call `isSourceLinkFun` (similarly, `isSinkLikeFun`). Likewise, `isSource` and `isSink` will always just check that the given node is contained within the set of source/sink nodes.

What do you think?