### PR TITLE
Use sets, not SBVs, for reverse points-to

### DIFF
--- a/include/MemoryModel/PersistentPointsToDS.h
+++ b/include/MemoryModel/PersistentPointsToDS.h
@@ -661,14 +661,14 @@ private:
     inline void removeVarFromDFInUpdatedSet(LocID loc, const Key& var)
     {
         typename UpdatedVarMap::iterator it = inUpdatedVarMap.find(loc);
-        if (it != inUpdatedVarMap.end()) it->second.reset(var);
+        if (it != inUpdatedVarMap.end()) it->second.erase(var);
     }
 
     /// Return TRUE if var has a new pts in loc's IN set
     inline bool varHasNewDFInPts(LocID loc, const Key& var)
     {
         typename UpdatedVarMap::iterator it = inUpdatedVarMap.find(loc);
-        if (it != inUpdatedVarMap.end()) return it->second.test(var);
+        if (it != inUpdatedVarMap.end()) return it->second.find(var) != it->second.end();
         return false;
     }
 
@@ -691,14 +691,14 @@ private:
     inline void removeVarFromDFOutUpdatedSet(LocID loc, const Key& var)
     {
         typename UpdatedVarMap::iterator it = outUpdatedVarMap.find(loc);
-        if (it != outUpdatedVarMap.end()) it->second.reset(var);
+        if (it != outUpdatedVarMap.end()) it->second.erase(var);
     }
 
     /// Return TRUE if var has a new pts in loc's OUT set.
     inline bool varHasNewDFOutPts(LocID loc, const Key& var)
     {
         typename UpdatedVarMap::iterator it = outUpdatedVarMap.find(loc);
-        if (it != outUpdatedVarMap.end()) return it->second.test(var);
+        if (it != outUpdatedVarMap.end()) return it->second.find(var) != it->second.end();
         return false;
     }
 

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -254,7 +254,7 @@ public:
 
     /// Given an object, get all the nodes having whose pointsto contains the object.
     /// Similar to getPts, this also needs to be implemented in child classes.
-    virtual const NodeBS& getRevPts(NodeID nodeId) = 0;
+    virtual const NodeSet& getRevPts(NodeID nodeId) = 0;
 
     /// Clear points-to data
     virtual void clearPts()

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -43,22 +43,22 @@ class BVDataPTAImpl : public PointerAnalysis
 {
 
 public:
-    typedef PTData<NodeID, NodeBS, NodeID, PointsTo> PTDataTy;
-    typedef DiffPTData<NodeID, NodeBS, NodeID, PointsTo> DiffPTDataTy;
-    typedef DFPTData<NodeID, NodeBS, NodeID, PointsTo> DFPTDataTy;
-    typedef VersionedPTData<NodeID, NodeBS, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> VersionedPTDataTy;
+    typedef PTData<NodeID, NodeSet, NodeID, PointsTo> PTDataTy;
+    typedef DiffPTData<NodeID, NodeSet, NodeID, PointsTo> DiffPTDataTy;
+    typedef DFPTData<NodeID, NodeSet, NodeID, PointsTo> DFPTDataTy;
+    typedef VersionedPTData<NodeID, NodeSet, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> VersionedPTDataTy;
 
-    typedef MutablePTData<NodeID, NodeBS, NodeID, PointsTo> MutPTDataTy;
-    typedef MutableDiffPTData<NodeID, NodeBS, NodeID, PointsTo> MutDiffPTDataTy;
-    typedef MutableDFPTData<NodeID, NodeBS, NodeID, PointsTo> MutDFPTDataTy;
-    typedef MutableIncDFPTData<NodeID, NodeBS, NodeID, PointsTo> MutIncDFPTDataTy;
-    typedef MutableVersionedPTData<NodeID, NodeBS, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> MutVersionedPTDataTy;
+    typedef MutablePTData<NodeID, NodeSet, NodeID, PointsTo> MutPTDataTy;
+    typedef MutableDiffPTData<NodeID, NodeSet, NodeID, PointsTo> MutDiffPTDataTy;
+    typedef MutableDFPTData<NodeID, NodeSet, NodeID, PointsTo> MutDFPTDataTy;
+    typedef MutableIncDFPTData<NodeID, NodeSet, NodeID, PointsTo> MutIncDFPTDataTy;
+    typedef MutableVersionedPTData<NodeID, NodeSet, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> MutVersionedPTDataTy;
 
-    typedef PersistentPTData<NodeID, NodeBS, NodeID, PointsTo> PersPTDataTy;
-    typedef PersistentDiffPTData<NodeID, NodeBS, NodeID, PointsTo> PersDiffPTDataTy;
-    typedef PersistentDFPTData<NodeID, NodeBS, NodeID, PointsTo> PersDFPTDataTy;
-    typedef PersistentIncDFPTData<NodeID, NodeBS, NodeID, PointsTo> PersIncDFPTDataTy;
-    typedef PersistentVersionedPTData<NodeID, NodeBS, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> PersVersionedPTDataTy;
+    typedef PersistentPTData<NodeID, NodeSet, NodeID, PointsTo> PersPTDataTy;
+    typedef PersistentDiffPTData<NodeID, NodeSet, NodeID, PointsTo> PersDiffPTDataTy;
+    typedef PersistentDFPTData<NodeID, NodeSet, NodeID, PointsTo> PersDFPTDataTy;
+    typedef PersistentIncDFPTData<NodeID, NodeSet, NodeID, PointsTo> PersIncDFPTDataTy;
+    typedef PersistentVersionedPTData<NodeID, NodeSet, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> PersVersionedPTDataTy;
 
     /// How the PTData used is implemented.
     enum PTBackingType
@@ -102,7 +102,7 @@ public:
     {
         return ptD->getPts(id);
     }
-    virtual inline const NodeBS& getRevPts(NodeID nodeId)
+    virtual inline const NodeSet& getRevPts(NodeID nodeId)
     {
         return ptD->getRevPts(nodeId);
     }
@@ -256,7 +256,7 @@ public:
     typedef PTData<CVar, Set<CVar>, CVar, CPtSet> PTDataTy;
     typedef MutablePTData<CVar, Set<CVar>, CVar, CPtSet> MutPTDataTy;
     typedef Map<NodeID,PointsTo> PtrToBVPtsMap; /// map a pointer to its BitVector points-to representation
-    typedef Map<NodeID, NodeBS> PtrToNSMap;
+    typedef Map<NodeID, NodeSet> PtrToNSMap;
     typedef Map<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
 
     /// Constructor
@@ -453,7 +453,7 @@ protected:
                 for(typename CPtSet::const_iterator cit = it->second.begin(), ecit=it->second.end(); cit!=ecit; ++cit)
                 {
                     ptrToBVPtsMap[(it->first).get_id()].set(cit->get_id());
-                    objToNSRevPtsMap[cit->get_id()].set((it->first).get_id());
+                    objToNSRevPtsMap[cit->get_id()].insert((it->first).get_id());
                     ptrToCPtsMap[(it->first).get_id()].set(*cit);
                 }
             }
