### PR TITLE
RFC: CMakeLists: +Wall, +Wextra, +Wpedantic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT COMMAND add_llvm_library)
         # add -std=gnu++14
         set(CMAKE_CXX_EXTENSIONS ON)
 
-        set(COMMON_FLAGS "-fPIC -Werror")
+        set(COMMON_FLAGS "-fPIC -Werror -Wall -Wextra -Wpedantic")
 
         if(CMAKE_BUILD_TYPE MATCHES "Debug")
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAGS} -O0 -fno-rtti")


### PR DESCRIPTION
Obviously, this does not pass the tests because of `-Werror`. However, adding the additional warnings usually leads to cleaner code. Do you think, adding them is a good idea?

I don't have the time and knowledge to fix all the warnings. A workaround of course is to disable `-Werror`.