### PR TITLE
Fix missing return in PersistentDFPTData::getRevPts

### DIFF
--- a/include/MemoryModel/PersistentPointsToDS.h
+++ b/include/MemoryModel/PersistentPointsToDS.h
@@ -319,6 +319,7 @@ public:
     virtual inline const KeySet& getRevPts(const Data&) override
     {
         assert(false && "PersistentDFPTData::getRevPts: not supported yet!");
+        return *(KeySet*)nullptr; // suppress -Werror=return-type
     }
 
     virtual inline bool unionPts(const Key& dstKey, const Key& srcKey) override


### PR DESCRIPTION
This PR fixes a compilation error due to missing return in include/MemoryModel/PersistentPointsToDS.h