@@ -500,7 +500,7 @@ public:
         return ptrToCPtsMap[ptr];
     }
     /// Given an object return all pointers points to this object
-    virtual inline NodeBS& getRevPts(NodeID obj)
+    virtual inline NodeSet& getRevPts(NodeID obj)
     {
         assert(normalized && "Pts of all context-var have to be merged/normalized. Want to use getPts(CVar cvar)??");
         return objToNSRevPtsMap[obj];

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -539,7 +539,7 @@ bool Andersen::collapseField(NodeID nodeId)
         if (fieldId != baseId)
         {
             // use the reverse pts of this field node to find all pointers point to it
-            const NodeBS revPts = getRevPts(fieldId);
+            const NodeSet revPts = getRevPts(fieldId);
             for (const NodeID o : revPts)
             {
                 // change the points-to target from field to base node


### PR DESCRIPTION
As expected, this produced a pretty decent improvement.

```
mbarbar@eres-Pad1:~/clone/svf-upstream/Release-build$ ag 'totaltime|totalmssatime' old* new*
old-debug.txt
81:TotalTime           618.85
123:TotalMSSATime       416.583
150:TotalTime           10.583

old-dense.txt
81:TotalTime           4326.81
123:TotalMSSATime       117.214
150:TotalTime           5.363

old-seq.txt
81:TotalTime           613.472
123:TotalMSSATime       385.63
150:TotalTime           10.513

new-debug.txt
81:TotalTime           243.361
123:TotalMSSATime       406.495
150:TotalTime           10.569

new-dense.txt
81:TotalTime           226.134
123:TotalMSSATime       138.262
150:TotalTime           5.841

new-seq.txt
81:TotalTime           237.199
123:TotalMSSATime       411.329
150:TotalTime           10.594
```

Summary:
* Dense was bad for Andersen's before, now it is good (best -- too close to tell though).
* All the strategies improve.
* Dense is best for SVFG construction time (the second TotalTime) and MSSA time.
* Unclear to me why seq is the same as debug for MSSA and SVFG.
* Allocation strategy for the Andersen's part is less impactful when using ptd=persistent (which these tests do) because we don't operate on the actual points-to sets as much.