### PR TITLE
Fix GraphTraits for GenericGraph

### DIFF
--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -449,15 +449,6 @@ public:
 namespace llvm
 {
 
-template<class PairTy, class NodeTy>
-struct pair_unary_function
-{
-    NodeTy operator()(PairTy pair) const {
-      return pair.second;
-    }
-};
-
-
 /*!
  * GraphTraits for nodes
  */
@@ -547,19 +538,23 @@ template<class NodeTy,class EdgeTy> struct GraphTraits<SVF::GenericGraph<NodeTy,
     {
         return nullptr; // return null here, maybe later we could create a dummy node
     }
+
     typedef std::pair<SVF::NodeID, NodeType*> PairTy;
-    typedef pair_unary_function<PairTy, NodeType*> DerefVal;
+    static inline NodeType* deref_val(PairTy P)
+    {
+        return P.second;
+    }
 
     // nodes_iterator/begin/end - Allow iteration over all nodes in the graph
-    typedef mapped_iterator<typename GenericGraphTy::iterator, DerefVal> nodes_iterator;
+    typedef mapped_iterator<typename GenericGraphTy::iterator, decltype(&deref_val)> nodes_iterator;
 
     static nodes_iterator nodes_begin(GenericGraphTy *G)
     {
-        return map_iterator(G->begin(), DerefVal());
+        return map_iterator(G->begin(), &deref_val);
     }
     static nodes_iterator nodes_end(GenericGraphTy *G)
     {
-        return map_iterator(G->end(), DerefVal());
+        return map_iterator(G->end(), &deref_val);
     }
 
     static unsigned graphSize(GenericGraphTy* G)

--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -449,14 +449,6 @@ public:
 namespace llvm
 {
 
-template<class EdgeTy, class NodeTy>
-struct edge_unary_function
-{
-    NodeTy operator()(EdgeTy edge) const {
-      return edge->getDstNode();
-    }
-};
-
 template<class PairTy, class NodeTy>
 struct pair_unary_function
 {
@@ -474,10 +466,13 @@ template<class NodeTy,class EdgeTy> struct GraphTraits<SVF::GenericNode<NodeTy,E
     typedef NodeTy NodeType;
     typedef EdgeTy EdgeType;
 
-    typedef edge_unary_function<EdgeType*, NodeType*> DerefEdge;
+    static inline NodeType* edge_dest(const EdgeType* E)
+    {
+        return E->getDstNode();
+    }
 
     // nodes_iterator/begin/end - Allow iteration over all nodes in the graph
-    typedef mapped_iterator<typename SVF::GenericNode<NodeTy,EdgeTy>::iterator, DerefEdge> ChildIteratorType;
+    typedef mapped_iterator<typename SVF::GenericNode<NodeTy,EdgeTy>::iterator, decltype(&edge_dest)> ChildIteratorType;
 
     static NodeType* getEntryNode(NodeType* pagN)
     {
@@ -486,21 +481,20 @@ template<class NodeTy,class EdgeTy> struct GraphTraits<SVF::GenericNode<NodeTy,E
 
     static inline ChildIteratorType child_begin(const NodeType* N)
     {
-        return map_iterator(N->OutEdgeBegin(), DerefEdge());
+        return map_iterator(N->OutEdgeBegin(), &edge_dest);
     }
     static inline ChildIteratorType child_end(const NodeType* N)
     {
-        return map_iterator(N->OutEdgeEnd(), DerefEdge());
+        return map_iterator(N->OutEdgeEnd(), &edge_dest);
     }
     static inline ChildIteratorType direct_child_begin(const NodeType *N)
     {
-        return map_iterator(N->directOutEdgeBegin(), DerefEdge());
+        return map_iterator(N->directOutEdgeBegin(), &edge_dest);
     }
     static inline ChildIteratorType direct_child_end(const NodeType *N)
     {
-        return map_iterator(N->directOutEdgeEnd(), DerefEdge());
+        return map_iterator(N->directOutEdgeEnd(), &edge_dest);
     }
-
 };
 
 /*!
@@ -512,10 +506,13 @@ struct GraphTraits<Inverse<SVF::GenericNode<NodeTy,EdgeTy>* > >
     typedef NodeTy NodeType;
     typedef EdgeTy EdgeType;
 
-    typedef edge_unary_function<EdgeType*, NodeType*> DerefEdge;
+    static inline NodeType* edge_dest(const EdgeType* E)
+    {
+        return E->getSrcNode();
+    }
 
     // nodes_iterator/begin/end - Allow iteration over all nodes in the graph
-    typedef mapped_iterator<typename SVF::GenericNode<NodeTy,EdgeTy>::iterator, DerefEdge> ChildIteratorType;
+    typedef mapped_iterator<typename SVF::GenericNode<NodeTy,EdgeTy>::iterator, decltype(&edge_dest)> ChildIteratorType;
 
     static inline NodeType* getEntryNode(Inverse<NodeType* > G)
     {
@@ -524,11 +521,11 @@ struct GraphTraits<Inverse<SVF::GenericNode<NodeTy,EdgeTy>* > >
 
     static inline ChildIteratorType child_begin(const NodeType* N)
     {
-        return map_iterator(N->InEdgeBegin(), DerefEdge());
+        return map_iterator(N->InEdgeBegin(), &edge_dest);
     }
     static inline ChildIteratorType child_end(const NodeType* N)
     {
-        return map_iterator(N->InEdgeEnd(), DerefEdge());
+        return map_iterator(N->InEdgeEnd(), &edge_dest);
     }
 
     static inline unsigned getNodeID(const NodeType* N)


### PR DESCRIPTION
Hi @yuleisui,

I noticed the inverse GraphTraits for `GenericNode` does not dereference edges to their source nodes, but to their destination nodes.

This patch fixes the bug. It also inlines `edge_unary_function()` into the two `GraphTraits` and renames it to `edge_dest()`, as this name is suggested by the `GraphTraits` template.

For completeness, in a separate commit, I also inlined `pair_unary_function()`. This also cleans up the `llvm` namespace a bit.