### PR TITLE
Speed up VSFS

### DIFF
--- a/include/WPA/VersionedFlowSensitive.h
+++ b/include/WPA/VersionedFlowSensitive.h
@@ -40,7 +40,7 @@ public:
     /// Maps locations to all versions it sees (through objects).
     typedef Map<NodeID, ObjToMeldVersionMap> LocMeldVersionMap;
     /// (o -> (v -> versions with rely on o:v).
-    typedef Map<NodeID, Map<Version, Set<Version>>> VersionRelianceMap;
+    typedef Map<NodeID, Map<Version, std::vector<Version>>> VersionRelianceMap;
 
     /// For caching the first step in LocVersionMaps.
     typedef struct VersionCache

--- a/include/WPA/VersionedFlowSensitive.h
+++ b/include/WPA/VersionedFlowSensitive.h
@@ -138,6 +138,10 @@ private:
     /// Adds any statements which rely on any changes made to the worklist.
     void propagateVersion(NodeID o, Version v);
 
+    /// Propagates version v of o to version vp of o. time indicates whether it should record time
+    /// taken itself.
+    void propagateVersion(const NodeID o, const Version v, const Version vp, bool time=true);
+
     /// Returns true if l is a delta node, i.e., may have new incoming edges due to
     /// on-the-fly call graph resolution. approxCallGraph is the over-approximate
     /// call graph built by the pre-analysis.

--- a/lib/WPA/VersionedFlowSensitive.cpp
+++ b/lib/WPA/VersionedFlowSensitive.cpp
@@ -250,6 +250,9 @@ VersionedFlowSensitive::MeldVersion VersionedFlowSensitive::newMeldVersion(NodeI
 
 void VersionedFlowSensitive::determineReliance(void)
 {
+    // Use a set-based version to build, then we'll move things to vectors.
+    Map<NodeID, Map<Version, Set<Version>>> setVersionReliance;
+
     double start = stat->getClk(true);
     for (SVFG::iterator it = svfg->begin(); it != svfg->end(); ++it)
     {
@@ -270,7 +273,7 @@ void VersionedFlowSensitive::determineReliance(void)
                 const Version cp = getConsume(lp, o);
                 if (cp == invalidVersion) continue;
 
-                if (cp != y) versionReliance[o][y].insert(cp);
+                if (cp != y) setVersionReliance[o][y].insert(cp);
             }
         }
 
@@ -290,6 +293,18 @@ void VersionedFlowSensitive::determineReliance(void)
         }
     }
 
+    for (const std::pair<NodeID, Map<Version, Set<Version>>> &ovvs : setVersionReliance)
+    {
+        const NodeID o = ovvs.first;
+        Map<Version, std::vector<Version>> &osRelying = versionReliance[o];
+        for (const std::pair<Version, Set<Version>> &vvs : ovvs.second)
+        {
+            const Version v = vvs.first;
+            const Set<Version> &vs = vvs.second;
+            osRelying[v] = std::vector<Version>(vs.begin(), vs.end());
+        }
+    }
+
     double end = stat->getClk(true);
     relianceTime = (end - start) / TIMEINTERVAL;
 }
@@ -298,7 +313,7 @@ void VersionedFlowSensitive::propagateVersion(NodeID o, Version v)
 {
     double start = stat->getClk();
 
-    Map<Version, Set<Version>>::iterator relyingVersions = versionReliance[o].find(v);
+    Map<Version, std::vector<Version>>::iterator relyingVersions = versionReliance[o].find(v);
     if (relyingVersions != versionReliance[o].end())
     {
         const VersionedVar srcVar = atKey(o, v);
@@ -339,7 +354,10 @@ void VersionedFlowSensitive::processNode(NodeID n)
     {
         propagateVersion(dvp->getObject(), dvp->getVersion());
     }
-    else if (processSVFGNode(sn)) propagate(&sn);
+    else if (processSVFGNode(sn))
+    {
+        propagate(&sn);
+    }
 }
 
 void VersionedFlowSensitive::updateConnectedNodes(const SVFGEdgeSetTy& newEdges)
@@ -372,10 +390,10 @@ void VersionedFlowSensitive::updateConnectedNodes(const SVFGEdgeSetTy& newEdges)
                 Version dstC = getConsume(dst, o);
                 if (dstC == invalidVersion) continue;
 
-                Set<Version> &versionsRelyingOnSrcY = versionReliance[o][srcY];
-                if (versionsRelyingOnSrcY.find(dstC) == versionsRelyingOnSrcY.end())
+                std::vector<Version> &versionsRelyingOnSrcY = versionReliance[o][srcY];
+                if (std::find(versionsRelyingOnSrcY.begin(), versionsRelyingOnSrcY.end(), dstC) == versionsRelyingOnSrcY.end())
                 {
-                    versionsRelyingOnSrcY.insert(dstC);
+                    versionsRelyingOnSrcY.push_back(dstC);
                     propagateVersion(o, srcY);
                 }
             }
@@ -587,11 +605,11 @@ void VersionedFlowSensitive::invalidateConsumeCache(void)
 void VersionedFlowSensitive::dumpReliances(void) const
 {
     SVFUtil::outs() << "# Version reliances\n";
-    for (const Map<NodeID, Map<Version, Set<Version>>>::value_type ovrv : versionReliance)
+    for (const Map<NodeID, Map<Version, std::vector<Version>>>::value_type &ovrv : versionReliance)
     {
         NodeID o = ovrv.first;
         SVFUtil::outs() << "  Object " << o << "\n";
-        for (const Map<Version, Set<Version>>::value_type vrv : ovrv.second)
+        for (const Map<Version, std::vector<Version>>::value_type vrv : ovrv.second)
         {
             Version v = vrv.first;
             SVFUtil::outs() << "    Version " << v << " is a reliance for: ";


### PR DESCRIPTION
When updating the call graph, if we connect a yielded version `y` to a consumed version `c`, we were propagating `y` to **every** version which relies on `y`, rather than just to `c`. This fixes that. For some benchmarks, this makes a big difference. `lynx` for example, on the first call to update the call graph, adds over 200k edges (!), thus performing redundant propagation.

The `Set` -> `vector` change may also make a difference in extremely large benchmarks.