### PR TITLE
Use better performing defaults.

### DIFF
--- a/include/MemoryModel/PersistentPointsToCache.h
+++ b/include/MemoryModel/PersistentPointsToCache.h
@@ -190,7 +190,7 @@ public:
                 ++totalIntersections;
 
                 // and result AND lhs = result,
-                intersectionCache[std::minmax(result, lhs)] = lhs;
+                intersectionCache[std::minmax(result, lhs)] = result;
                 ++propertyIntersections;
                 ++totalIntersections;
 

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -7,12 +7,12 @@ namespace SVF
 {
     const llvm::cl::opt<bool> Options::MarkedClocksOnly(
         "marked-clocks-only",
-        llvm::cl::init(false),
+        llvm::cl::init(true),
         llvm::cl::desc("Only measure times where explicitly marked"));
 
     const llvm::cl::opt<NodeIDAllocator::Strategy> Options::NodeAllocStrat(
         "node-alloc-strat",
-        llvm::cl::init(NodeIDAllocator::Strategy::DEBUG),
+        llvm::cl::init(NodeIDAllocator::Strategy::SEQ),
         llvm::cl::desc("Method of allocating (LLVM) values and memory objects as node IDs"),
         llvm::cl::values(
             clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together and values together, separately"),
@@ -26,7 +26,7 @@ namespace SVF
 
     const llvm::cl::opt<BVDataPTAImpl::PTBackingType> Options::ptDataBacking(
         "ptd",
-        llvm::cl::init(BVDataPTAImpl::PTBackingType::Mutable),
+        llvm::cl::init(BVDataPTAImpl::PTBackingType::Persistent),
         llvm::cl::desc("Overarching points-to data structure"),
         llvm::cl::values(
             clEnumValN(BVDataPTAImpl::PTBackingType::Mutable, "mutable", "points-to set per pointer"),


### PR DESCRIPTION
`ptd`: `mutable` -> `persistent`
`marked-clocks-only`: now true
`node-alloc-strat`: `seq`

For the reserved names, I think we need a bit more discussion, so let's save this till next week.