### PR TITLE
Add functions for mapping from SVFG nodes to LLVM values and back

### DIFF
--- a/include/Graphs/SVFG.h
+++ b/include/Graphs/SVFG.h
@@ -173,6 +173,11 @@ public:
         return getSVFGNode(getDef(pagNode));
     }
 
+    /// Return the corresponding SVFGNodes to a given llvm::Value.
+    /// return an empty list, if the no mapping is possible
+    std::set<const SVFGNode*> fromLLVMValue(const llvm::Value* value) const;
+
+
     /// Perform statistics
     void performStat();
 

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -225,7 +225,7 @@ public:
     inline ActualParmVFGNode* getActualParmVFGNode(const PAGNode* aparm,const CallBlockNode* cs) const
     {
         PAGNodeToActualParmMapTy::const_iterator it = PAGNodeToActualParmMap.find(std::make_pair(aparm->getId(),cs));
-        assert(it!=PAGNodeToActualParmMap.end() && "acutal parameter VFG node can not be found??");
+        assert(it!=PAGNodeToActualParmMap.end() && "actual parameter VFG node can not be found??");
         return it->second;
     }
     inline ActualRetVFGNode* getActualRetVFGNode(const PAGNode* aret) const

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -182,7 +182,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*!
@@ -221,7 +221,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*!
@@ -260,7 +260,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*!
@@ -299,7 +299,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 
@@ -371,7 +371,7 @@ public:
         return opVers.end();
     }
     //@}
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 
@@ -443,7 +443,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*!
@@ -555,7 +555,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*
@@ -626,7 +626,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 
@@ -679,7 +679,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 
@@ -716,7 +716,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 
@@ -760,7 +760,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*
@@ -809,7 +809,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 
@@ -877,7 +877,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*!
@@ -933,7 +933,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*!
@@ -997,7 +997,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 /*
@@ -1054,7 +1054,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 
 private:
     const SVFFunction* fun;
@@ -1102,7 +1102,7 @@ public:
     }
     //@}
 
-    virtual const std::string toString() const;
+    const std::string toString() const override;
 };
 
 } // End namespace SVF

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -88,6 +88,12 @@ public:
         return icfgNode->getFun();
     }
 
+    /// Return the corresponding LLVM value, if possible, nullptr otherwise.
+    virtual const Value* getValue() const
+    {
+        return nullptr;
+    }
+
     /// Overloading operator << for dumping ICFG node ID
     //@{
     friend raw_ostream& operator<< (raw_ostream &o, const VFGNode &node)
@@ -182,6 +188,7 @@ public:
     }
     //@}
 
+    const Value* getValue() const override;
     const std::string toString() const override;
 };
 
@@ -371,6 +378,7 @@ public:
         return opVers.end();
     }
     //@}
+    const Value* getValue() const override;
     const std::string toString() const override;
 };
 
@@ -443,6 +451,7 @@ public:
     }
     //@}
 
+    const Value* getValue() const override;
     const std::string toString() const override;
 };
 
@@ -626,6 +635,7 @@ public:
     }
     //@}
 
+    const Value* getValue() const override;
     const std::string toString() const override;
 };
 
@@ -760,6 +770,7 @@ public:
     }
     //@}
 
+    const Value* getValue() const override;
     const std::string toString() const override;
 };
 

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -836,7 +836,7 @@ public:
     }
 
     /// Return function
-    inline const SVFFunction* getFun() const
+    inline const SVFFunction* getFun() const override
     {
         return fun;
     }
@@ -959,7 +959,7 @@ public:
         return param;
     }
     /// Function
-    inline const SVFFunction* getFun() const
+    inline const SVFFunction* getFun() const override
     {
         return fun;
     }
@@ -1022,7 +1022,7 @@ public:
         return (fun!=nullptr) && (callInst != nullptr);
     }
 
-    inline const SVFFunction* getFun() const
+    inline const SVFFunction* getFun() const override
     {
         assert((isFormalParmPHI() || isActualRetPHI())  && "expect a formal parameter phi");
         return fun;

--- a/include/MTA/TCT.h
+++ b/include/MTA/TCT.h
@@ -45,7 +45,7 @@ public:
     }
     /// Classof
     //@{
-    static inline bool classof(const TCTEdge *edge)
+    static inline bool classof(const TCTEdge*)
     {
         return true;
     }

--- a/include/MemoryModel/PersistentPointsToDS.h
+++ b/include/MemoryModel/PersistentPointsToDS.h
@@ -176,7 +176,7 @@ public:
 
     /// Constructor
     PersistentDiffPTData(PersistentPointsToCache<DataSet> &cache, bool reversePT = true, PTDataTy ty = PTDataTy::PersDiff)
-        : BaseDiffPTData(reversePT, ty), persPTData(cache, reversePT), ptCache(cache) { }
+        : BaseDiffPTData(reversePT, ty), ptCache(cache), persPTData(cache, reversePT) { }
 
     virtual ~PersistentDiffPTData() { }
 
@@ -316,7 +316,7 @@ public:
         return persPTData.getPts(var);
     }
 
-    virtual inline const KeySet& getRevPts(const Data &datum) override
+    virtual inline const KeySet& getRevPts(const Data&) override
     {
         assert(false && "PersistentDFPTData::getRevPts: not supported yet!");
     }

--- a/include/SVF-FE/PAGBuilder.h
+++ b/include/SVF-FE/PAGBuilder.h
@@ -178,9 +178,9 @@ public:
     /// TODO: var arguments need to be handled.
     /// https://llvm.org/docs/LangRef.html#id1911
     void visitVAArgInst(VAArgInst&);
-    void visitVACopyInst(VACopyInst& I){}
-    void visitVAEndInst(VAEndInst& I){}
-    void visitVAStartInst(VAStartInst& I){}
+    void visitVACopyInst(VACopyInst&){}
+    void visitVAEndInst(VAEndInst&){}
+    void visitVAStartInst(VAStartInst&){}
 
     /// <result> = freeze ty <val>
     /// If <val> is undef or poison, ‘freeze’ returns an arbitrary, but fixed value of type `ty`

--- a/include/SVF-FE/SymbolTableInfo.h
+++ b/include/SVF-FE/SymbolTableInfo.h
@@ -99,7 +99,7 @@ private:
 protected:
     /// Constructor
     SymbolTableInfo(void) :
-        modelConstants(false), maxStruct(nullptr), maxStSize(0), mod(nullptr), totalSymNum(0)
+        mod(nullptr), modelConstants(false), totalSymNum(0), maxStruct(nullptr), maxStSize(0)
     {
     }
 

--- a/include/Util/NodeIDAllocator.h
+++ b/include/Util/NodeIDAllocator.h
@@ -89,6 +89,6 @@ private:
     static NodeIDAllocator *allocator;
 };
 
-};  // namespace SVF
+}  // namespace SVF
 
 #endif  // ifdef NODEIDALLOCATOR_H_

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -202,7 +202,7 @@ public:
 
     //FlowSensitiveTBHC.cpp
     static const llvm::cl::opt<bool> TBHCStoreReuse;
-    static const llvm::cl::opt<bool> TBHCAllReuse;;
+    static const llvm::cl::opt<bool> TBHCAllReuse;
 
     // TypeAnalysis.cpp
     static const llvm::cl::opt<bool> GenICFG;
@@ -215,6 +215,6 @@ public:
     static llvm::cl::bits<WPAPass::AliasCheckRule> AliasRule;
 
 };
-};  // namespace SVF
+}  // namespace SVF
 
 #endif  // ifdef OPTIONS_H_

--- a/include/Util/SVFBasicTypes.h
+++ b/include/Util/SVFBasicTypes.h
@@ -133,8 +133,6 @@ template <> struct Hash<NodePair>
         // and u64_t. If NodeID is not actually u32_t or size_t
         // is not u64_t we should be fine since we get a
         // consistent result.
-        uint32_t first = (uint32_t)(p.first);
-        uint32_t second = (uint32_t)(p.second);
         return ((uint64_t)(p.first) << 32) | (uint64_t)(p.second);
     }
 };

--- a/include/WPA/VersionedFlowSensitive.h
+++ b/include/WPA/VersionedFlowSensitive.h
@@ -112,7 +112,7 @@ protected:
     virtual void updateConnectedNodes(const SVFGEdgeSetTy& newEdges) override;
 
     /// Override to do nothing. Instead, we will use propagateVersion when necessary.
-    virtual bool propAlongIndirectEdge(const IndirectSVFGEdge* edge) override { return false; }
+    virtual bool propAlongIndirectEdge(const IndirectSVFGEdge*) override { return false; }
 
 private:
     /// Prelabel the SVFG: set y(o) for stores and c(o) for delta nodes to a new version.

--- a/lib/Graphs/PAG.cpp
+++ b/lib/Graphs/PAG.cpp
@@ -365,6 +365,8 @@ PAG::PAG(bool buildFromFile) : fromFile(buildFromFile), nodeNumAfterPAGBuild(0),
     icfg = new ICFG();
     ICFGBuilder builder(icfg);
     builder.build(getModule());
+    // insert dummy value if a correct value cannot be found
+    valueToEdgeMap[nullptr] = PAGEdgeSet();
 }
 
 /*!

--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -544,6 +544,25 @@ void SVFG::dump(const std::string& file, bool simple)
     GraphPrinter::WriteGraphToFile(outs(), file, this, simple);
 }
 
+std::set<const SVFGNode*> SVFG::fromLLVMValue(const llvm::Value* value) const
+{
+    PAG* pag = PAG::getPAG();
+    std::set<const SVFGNode*> ret;
+    // search for all PAGEdges first
+    for (const PAGEdge* pagEdge : pag->getValueEdges(value)) {
+        PAGEdgeToStmtVFGNodeMapTy::const_iterator it = PAGEdgeToStmtVFGNodeMap.find(pagEdge);
+        if (it != PAGEdgeToStmtVFGNodeMap.end()) {
+            ret.emplace(it->second);
+        }
+    }
+    // add all PAGNodes
+    PAGNode* pagNode = pag->getPAGNode(pag->getValueNode(value));
+    if(hasDef(pagNode)) {
+        ret.emplace(getDefSVFGNode(pagNode));
+    }
+    return ret;
+}
+
 /**
  * Get all inter value flow edges at this indirect call site, including call and return edges.
  */

