### PR TITLE
cmake: build correctly with globally installed z3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,22 @@ Please set this to environment variable to point to the LLVM build directory\
 else()
         set(IN_SOURCE_BUILD 1)
 endif()
-set(Z3_DIR $ENV{Z3_DIR})
+
+if (DEFINED ENV{Z3_DIR})
+	get_filename_component(Z3_DIR $ENV{Z3_DIR} REALPATH BASE_DIR ${CMAKE_BINARY_DIR})
+    set(Z3_LIBRARIES ${Z3_DIR}/bin/libz3.a)
+	set(Z3_INSTALLS ${Z3_DIR}/include)
+	set(Z3_EXTRA_LINK_DIR ${Z3_DIR}/bin)
+else()
+    include(FindPkgConfig)
+    pkg_search_module(Z3 REQUIRED z3)
+	set(Z3_INSTALLS )
+	set(Z3_EXTRA_LINK_DIR )
+endif()
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
                     ${CMAKE_CURRENT_BINARY_DIR}/include
-                    ${Z3_DIR}/include/)
+                    ${Z3_INSTALLS})
 
 # checks if the test-suite is present, if it is then build bc files and add testing to cmake build
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite")
@@ -63,12 +75,11 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite")
     include(CTest)
 endif()
 
-LINK_DIRECTORIES(${Z3_DIR}/bin)
 add_subdirectory(lib)
 add_subdirectory(tools)
 
 INSTALL(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ ${CMAKE_CURRENT_BINARY_DIR}/include/ ${Z3_DIR}/include/
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ ${CMAKE_CURRENT_BINARY_DIR}/include/ ${Z3_INSTALLS}
     COMPONENT devel
     DESTINATION include/svf
     FILES_MATCHING

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,9 +20,9 @@ file (GLOB SOURCES
         MTA/*.cpp
         SABER/*.cpp
         DDA/*.cpp)
-add_llvm_library(Svf STATIC ${SOURCES} LINK_LIBS Cudd ${Z3_DIR}/bin/libz3.a)
+add_llvm_library(Svf STATIC ${SOURCES} LINK_LIBS Cudd ${Z3_LIBRARIES})
 
-link_directories( ${CMAKE_BINARY_DIR}/lib/Cudd ${Z3_DIR}/bin)
+link_directories(${CMAKE_BINARY_DIR}/lib/Cudd ${Z3_EXTRA_LINK_DIRS})
 
 
 if(DEFINED IN_SOURCE_BUILD)


### PR DESCRIPTION
I have no clue of cmake but this seems to enable building against a globally installed z3 (like per a distribution package).