### PR TITLE
cmake: find local Z3 install only using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,21 +54,21 @@ endif()
 if (DEFINED Z3_DIR)
     set(ENV{Z3_DIR} "${Z3_DIR}")
 endif()
-if (DEFINED ENV{Z3_DIR})
-	get_filename_component(Z3_DIR $ENV{Z3_DIR} REALPATH BASE_DIR ${CMAKE_BINARY_DIR})
-    set(Z3_LIBRARIES ${Z3_DIR}/bin/libz3.a)
-	set(Z3_INSTALLS ${Z3_DIR}/include)
-	set(Z3_EXTRA_LINK_DIR ${Z3_DIR}/bin)
-else()
-    include(FindPkgConfig)
-    pkg_search_module(Z3 REQUIRED z3)
-	set(Z3_INSTALLS )
-	set(Z3_EXTRA_LINK_DIR )
+find_library(Z3_LIBRARIES NAMES libz3.a libz3.so
+                          HINTS $ENV{Z3_DIR}
+                          PATH_SUFFIXES bin)
+find_path(Z3_INCLUDES NAMES z3++.h
+                      HINTS $ENV{Z3_DIR}
+                      PATH_SUFFIXES include z3)
+if(NOT Z3_LIBRARIES OR NOT Z3_INCLUDES)
+    message(FATAL_ERROR "Z3 not found!")
 endif()
+message(STATUS "Found Z3: ${Z3_LIBRARIES}")
+message(STATUS "Z3 include dir: ${Z3_INCLUDES}")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
                     ${CMAKE_CURRENT_BINARY_DIR}/include
-                    ${Z3_INSTALLS})
+                    ${Z3_INCLUDES})
 
 # checks if the test-suite is present, if it is then build bc files and add testing to cmake build
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite")
@@ -82,7 +82,7 @@ add_subdirectory(lib)
 add_subdirectory(tools)
 
 INSTALL(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ ${CMAKE_CURRENT_BINARY_DIR}/include/ ${Z3_INSTALLS}
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ ${CMAKE_CURRENT_BINARY_DIR}/include/ ${Z3_INCLUDES}
     COMPONENT devel
     DESTINATION include/svf
     FILES_MATCHING

--- a/build.sh
+++ b/build.sh
@@ -118,6 +118,7 @@ fi
 
 export PATH=$LLVM_DIR/bin:$PATH
 echo "LLVM_DIR =" $LLVM_DIR
+echo "Z3_DIR =" $Z3_DIR
 
 ########
 # Build SVF

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,7 +22,7 @@ file (GLOB SOURCES
         DDA/*.cpp)
 add_llvm_library(Svf STATIC ${SOURCES} LINK_LIBS Cudd ${Z3_LIBRARIES})
 
-link_directories(${CMAKE_BINARY_DIR}/lib/Cudd ${Z3_EXTRA_LINK_DIRS})
+link_directories(${CMAKE_BINARY_DIR}/lib/Cudd)
 
 
 if(DEFINED IN_SOURCE_BUILD)


### PR DESCRIPTION
`pkg-config` was not a good idea since Z3's `pkg-config` files are distributed only on Ubuntu 21.04 and newer.  This approach does not depend on any external tools or special packaging.

Tested on Ubuntu 20.04, Fedora Linux 34 and Arch Linux.