--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -156,6 +156,26 @@ const std::string ThreadMHPIndSVFGEdge::toString() const {
     return rawstr.str();
 }
 
+const Value* StmtSVFGNode::getValue() const {
+    return getPAGEdge()->getValue();
+}
+
+const Value* CmpVFGNode::getValue() const {
+    return getRes()->getValue();
+}
+
+const Value* BinaryOPVFGNode::getValue() const {
+    return getRes()->getValue();
+}
+
+const Value* PHIVFGNode::getValue() const {
+    return getRes()->getValue();
+}
+
+const Value* ArgumentVFGNode::getValue() const {
+    return param->getValue();
+}
+
 
 FormalOUTSVFGNode::FormalOUTSVFGNode(NodeID id, const MemSSA::RETMU* exit): MRSVFGNode(id, FPOUT), mu(exit)
 {

--- a/lib/Graphs/VFG.cpp
+++ b/lib/Graphs/VFG.cpp
@@ -135,7 +135,7 @@ const std::string PHIVFGNode::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "PHIVFGNode ID: " << getId() << " ";
-    rawstr << "PAGEdge: [" << res->getId() << " = PHI(";
+    rawstr << "PAGNode: [" << res->getId() << " = PHI(";
     for(PHIVFGNode::OPVers::const_iterator it = opVerBegin(), eit = opVerEnd();
             it != eit; it++)
         rawstr << it->second->getId() << ", ";
@@ -151,7 +151,7 @@ const std::string IntraPHIVFGNode::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
     rawstr << "IntraPHIVFGNode ID: " << getId() << " ";
-    rawstr << "PAGEdge: [" << res->getId() << " = PHI(";
+    rawstr << "PAGNode: [" << res->getId() << " = PHI(";
     for(PHIVFGNode::OPVers::const_iterator it = opVerBegin(), eit = opVerEnd();
             it != eit; it++)
         rawstr << it->second->getId() << ", ";

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -1437,6 +1437,8 @@ void PAGBuilder::setCurrentBBAndValueForPAGEdge(PAGEdge* edge)
     assert(curVal && "current Val is nullptr?");
     edge->setBB(curBB);
     edge->setValue(curVal);
+    // backmap in valuToEdgeMap
+    pag->mapValueToEdge(curVal, edge);
     ICFGNode* icfgNode = pag->getICFG()->getGlobalBlockNode();
     if (const Instruction *curInst = SVFUtil::dyn_cast<Instruction>(curVal))
     {

--- a/lib/SVF-FE/PAGBuilder.cpp
+++ b/lib/SVF-FE/PAGBuilder.cpp
@@ -1388,7 +1388,7 @@ NodeID PAGBuilder::getGepValNode(const Value* val, const LocationSet& ls, const 
     NodeID gepval = pag->getGepValNode(curVal, base, ls);
     if (gepval==UINT_MAX)
     {
-		assert(UINT_MAX==-1 && "maximum limit of unsigned int is not -1?");
+        assert(((int) UINT_MAX)==-1 && "maximum limit of unsigned int is not -1?");
         /*
          * getGepValNode can only be called from two places:
          * 1. PAGBuilder::addComplexConsForExt to handle external calls

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -32,7 +32,7 @@ namespace SVF
 
     // Initialise counts to 4 because that's how many special nodes we have.
     NodeIDAllocator::NodeIDAllocator(void)
-        : numNodes(4), numObjects(4), numValues(4), numSymbols(4), strategy(Options::NodeAllocStrat)
+        : numObjects(4), numValues(4), numSymbols(4), numNodes(4), strategy(Options::NodeAllocStrat)
     { }
 
     NodeID NodeIDAllocator::allocateObjectId(void)
@@ -143,4 +143,4 @@ namespace SVF
         numSymbols = numNodes;
     }
 
-};  // namespace SVF.
+}  // namespace SVF.

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -710,6 +710,4 @@ namespace SVF
             clEnumValN(WPAPass::Conservative, "conservative", "return MayAlias if any pta says alias"),
             clEnumValN(WPAPass::Veto, "veto", "return NoAlias if any pta says no alias")
         ));
-
-    
-}; // namespace SVF.
+} // namespace SVF.

--- a/lib/Util/SVFUtil.cpp
+++ b/lib/Util/SVFUtil.cpp
@@ -381,7 +381,7 @@ void SVFFunction::viewCFGOnly() {
     }
 }
 
-void SVFUtil::timeLimitReached(int signum)
+void SVFUtil::timeLimitReached(int)
 {
     std::cout.flush();
     SVFUtil::outs().flush();

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -444,7 +444,6 @@ void FlowSensitiveStat::statInOutPtsSize(const DFInOutMap& data, ENUM_INOUT inOr
     const SVFG *svfg = fspta->svfg;
     for (SVFG::const_iterator it = svfg->begin(); it != svfg->end(); ++it)
     {
-        NodeID s = it->first;
         const SVFGNode *sn = it->second;
 
         // Unique objects coming into s.


### PR DESCRIPTION
See #485.

I have tested the code with https://gitlab.com/geri0n/svf-test/-/tree/llvmtovfg.

The back map seems not to work with these nodes (since the PAGNodes are not linked to llvm::Values):
- ActualParmSVFGNode
- FormalRetVFGNode
- IntraPHIVFGNode

Moreover an `assert` in the map filling code does not work: `pag->getPAGEdgeNum()` give me way more edges, than I can find in the graph.