### PR TITLE
first/second vs. p.first/p.second

### DIFF
--- a/include/Util/SVFBasicTypes.h
+++ b/include/Util/SVFBasicTypes.h
@@ -138,6 +138,8 @@ template <> struct Hash<NodePair>
         // and u64_t. If NodeID is not actually u32_t or size_t
         // is not u64_t we should be fine since we get a
         // consistent result.
+        uint32_t first = (uint32_t)(p.first);
+        uint32_t second = (uint32_t)(p.second);
         return ((uint64_t)(first) << 32) | (uint64_t)(second);
     }
 };
@@ -266,7 +268,7 @@ template <> struct std::hash<SVF::NodePair> {
         // consistent result.
         uint32_t first = (uint32_t)(p.first);
         uint32_t second = (uint32_t)(p.second);
-        return ((uint64_t)(p.first) << 32) | (uint64_t)(p.second);
+        return ((uint64_t)(first) << 32) | (uint64_t)(second);
     }
 };
 

--- a/include/Util/SVFBasicTypes.h
+++ b/include/Util/SVFBasicTypes.h
@@ -138,7 +138,7 @@ template <> struct Hash<NodePair>
         // and u64_t. If NodeID is not actually u32_t or size_t
         // is not u64_t we should be fine since we get a
         // consistent result.
-        return ((uint64_t)(p.first) << 32) | (uint64_t)(p.second);
+        return ((uint64_t)(first) << 32) | (uint64_t)(second);
     }
 };
 


### PR DESCRIPTION
For some reason there are two identical hashes. I don't have time to fix it now though.