### PR TITLE
Fix build errors (-Werror, wpa: missing pthreads)

### DIFF
--- a/lib/MemoryModel/PointsTo.cpp
+++ b/lib/MemoryModel/PointsTo.cpp
@@ -276,9 +276,9 @@ bool PointsTo::intersectWithComplement(const PointsTo &rhs)
     if (type == CBV) return cbv.intersectWithComplement(rhs.cbv);
     else if (type == SBV) return sbv.intersectWithComplement(rhs.sbv);
     else if (type == BV) return bv.intersectWithComplement(rhs.bv);
-    else {
-        assert(false && "PointsTo::intersectWithComplement(PT): unknown type");
-    }
+
+    assert(false && "PointsTo::intersectWithComplement(PT): unknown type");
+    abort();
 }
 
 void PointsTo::intersectWithComplement(const PointsTo &lhs, const PointsTo &rhs)

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -124,10 +124,9 @@ double PTAStat::getClk(bool mark) {
     {
         return CLOCK_IN_MS();
     }
-    else
-    {
-        assert(false && "PTAStat::getClk: unknown clock type");
-    }
+
+    assert(false && "PTAStat::getClk: unknown clock type");
+    abort();
 }
 
 void PTAStat::performStat()

--- a/lib/Util/SVFUtil.cpp
+++ b/lib/Util/SVFUtil.cpp
@@ -378,6 +378,7 @@ std::string SVFUtil::hclustMethodToString(hclust_fast_methods method)
         return "svf-best";
     default:
         assert(false && "SVFUtil::hclustMethodToString: unknown method");
+        abort();
     }
 }
 

--- a/tools/WPA/CMakeLists.txt
+++ b/tools/WPA/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 
 if(DEFINED IN_SOURCE_BUILD)
     set(LLVM_LINK_COMPONENTS BitWriter Core IPO IrReader InstCombine Instrumentation Target Linker Analysis ScalarOpts Support Svf Cudd)
@@ -5,7 +7,7 @@ if(DEFINED IN_SOURCE_BUILD)
 else()
     add_executable( wpa wpa.cpp )
 
-    target_link_libraries( wpa Svf Cudd ${llvm_libs} )
+    target_link_libraries( wpa Svf Cudd ${llvm_libs} Threads::Threads )
 
     set_target_properties( wpa PROPERTIES
                            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )


### PR DESCRIPTION
I wasn't able to build the latest commit with gcc 11.1.0 and had to fix some minor issues.

* wpa: pthreads is not linked
* missing return value for non-void functions (fails due to `-Werror`) in three cases