### PR TITLE
Fix SVFG build error on clang 12

### DIFF
--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -706,7 +706,7 @@ const SVFFunction* SVFG::isFunEntrySVFGNode(const SVFGNode* node) const
     else if(const InterMSSAPHISVFGNode* mphi = SVFUtil::dyn_cast<InterMSSAPHISVFGNode>(node))
     {
         if(mphi->isFormalINPHI())
-            return phi->getFun();
+            return mphi->getFun();
     }
     return nullptr;
 }


### PR DESCRIPTION
Clang 12 is able to statically determine that `phi` will always be NULL here. This caused build problems on my end, and seems like just a typo.