### PR TITLE
Add option for wall time

### DIFF
--- a/include/Graphs/SVFGStat.h
+++ b/include/Graphs/SVFGStat.h
@@ -108,52 +108,52 @@ public:
 
     void dirVFEdgeStart()
     {
-        connectDirSVFGEdgeTimeStart = CLOCK_IN_MS();
+        connectDirSVFGEdgeTimeStart = PTAStat::getClk(true);
     }
 
     void dirVFEdgeEnd()
     {
-        connectDirSVFGEdgeTimeEnd = CLOCK_IN_MS();
+        connectDirSVFGEdgeTimeEnd = PTAStat::getClk(true);
     }
 
     void indVFEdgeStart()
     {
-        connectIndSVFGEdgeTimeStart = CLOCK_IN_MS();
+        connectIndSVFGEdgeTimeStart = PTAStat::getClk(true);
     }
 
     void indVFEdgeEnd()
     {
-        connectIndSVFGEdgeTimeEnd = CLOCK_IN_MS();
+        connectIndSVFGEdgeTimeEnd = PTAStat::getClk(true);
     }
 
     void TLVFNodeStart()
     {
-        addTopLevelNodeTimeStart = CLOCK_IN_MS();
+        addTopLevelNodeTimeStart = PTAStat::getClk(true);
     }
 
     void TLVFNodeEnd()
     {
-        addTopLevelNodeTimeEnd = CLOCK_IN_MS();
+        addTopLevelNodeTimeEnd = PTAStat::getClk(true);
     }
 
     void ATVFNodeStart()
     {
-        addAddrTakenNodeTimeStart = CLOCK_IN_MS();
+        addAddrTakenNodeTimeStart = PTAStat::getClk(true);
     }
 
     void ATVFNodeEnd()
     {
-        addAddrTakenNodeTimeEnd = CLOCK_IN_MS();
+        addAddrTakenNodeTimeEnd = PTAStat::getClk(true);
     }
 
     void sfvgOptStart()
     {
-        svfgOptTimeStart = CLOCK_IN_MS();
+        svfgOptTimeStart = PTAStat::getClk(true);
     }
 
     void sfvgOptEnd()
     {
-        svfgOptTimeEnd = CLOCK_IN_MS();
+        svfgOptTimeEnd = PTAStat::getClk(true);
     }
 
 private:

--- a/include/MemoryModel/PTAStat.h
+++ b/include/MemoryModel/PTAStat.h
@@ -122,16 +122,22 @@ public:
 
     typedef Map<const char*,double> TIMEStatMap;
 
+    enum ClockType
+    {
+        Wall,
+        CPU,
+    };
+
     PTAStat(PointerAnalysis* p);
     virtual ~PTAStat() {}
 
     virtual inline void startClk()
     {
-        startTime = CLOCK_IN_MS();
+        startTime = getClk(true);
     }
     virtual inline void endClk()
     {
-        endTime = CLOCK_IN_MS();
+        endTime = getClk(true);
     }
     /// When mark is true, real clock is always returned. When mark is false, it is
     /// only returned when Options::MarkedClocksOnly is not set.

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -5,6 +5,7 @@
 
 #include <sstream>
 #include "FastCluster/fastcluster.h"
+#include "MemoryModel/PTAStat.h"
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "Util/NodeIDAllocator.h"
 #include "MSSA/MemSSA.h"
@@ -18,6 +19,8 @@ class Options
 {
 public:
     Options(void) = delete;
+
+    static const llvm::cl::opt<enum PTAStat::ClockType> ClockType;
 
     /// If set, only return the clock when getClk is called as getClk(true).
     /// Retrieving the clock is slow but it should be fine for a few calls.

--- a/lib/SVF-FE/CHG.cpp
+++ b/lib/SVF-FE/CHG.cpp
@@ -43,6 +43,7 @@
 #include "Util/SVFUtil.h"
 #include "SVF-FE/LLVMUtil.h"
 #include "Util/SVFModule.h"
+#include "MemoryModel/PTAStat.h"
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -88,7 +89,7 @@ void CHGraph::buildCHG()
 {
 
     double timeStart, timeEnd;
-    timeStart = CLOCK_IN_MS();
+    timeStart = PTAStat::getClk(true);
     for (u32_t i = 0; i < LLVMModuleSet::getLLVMModuleSet()->getModuleNum(); ++i)
     {
         Module *M = LLVMModuleSet::getLLVMModuleSet()->getModule(i);
@@ -109,7 +110,7 @@ void CHGraph::buildCHG()
     DBOUT(DGENERAL, outs() << SVFUtil::pasMsg("build Internal Maps ...\n"));
     buildInternalMaps();
 
-    timeEnd = CLOCK_IN_MS();
+    timeEnd = PTAStat::getClk(true);
     buildingCHGTime = (timeEnd - timeStart) / TIMEINTERVAL;
 
     if (Options::DumpCHA)

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -5,6 +5,16 @@
 
 namespace SVF
 {
+    const llvm::cl::opt<enum PTAStat::ClockType> Options::ClockType(
+        "clock-type",
+        llvm::cl::init(PTAStat::ClockType::CPU),
+        llvm::cl::desc("how time should be measured"),
+        llvm::cl::values(
+            clEnumValN(PTAStat::ClockType::Wall, "wall", "use wall time"),
+            clEnumValN(PTAStat::ClockType::CPU, "cpu", "use CPU time")
+        )
+    );
+
     const llvm::cl::opt<bool> Options::MarkedClocksOnly(
         "marked-clocks-only",
         llvm::cl::init(true),

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -107,12 +107,27 @@ const char* PTAStat:: NumOfNullPointer = "NullPointer";	///< Number of pointers 
 
 PTAStat::PTAStat(PointerAnalysis* p) : startTime(0), endTime(0), pta(p)
 {
-
+    assert((Options::ClockType == ClockType::Wall || Options::ClockType == ClockType::CPU)
+           && "PTAStat: unknown clock type!");
 }
 
 double PTAStat::getClk(bool mark) {
     if (Options::MarkedClocksOnly && !mark) return 0.0;
-    return CLOCK_IN_MS();
+
+    if (Options::ClockType == ClockType::Wall)
+    {
+        struct timespec time;
+        clock_gettime(CLOCK_MONOTONIC, &time);
+        return (double)(time.tv_nsec + time.tv_sec * 1000000000) / 1000000.0;
+    }
+    else if (Options::ClockType == ClockType::CPU)
+    {
+        return CLOCK_IN_MS();
+    }
+    else
+    {
+        assert(false && "PTAStat::getClk: unknown clock type");
+    }
 }
 
 void PTAStat::performStat()


### PR DESCRIPTION
Basically, `getClk` checks what it wants: it uses `clock` (`CLOCK_IN_MS`) if the option is for CPU time, otherwise it uses `clock_gettime`, returning the value in ms.

I also changed a bunch of calls to the higher level `getClk`.