### PR TITLE
Fix CBV

### DIFF
--- a/lib/Util/CoreBitVector.cpp
+++ b/lib/Util/CoreBitVector.cpp
@@ -161,7 +161,7 @@ bool CoreBitVector::operator==(const CoreBitVector &rhs) const
     }
 
     // Make sure both got to the end at the same time.
-    return lhsSetIndex >= words.size() && rhsSetIndex >= words.size();
+    return lhsSetIndex >= words.size() && rhsSetIndex >= rhs.words.size();
 }
 
 bool CoreBitVector::operator!=(const CoreBitVector &rhs) const


### PR DESCRIPTION
Was not comparing with RHS words size.

This actually thus only seemed to affect persistent which uses operator==. This fixes the inconsistency we saw.

I couldn't reproduce the crashing though, could you test if this fixes that?