### PR TITLE
better naming convention for subclasses of SVFVar and SVFStmt

### DIFF
--- a/include/Graphs/ICFGNode.h
+++ b/include/Graphs/ICFGNode.h
@@ -47,7 +47,7 @@ class VFGNode;
 
 /*!
  * Interprocedural control-flow graph node, representing different kinds of program statements
- * including top-level pointers (ValPN) and address-taken objects (ObjPN)
+ * including top-level pointers (ValVar) and address-taken objects (ObjVar)
  */
 typedef GenericNode<ICFGNode, ICFGEdge> GenericICFGNodeTy;
 

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -483,28 +483,28 @@ protected:
         setDef(pagNode,sNode);
     }
     /// Add an Address VFG node
-    inline void addAddrVFGNode(const AddrPE* addr)
+    inline void addAddrVFGNode(const AddrStmt* addr)
     {
         AddrVFGNode* sNode = new AddrVFGNode(totalVFGNode++,addr);
         addStmtVFGNode(sNode, addr);
         setDef(addr->getDstNode(),sNode);
     }
     /// Add a Copy VFG node
-    inline void addCopyVFGNode(const CopyPE* copy)
+    inline void addCopyVFGNode(const CopyStmt* copy)
     {
         CopyVFGNode* sNode = new CopyVFGNode(totalVFGNode++,copy);
         addStmtVFGNode(sNode, copy);
         setDef(copy->getDstNode(),sNode);
     }
     /// Add a Gep VFG node
-    inline void addGepVFGNode(const GepPE* gep)
+    inline void addGepVFGNode(const GepStmt* gep)
     {
         GepVFGNode* sNode = new GepVFGNode(totalVFGNode++,gep);
         addStmtVFGNode(sNode, gep);
         setDef(gep->getDstNode(),sNode);
     }
     /// Add a Load VFG node
-    void addLoadVFGNode(const LoadPE* load)
+    void addLoadVFGNode(const LoadStmt* load)
     {
         LoadVFGNode* sNode = new LoadVFGNode(totalVFGNode++,load);
         addStmtVFGNode(sNode, load);
@@ -512,7 +512,7 @@ protected:
     }
     /// Add a Store VFG node,
     /// To be noted store does not create a new pointer, we do not set def for any SVFIR node
-    void addStoreVFGNode(const StorePE* store)
+    void addStoreVFGNode(const StoreStmt* store)
     {
         StoreVFGNode* sNode = new StoreVFGNode(totalVFGNode++,store);
         addStmtVFGNode(sNode, store);
@@ -569,7 +569,7 @@ protected:
         PAGNodeToActualRetMap[ret] = sNode;
     }
     /// Add an llvm PHI VFG node
-    inline void addIntraPHIVFGNode(const PhiPE* edge)
+    inline void addIntraPHIVFGNode(const PhiStmt* edge)
     {
         IntraPHIVFGNode* sNode = new IntraPHIVFGNode(totalVFGNode++,edge->getRes());
         u32_t pos = 0;
@@ -583,7 +583,7 @@ protected:
         PAGNodeToIntraPHIVFGNodeMap[edge->getRes()] = sNode;
     }
     /// Add a Compare VFG node
-    inline void addCmpVFGNode(const CmpPE* edge)
+    inline void addCmpVFGNode(const CmpStmt* edge)
     {
         CmpVFGNode* sNode = new CmpVFGNode(totalVFGNode++, edge->getRes());
         u32_t pos = 0;
@@ -597,7 +597,7 @@ protected:
         PAGNodeToCmpVFGNodeMap[edge->getRes()] = sNode;
     }
     /// Add a BinaryOperator VFG node
-    inline void addBinaryOPVFGNode(const BinaryOPPE* edge)
+    inline void addBinaryOPVFGNode(const BinaryOPStmt* edge)
     {
         BinaryOPVFGNode* sNode = new BinaryOPVFGNode(totalVFGNode++, edge->getRes());
         u32_t pos = 0;
@@ -611,7 +611,7 @@ protected:
         PAGNodeToBinaryOPVFGNodeMap[edge->getRes()] = sNode;
     }
     /// Add a UnaryOperator VFG node
-    inline void addUnaryOPVFGNode(const UnaryOPPE* edge)
+    inline void addUnaryOPVFGNode(const UnaryOPStmt* edge)
     {
         UnaryOPVFGNode* sNode = new UnaryOPVFGNode(totalVFGNode++, edge->getRes());
         sNode->setOpVer(0, edge->getOpVar());

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -40,7 +40,7 @@ namespace SVF
 
 /*!
  * Interprocedural control-flow graph node, representing different kinds of program statements
- * including top-level pointers (ValPN) and address-taken objects (ObjPN)
+ * including top-level pointers (ValVar) and address-taken objects (ObjVar)
  */
 typedef GenericNode<VFGNode,VFGEdge> GenericVFGNodeTy;
 class VFGNode : public GenericVFGNodeTy
@@ -202,7 +202,7 @@ private:
 
 public:
     /// Constructor
-    LoadVFGNode(NodeID id, const LoadPE* edge): StmtVFGNode(id, edge,Load)
+    LoadVFGNode(NodeID id, const LoadStmt* edge): StmtVFGNode(id, edge,Load)
     {
 
     }
@@ -241,7 +241,7 @@ private:
 
 public:
     /// Constructor
-    StoreVFGNode(NodeID id,const StorePE* edge): StmtVFGNode(id,edge,Store)
+    StoreVFGNode(NodeID id,const StoreStmt* edge): StmtVFGNode(id,edge,Store)
     {
 
     }
@@ -280,7 +280,7 @@ private:
 
 public:
     /// Constructor
-    CopyVFGNode(NodeID id,const CopyPE* copy): StmtVFGNode(id,copy,Copy)
+    CopyVFGNode(NodeID id,const CopyStmt* copy): StmtVFGNode(id,copy,Copy)
     {
 
     }
@@ -591,7 +591,7 @@ private:
 
 public:
     /// Constructor
-    GepVFGNode(NodeID id,const GepPE* edge): StmtVFGNode(id,edge,Gep)
+    GepVFGNode(NodeID id,const GepStmt* edge): StmtVFGNode(id,edge,Gep)
     {
 
     }
@@ -753,7 +753,7 @@ private:
 
 public:
     /// Constructor
-    AddrVFGNode(NodeID id, const AddrPE* edge): StmtVFGNode(id, edge,Addr)
+    AddrVFGNode(NodeID id, const AddrStmt* edge): StmtVFGNode(id, edge,Addr)
     {
 
     }

--- a/include/MSSA/MSSAMuChi.h
+++ b/include/MSSA/MSSAMuChi.h
@@ -166,13 +166,13 @@ class LoadMU : public MSSAMU<Cond>
 {
 
 private:
-    const LoadPE* inst;
+    const LoadStmt* inst;
     const BasicBlock* bb;
 
 public:
     /// Constructor/Destructor for MU
     //@{
-    LoadMU(const BasicBlock* b,const LoadPE* i, const MemRegion* m, Cond c = true) :
+    LoadMU(const BasicBlock* b,const LoadStmt* i, const MemRegion* m, Cond c = true) :
         MSSAMU<Cond>(MSSAMU<Cond>::LoadMSSAMU,m,c), inst(i), bb(b)
     {
     }
@@ -183,7 +183,7 @@ public:
     //@}
 
     /// Return load instruction
-    inline const LoadPE* getLoadInst() const
+    inline const LoadStmt* getLoadInst() const
     {
         return inst;
     }
@@ -462,11 +462,11 @@ class StoreCHI : public MSSACHI<Cond>
 {
 private:
     const BasicBlock* bb;
-    const StorePE* inst;
+    const StoreStmt* inst;
 public:
     /// Constructors for StoreCHI
     //@{
-    StoreCHI(const BasicBlock* b, const StorePE* i, const MemRegion* m, Cond c = true) :
+    StoreCHI(const BasicBlock* b, const StoreStmt* i, const MemRegion* m, Cond c = true) :
         MSSACHI<Cond>(MSSADEF::StoreMSSACHI,m,c), bb(b), inst(i)
     {
     }
@@ -482,7 +482,7 @@ public:
     }
 
     /// Get store instruction
-    inline const StorePE* getStoreInst() const
+    inline const StoreStmt* getStoreInst() const
     {
         return inst;
     }

--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -146,15 +146,15 @@ public:
     /// Map loads/stores to its mem regions,
     /// TODO:visitAtomicCmpXchgInst, visitAtomicRMWInst??
     //@{
-    typedef Map<const LoadPE*, MRSet> LoadsToMRsMap;
-    typedef Map<const StorePE*, MRSet> StoresToMRsMap;
+    typedef Map<const LoadStmt*, MRSet> LoadsToMRsMap;
+    typedef Map<const StoreStmt*, MRSet> StoresToMRsMap;
     typedef Map<const CallBlockNode*, MRSet> CallSiteToMRsMap;
     //@}
 
     /// Map loads/stores/callsites to their cpts set
     //@{
-    typedef Map<const LoadPE*, NodeBS> LoadsToPointsToMap;
-    typedef Map<const StorePE*, NodeBS> StoresToPointsToMap;
+    typedef Map<const LoadStmt*, NodeBS> LoadsToPointsToMap;
+    typedef Map<const StoreStmt*, NodeBS> StoresToPointsToMap;
     typedef Map<const CallBlockNode*, NodeBS> CallSiteToPointsToMap;
     //@}
 
@@ -334,13 +334,13 @@ protected:
 
     /// Add cpts to store/load
     //@{
-    inline void addCPtsToStore(NodeBS& cpts, const StorePE *st, const SVFFunction* fun)
+    inline void addCPtsToStore(NodeBS& cpts, const StoreStmt *st, const SVFFunction* fun)
     {
         storesToPointsToMap[st] = cpts;
         funToPointsToMap[fun].insert(cpts);
         addModSideEffectOfFunction(fun,cpts);
     }
-    inline void addCPtsToLoad(NodeBS& cpts, const LoadPE *ld, const SVFFunction* fun)
+    inline void addCPtsToLoad(NodeBS& cpts, const LoadStmt *ld, const SVFFunction* fun)
     {
         loadsToPointsToMap[ld] = cpts;
         funToPointsToMap[fun].insert(cpts);
@@ -440,11 +440,11 @@ public:
     {
         return funToMRsMap[fun];
     }
-    inline MRSet& getLoadMRSet(const LoadPE* load)
+    inline MRSet& getLoadMRSet(const LoadStmt* load)
     {
         return loadsToMRsMap[load];
     }
-    inline MRSet& getStoreMRSet(const StorePE* store)
+    inline MRSet& getStoreMRSet(const StoreStmt* store)
     {
         return storesToMRsMap[store];
     }

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -71,8 +71,8 @@ public:
     /// Map loads/stores to its mem regions,
     /// TODO:visitAtomicCmpXchgInst, visitAtomicRMWInst??
     //@{
-    typedef Map<const LoadPE*, MUSet> LoadToMUSetMap;
-    typedef Map<const StorePE*, CHISet> StoreToChiSetMap;
+    typedef Map<const LoadStmt*, MUSet> LoadToMUSetMap;
+    typedef Map<const StoreStmt*, CHISet> StoreToChiSetMap;
     typedef Map<const CallBlockNode*, MUSet> CallSiteToMUSetMap;
     typedef Map<const CallBlockNode*, CHISet> CallSiteToCHISetMap;
     typedef Map<const BasicBlock*, PHISet> BBToPhiSetMap;
@@ -180,12 +180,12 @@ private:
 
     /// Add methods for mus/chis/phis
     //@{
-    inline void AddLoadMU(const BasicBlock* bb, const LoadPE* load, const MRSet& mrSet)
+    inline void AddLoadMU(const BasicBlock* bb, const LoadStmt* load, const MRSet& mrSet)
     {
         for (MRSet::iterator iter = mrSet.begin(), eiter = mrSet.end(); iter != eiter; ++iter)
             AddLoadMU(bb,load,*iter);
     }
-    inline void AddStoreCHI(const BasicBlock* bb, const StorePE* store, const MRSet& mrSet)
+    inline void AddStoreCHI(const BasicBlock* bb, const StoreStmt* store, const MRSet& mrSet)
     {
         for (MRSet::iterator iter = mrSet.begin(), eiter = mrSet.end(); iter != eiter; ++iter)
             AddStoreCHI(bb,store,*iter);
@@ -205,13 +205,13 @@ private:
         for (MRSet::iterator iter = mrSet.begin(), eiter = mrSet.end(); iter != eiter; ++iter)
             AddMSSAPHI(bb,*iter);
     }
-    inline void AddLoadMU(const BasicBlock* bb, const LoadPE* load, const MemRegion* mr)
+    inline void AddLoadMU(const BasicBlock* bb, const LoadStmt* load, const MemRegion* mr)
     {
         LOADMU* mu = new LOADMU(bb,load, mr);
         load2MuSetMap[load].insert(mu);
         collectRegUses(mr);
     }
-    inline void AddStoreCHI(const BasicBlock* bb, const StorePE* store, const MemRegion* mr)
+    inline void AddStoreCHI(const BasicBlock* bb, const StoreStmt* store, const MemRegion* mr)
     {
         STORECHI* chi = new STORECHI(bb,store, mr);
         store2ChiSetMap[store].insert(chi);
@@ -331,7 +331,7 @@ public:
     //@{
     inline bool hasMU(const PAGEdge* inst) const
     {
-        if (const LoadPE* load = SVFUtil::dyn_cast<LoadPE>(inst))
+        if (const LoadStmt* load = SVFUtil::dyn_cast<LoadStmt>(inst))
         {
             assert(0 != load2MuSetMap.count(load)
                    && "not associated with mem region!");
@@ -342,7 +342,7 @@ public:
     }
     inline bool hasCHI(const PAGEdge* inst) const
     {
-        if (const StorePE* store = SVFUtil::dyn_cast<StorePE>(
+        if (const StoreStmt* store = SVFUtil::dyn_cast<StoreStmt>(
                                        inst))
         {
             assert(0 != store2ChiSetMap.count(store)
@@ -385,11 +385,11 @@ public:
 
     /// Get methods of mu/chi/phi
     //@{
-    inline MUSet& getMUSet(const LoadPE* ld)
+    inline MUSet& getMUSet(const LoadStmt* ld)
     {
         return load2MuSetMap[ld];
     }
-    inline CHISet& getCHISet(const StorePE* st)
+    inline CHISet& getCHISet(const StoreStmt* st)
     {
         return store2ChiSetMap[st];
     }

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -344,7 +344,7 @@ public:
     ///@{
     inline bool isFIObjNode(NodeID id) const
     {
-        return (SVFUtil::isa<FIObjPN>(pag->getGNode(id)));
+        return (SVFUtil::isa<FIObjVar>(pag->getGNode(id)));
     }
     inline NodeID getBaseObjNode(NodeID id)
     {

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -577,11 +577,11 @@ public:
             const PAGNode* node = this->getPAG()->getGNode(*nIter);
             if (this->getPAG()->isValidTopLevelPtr(node))
             {
-                if (SVFUtil::isa<DummyObjPN>(node))
+                if (SVFUtil::isa<DummyObjVar>(node))
                 {
                     SVFUtil::outs() << "##<Blackhole or constant> id:" << node->getId();
                 }
-                else if (!SVFUtil::isa<DummyValPN>(node))
+                else if (!SVFUtil::isa<DummyValVar>(node))
                 {
                     SVFUtil::outs() << "##<" << node->getValue()->getName() << "> ";
                     //SVFUtil::outs() << "Source Loc: " << SVFUtil::getSourceLoc(node->getValue());

--- a/include/MemoryModel/SVFStatements.h
+++ b/include/MemoryModel/SVFStatements.h
@@ -193,16 +193,16 @@ private:
 /*!
  * Copy edge
  */
-class AddrPE: public SVFStmt
+class AddrStmt: public SVFStmt
 {
 private:
-    AddrPE();                      ///< place holder
-    AddrPE(const AddrPE &);  ///< place holder
-    void operator=(const AddrPE &); ///< place holder
+    AddrStmt();                      ///< place holder
+    AddrStmt(const AddrStmt &);  ///< place holder
+    void operator=(const AddrStmt &); ///< place holder
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const AddrPE *)
+    static inline bool classof(const AddrStmt *)
     {
         return true;
     }
@@ -217,7 +217,7 @@ public:
     //@}
 
     /// constructor
-    AddrPE(SVFVar* s, SVFVar* d) : SVFStmt(s,d,SVFStmt::Addr)
+    AddrStmt(SVFVar* s, SVFVar* d) : SVFStmt(s,d,SVFStmt::Addr)
     {
     }
 
@@ -228,16 +228,16 @@ public:
 /*!
  * Copy edge
  */
-class CopyPE: public SVFStmt
+class CopyStmt: public SVFStmt
 {
 private:
-    CopyPE();                      ///< place holder
-    CopyPE(const CopyPE &);  ///< place holder
-    void operator=(const CopyPE &); ///< place holder
+    CopyStmt();                      ///< place holder
+    CopyStmt(const CopyStmt &);  ///< place holder
+    void operator=(const CopyStmt &); ///< place holder
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const CopyPE *)
+    static inline bool classof(const CopyStmt *)
     {
         return true;
     }
@@ -252,7 +252,7 @@ public:
     //@}
 
     /// constructor
-    CopyPE(SVFVar* s, SVFVar* d) : SVFStmt(s,d,SVFStmt::Copy)
+    CopyStmt(SVFVar* s, SVFVar* d) : SVFStmt(s,d,SVFStmt::Copy)
     {
     }
 
@@ -325,12 +325,12 @@ public:
 /*!
  * Phi instruction edge
  */
-class PhiPE: public MultiOpndStmt
+class PhiStmt: public MultiOpndStmt
 {
 private:
-    PhiPE();                      ///< place holder
-    PhiPE(const PhiPE &);  ///< place holder
-    void operator=(const PhiPE &); ///< place holder
+    PhiStmt();                      ///< place holder
+    PhiStmt(const PhiStmt &);  ///< place holder
+    void operator=(const PhiStmt &); ///< place holder
     SVFVar* getSrcNode();  ///< place holder, not allowed since this SVFStmt has multiple operands but not a single source
     SVFVar* getDstNode();    ///< place holder, use getRes() instead
     SVFVar* getSrcID();  ///< place holder, use getOpVarID(pos) instead
@@ -339,7 +339,7 @@ private:
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const PhiPE *)
+    static inline bool classof(const PhiStmt *)
     {
         return true;
     }
@@ -358,7 +358,7 @@ public:
     //@}
 
     /// constructor
-    PhiPE(SVFVar* s, const OPVars& opnds) : MultiOpndStmt(s,opnds,SVFStmt::Phi)
+    PhiStmt(SVFVar* s, const OPVars& opnds) : MultiOpndStmt(s,opnds,SVFStmt::Phi)
     {
     }
     void addOpVar(SVFVar* op){
@@ -371,12 +371,12 @@ public:
 /*!
  * Compare instruction edge
  */
-class CmpPE: public MultiOpndStmt
+class CmpStmt: public MultiOpndStmt
 {
 private:
-    CmpPE();                      ///< place holder
-    CmpPE(const CmpPE &);  ///< place holder
-    void operator=(const CmpPE &); ///< place holder
+    CmpStmt();                      ///< place holder
+    CmpStmt(const CmpStmt &);  ///< place holder
+    void operator=(const CmpStmt &); ///< place holder
     SVFVar* getSrcNode();  ///< place holder, not allowed since this SVFStmt has multiple operands but not a single source
     SVFVar* getDstNode();    ///< place holder, use getRes() instead
     SVFVar* getSrcID();  ///< place holder, use getOpVarID(pos) instead
@@ -386,7 +386,7 @@ private:
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const CmpPE *)
+    static inline bool classof(const CmpStmt *)
     {
         return true;
     }
@@ -405,7 +405,7 @@ public:
     //@}
 
     /// constructor
-    CmpPE(SVFVar* s, const OPVars& opnds, u32_t oc) : MultiOpndStmt(s,opnds,SVFStmt::Cmp), opcode(oc)
+    CmpStmt(SVFVar* s, const OPVars& opnds, u32_t oc) : MultiOpndStmt(s,opnds,SVFStmt::Cmp), opcode(oc)
     {
     }
 
@@ -421,12 +421,12 @@ public:
 /*!
  * Binary instruction edge
  */
-class BinaryOPPE: public MultiOpndStmt
+class BinaryOPStmt: public MultiOpndStmt
 {
 private:
-    BinaryOPPE();                      ///< place holder
-    BinaryOPPE(const BinaryOPPE &);  ///< place holder
-    void operator=(const BinaryOPPE &); ///< place holder
+    BinaryOPStmt();                      ///< place holder
+    BinaryOPStmt(const BinaryOPStmt &);  ///< place holder
+    void operator=(const BinaryOPStmt &); ///< place holder
     SVFVar* getSrcNode();  ///< place holder, not allowed since this SVFStmt has multiple operands but not a single source
     SVFVar* getDstNode();    ///< place holder, use getRes() instead
     SVFVar* getSrcID();  ///< place holder, use getOpVarID(pos) instead
@@ -437,7 +437,7 @@ private:
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const BinaryOPPE *)
+    static inline bool classof(const BinaryOPStmt *)
     {
         return true;
     }
@@ -456,7 +456,7 @@ public:
     //@}
 
     /// constructor
-    BinaryOPPE(SVFVar* s, const OPVars& opnds, u32_t oc) : MultiOpndStmt(s,opnds,SVFStmt::BinaryOp), opcode(oc)
+    BinaryOPStmt(SVFVar* s, const OPVars& opnds, u32_t oc) : MultiOpndStmt(s,opnds,SVFStmt::BinaryOp), opcode(oc)
     {
     }
 
@@ -471,12 +471,12 @@ public:
 /*!
  * Unary instruction edge
  */
-class UnaryOPPE: public SVFStmt
+class UnaryOPStmt: public SVFStmt
 {
 private:
-    UnaryOPPE();                      ///< place holder
-    UnaryOPPE(const UnaryOPPE &);  ///< place holder
-    void operator=(const UnaryOPPE &); ///< place holder
+    UnaryOPStmt();                      ///< place holder
+    UnaryOPStmt(const UnaryOPStmt &);  ///< place holder
+    void operator=(const UnaryOPStmt &); ///< place holder
     SVFVar* getSrcNode();  ///< place holder, use getOpVar() instead
     SVFVar* getDstNode();    ///< place holder, use getRes() instead
     SVFVar* getSrcID();  ///< place holder, use getOpVarID() instead
@@ -486,7 +486,7 @@ private:
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const UnaryOPPE *)
+    static inline bool classof(const UnaryOPStmt *)
     {
         return true;
     }
@@ -501,7 +501,7 @@ public:
     //@}
 
     /// constructor
-    UnaryOPPE(SVFVar* s, SVFVar* d, u32_t oc) : SVFStmt(s,d,SVFStmt::UnaryOp), opcode(oc)
+    UnaryOPStmt(SVFVar* s, SVFVar* d, u32_t oc) : SVFStmt(s,d,SVFStmt::UnaryOp), opcode(oc)
     {
     }
 
@@ -588,17 +588,17 @@ public:
 /*!
  * Store edge
  */
-class StorePE: public SVFStmt
+class StoreStmt: public SVFStmt
 {
 private:
-    StorePE();                      ///< place holder
-    StorePE(const StorePE &);  ///< place holder
-    void operator=(const StorePE &); ///< place holder
+    StoreStmt();                      ///< place holder
+    StoreStmt(const StoreStmt &);  ///< place holder
+    void operator=(const StoreStmt &); ///< place holder
 
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const StorePE *)
+    static inline bool classof(const StoreStmt *)
     {
         return true;
     }
@@ -613,7 +613,7 @@ public:
     //@}
 
     /// constructor
-    StorePE(SVFVar* s, SVFVar* d, const IntraBlockNode* st) :
+    StoreStmt(SVFVar* s, SVFVar* d, const IntraBlockNode* st) :
         SVFStmt(s, d, makeEdgeFlagWithStoreInst(SVFStmt::Store, st))
     {
     }
@@ -625,17 +625,17 @@ public:
 /*!
  * Load edge
  */
-class LoadPE: public SVFStmt
+class LoadStmt: public SVFStmt
 {
 private:
-    LoadPE();                      ///< place holder
-    LoadPE(const LoadPE &);  ///< place holder
-    void operator=(const LoadPE &); ///< place holder
+    LoadStmt();                      ///< place holder
+    LoadStmt(const LoadStmt &);  ///< place holder
+    void operator=(const LoadStmt &); ///< place holder
 
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const LoadPE *)
+    static inline bool classof(const LoadStmt *)
     {
         return true;
     }
@@ -650,7 +650,7 @@ public:
     //@}
 
     /// constructor
-    LoadPE(SVFVar* s, SVFVar* d) : SVFStmt(s,d,SVFStmt::Load)
+    LoadStmt(SVFVar* s, SVFVar* d) : SVFStmt(s,d,SVFStmt::Load)
     {
     }
 
@@ -661,17 +661,17 @@ public:
 /*!
  * Gep edge
  */
-class GepPE: public SVFStmt
+class GepStmt: public SVFStmt
 {
 private:
-    GepPE();                      ///< place holder
-    GepPE(const GepPE &);  ///< place holder
-    void operator=(const GepPE &); ///< place holder
+    GepStmt();                      ///< place holder
+    GepStmt(const GepStmt &);  ///< place holder
+    void operator=(const GepStmt &); ///< place holder
 
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const GepPE *)
+    static inline bool classof(const GepStmt *)
     {
         return true;
     }
@@ -689,7 +689,7 @@ public:
 
 protected:
     /// constructor
-    GepPE(SVFVar* s, SVFVar* d, PEDGEK k) : SVFStmt(s,d,k)
+    GepStmt(SVFVar* s, SVFVar* d, PEDGEK k) : SVFStmt(s,d,k)
     {
 
     }
@@ -701,23 +701,23 @@ protected:
 /*!
  * Gep edge with a fixed offset
  */
-class NormalGepPE : public GepPE
+class NormalGepStmt : public GepStmt
 {
 private:
-    NormalGepPE(); ///< place holder
-    NormalGepPE(const NormalGepPE&); ///< place holder
-    void operator=(const NormalGepPE&); ///< place holder
+    NormalGepStmt(); ///< place holder
+    NormalGepStmt(const NormalGepStmt&); ///< place holder
+    void operator=(const NormalGepStmt&); ///< place holder
 
     LocationSet ls;	///< location set of the gep edge
 
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const NormalGepPE *)
+    static inline bool classof(const NormalGepStmt *)
     {
         return true;
     }
-    static inline bool classof(const GepPE *edge)
+    static inline bool classof(const GepStmt *edge)
     {
         return edge->getEdgeKind() == SVFStmt::NormalGep;
     }
@@ -732,7 +732,7 @@ public:
     //@}
 
     /// constructor
-    NormalGepPE(SVFVar* s, SVFVar* d, const LocationSet& l) : GepPE(s,d,SVFStmt::NormalGep), ls(l)
+    NormalGepStmt(SVFVar* s, SVFVar* d, const LocationSet& l) : GepStmt(s,d,SVFStmt::NormalGep), ls(l)
     {}
 
     /// offset of the gep edge
@@ -751,21 +751,21 @@ public:
 /*!
  * Gep edge with a variant offset
  */
-class VariantGepPE : public GepPE
+class VariantGepStmt : public GepStmt
 {
 private:
-    VariantGepPE(); ///< place holder
-    VariantGepPE(const VariantGepPE&); ///< place holder
-    void operator=(const VariantGepPE&); ///< place holder
+    VariantGepStmt(); ///< place holder
+    VariantGepStmt(const VariantGepStmt&); ///< place holder
+    void operator=(const VariantGepStmt&); ///< place holder
 
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const VariantGepPE *)
+    static inline bool classof(const VariantGepStmt *)
     {
         return true;
     }
-    static inline bool classof(const GepPE *edge)
+    static inline bool classof(const GepStmt *edge)
     {
         return edge->getEdgeKind() == SVFStmt::VariantGep;
     }
@@ -780,7 +780,7 @@ public:
     //@}
 
     /// constructor
-    VariantGepPE(SVFVar* s, SVFVar* d) : GepPE(s,d,SVFStmt::VariantGep) {}
+    VariantGepStmt(SVFVar* s, SVFVar* d) : GepStmt(s,d,SVFStmt::VariantGep) {}
 
     virtual const std::string toString() const override;
 

--- a/include/MemoryModel/SVFVariables.h
+++ b/include/MemoryModel/SVFVariables.h
@@ -270,13 +270,13 @@ public:
 /*
  * Value(Pointer) node
  */
-class ValPN: public SVFVar
+class ValVar: public SVFVar
 {
 
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const ValPN *)
+    static inline bool classof(const ValVar *)
     {
         return true;
     }
@@ -295,7 +295,7 @@ public:
     //@}
 
     /// Constructor
-    ValPN(const Value* val, NodeID i, PNODEK ty = ValNode) :
+    ValVar(const Value* val, NodeID i, PNODEK ty = ValNode) :
         SVFVar(val, i, ty)
     {
     }
@@ -314,20 +314,20 @@ public:
 /*
  * Memory Object node
  */
-class ObjPN: public SVFVar
+class ObjVar: public SVFVar
 {
 
 protected:
     const MemObj* mem;	///< memory object
     /// Constructor
-    ObjPN(const Value* val, NodeID i, const MemObj* m, PNODEK ty = ObjNode) :
+    ObjVar(const Value* val, NodeID i, const MemObj* m, PNODEK ty = ObjNode) :
         SVFVar(val, i, ty), mem(m)
     {
     }
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const ObjPN *)
+    static inline bool classof(const ObjVar *)
     {
         return true;
     }
@@ -381,7 +381,7 @@ public:
  * e.g. memcpy, temp gep value node needs to be created
  * Each Gep Value node is connected to base value node via gep edge
  */
-class GepValPN: public ValPN
+class GepValVar: public ValVar
 {
 
 private:
@@ -392,11 +392,11 @@ private:
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const GepValPN *)
+    static inline bool classof(const GepValVar *)
     {
         return true;
     }
-    static inline bool classof(const ValPN * node)
+    static inline bool classof(const ValVar * node)
     {
         return node->getNodeKind() == SVFVar::GepValNode;
     }
@@ -411,8 +411,8 @@ public:
     //@}
 
     /// Constructor
-    GepValPN(const Value* val, NodeID i, const LocationSet& l, const Type *ty, u32_t idx) :
-        ValPN(val, i, GepValNode), ls(l), gepValType(ty), fieldIdx(idx)
+    GepValVar(const Value* val, NodeID i, const LocationSet& l, const Type *ty, u32_t idx) :
+        ValVar(val, i, GepValNode), ls(l), gepValType(ty), fieldIdx(idx)
     {
     }
 
@@ -448,7 +448,7 @@ public:
  * Gep Obj node, this is dynamic generated for field sensitive analysis
  * Each gep obj node is one field of a MemObj (base)
  */
-class GepObjPN: public ObjPN
+class GepObjPN: public ObjVar
 {
 private:
     LocationSet ls;
@@ -461,7 +461,7 @@ public:
     {
         return true;
     }
-    static inline bool classof(const ObjPN * node)
+    static inline bool classof(const ObjVar * node)
     {
         return node->getNodeKind() == SVFVar::GepObjNode
                || node->getNodeKind() == SVFVar::CloneGepObjNode;
@@ -480,7 +480,7 @@ public:
 
     /// Constructor
     GepObjPN(const MemObj* mem, NodeID i, const LocationSet& l, PNODEK ty = GepObjNode) :
-        ObjPN(mem->getValue(), i, mem, ty), ls(l)
+        ObjVar(mem->getValue(), i, mem, ty), ls(l)
     {
         base = mem->getId();
     }
@@ -524,17 +524,17 @@ public:
  * Field-insensitive Gep Obj node, this is dynamic generated for field sensitive analysis
  * Each field-insensitive gep obj node represents all fields of a MemObj (base)
  */
-class FIObjPN: public ObjPN
+class FIObjVar: public ObjVar
 {
 public:
 
     ///  Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const FIObjPN *)
+    static inline bool classof(const FIObjVar *)
     {
         return true;
     }
-    static inline bool classof(const ObjPN * node)
+    static inline bool classof(const ObjVar * node)
     {
         return node->getNodeKind() == SVFVar::FIObjNode
                || node->getNodeKind() == SVFVar::CloneFIObjNode;
@@ -552,8 +552,8 @@ public:
     //@}
 
     /// Constructor
-    FIObjPN(const Value* val, NodeID i, const MemObj* mem, PNODEK ty = FIObjNode) :
-        ObjPN(val, i, mem, ty)
+    FIObjVar(const Value* val, NodeID i, const MemObj* mem, PNODEK ty = FIObjNode) :
+        ObjVar(val, i, mem, ty)
     {
     }
 
@@ -651,13 +651,13 @@ public:
 /*
  * Dummy node
  */
-class DummyValPN: public ValPN
+class DummyValVar: public ValVar
 {
 
 public:
 
     //@{ Methods for support type inquiry through isa, cast, and dyn_cast:
-    static inline bool classof(const DummyValPN *)
+    static inline bool classof(const DummyValVar *)
     {
         return true;
     }
@@ -672,7 +672,7 @@ public:
     //@}
 
     /// Constructor
-    DummyValPN(NodeID i) : ValPN(nullptr, i, DummyValNode)
+    DummyValVar(NodeID i) : ValVar(nullptr, i, DummyValNode)
     {
     }
 
@@ -690,13 +690,13 @@ public:
 /*
  * Dummy node
  */
-class DummyObjPN: public ObjPN
+class DummyObjVar: public ObjVar
 {
 
 public:
 
     //@{ Methods for support type inquiry through isa, cast, and dyn_cast:
-    static inline bool classof(const DummyObjPN *)
+    static inline bool classof(const DummyObjVar *)
     {
         return true;
     }
@@ -713,8 +713,8 @@ public:
     //@}
 
     /// Constructor
-    DummyObjPN(NodeID i,const MemObj* m, PNODEK ty = DummyObjNode)
-        : ObjPN(nullptr, i, m, ty)
+    DummyObjVar(NodeID i,const MemObj* m, PNODEK ty = DummyObjNode)
+        : ObjVar(nullptr, i, m, ty)
     {
     }
 
@@ -730,11 +730,11 @@ public:
 /*
  * Clone object node for dummy objects.
  */
-class CloneDummyObjPN: public DummyObjPN
+class CloneDummyObjVar: public DummyObjVar
 {
 public:
     //@{ Methods to support type inquiry through isa, cast, and dyn_cast:
-    static inline bool classof(const CloneDummyObjPN *)
+    static inline bool classof(const CloneDummyObjVar *)
     {
         return true;
     }
@@ -749,15 +749,15 @@ public:
     //@}
 
     /// Constructor
-    CloneDummyObjPN(NodeID i, const MemObj* m, PNODEK ty = CloneDummyObjNode)
-        : DummyObjPN(i, m, ty)
+    CloneDummyObjVar(NodeID i, const MemObj* m, PNODEK ty = CloneDummyObjNode)
+        : DummyObjVar(i, m, ty)
     {
     }
 
     /// Return name of this node
     inline const std::string getValueName() const
     {
-        return "clone of " + ObjPN::getValueName();
+        return "clone of " + ObjVar::getValueName();
     }
 
     virtual const std::string toString() const;
@@ -766,11 +766,11 @@ public:
 /*
  * Clone object for GEP objects.
  */
-class CloneGepObjPN : public GepObjPN
+class CloneGepObjVar : public GepObjPN
 {
 public:
     //@{ Methods to support type inquiry through isa, cast, and dyn_cast:
-    static inline bool classof(const CloneGepObjPN *)
+    static inline bool classof(const CloneGepObjVar *)
     {
         return true;
     }
@@ -785,7 +785,7 @@ public:
     //@}
 
     /// Constructor
-    CloneGepObjPN(const MemObj* mem, NodeID i, const LocationSet& l, PNODEK ty = CloneGepObjNode) :
+    CloneGepObjVar(const MemObj* mem, NodeID i, const LocationSet& l, PNODEK ty = CloneGepObjNode) :
         GepObjPN(mem, i, l, ty)
     {
     }
@@ -802,11 +802,11 @@ public:
 /*
  * Clone object for FI objects.
  */
-class CloneFIObjPN : public FIObjPN
+class CloneFIObjVar : public FIObjVar
 {
 public:
     //@{ Methods to support type inquiry through isa, cast, and dyn_cast:
-    static inline bool classof(const CloneFIObjPN *)
+    static inline bool classof(const CloneFIObjVar *)
     {
         return true;
     }
@@ -821,15 +821,15 @@ public:
     //@}
 
     /// Constructor
-    CloneFIObjPN(const Value* val, NodeID i, const MemObj* mem, PNODEK ty = CloneFIObjNode) :
-        FIObjPN(val, i, mem, ty)
+    CloneFIObjVar(const Value* val, NodeID i, const MemObj* mem, PNODEK ty = CloneFIObjNode) :
+        FIObjVar(val, i, mem, ty)
     {
     }
 
     /// Return name of this node
     inline const std::string getValueName() const
     {
-        return "clone (FI) of " + FIObjPN::getValueName();
+        return "clone (FI) of " + FIObjVar::getValueName();
     }
 
     virtual const std::string toString() const;

--- a/include/SVF-FE/SVFIRBuilder.h
+++ b/include/SVF-FE/SVFIRBuilder.h
@@ -281,44 +281,44 @@ public:
     }
 
     /// Add Address edge
-    inline AddrPE* addAddrEdge(NodeID src, NodeID dst)
+    inline AddrStmt* addAddrEdge(NodeID src, NodeID dst)
     {
-        AddrPE *edge = pag->addAddrPE(src, dst);
+        AddrStmt *edge = pag->addAddrPE(src, dst);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Copy edge
-    inline CopyPE* addCopyEdge(NodeID src, NodeID dst)
+    inline CopyStmt* addCopyEdge(NodeID src, NodeID dst)
     {
-        CopyPE *edge = pag->addCopyPE(src, dst);
+        CopyStmt *edge = pag->addCopyPE(src, dst);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Copy edge
-    inline PhiPE* addPhiNode(NodeID res, NodeID opnd)
+    inline PhiStmt* addPhiNode(NodeID res, NodeID opnd)
     {
-        PhiPE *edge = pag->addPhiNode(res,opnd);
+        PhiStmt *edge = pag->addPhiNode(res,opnd);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Copy edge
-    inline CmpPE* addCmpEdge(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
+    inline CmpStmt* addCmpEdge(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
     {
-        CmpPE *edge = pag->addCmpPE(op1, op2, dst, opcode);
+        CmpStmt *edge = pag->addCmpPE(op1, op2, dst, opcode);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Copy edge
-    inline BinaryOPPE* addBinaryOPEdge(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
+    inline BinaryOPStmt* addBinaryOPEdge(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
     {
-        BinaryOPPE *edge = pag->addBinaryOPPE(op1, op2, dst, opcode);
+        BinaryOPStmt *edge = pag->addBinaryOPPE(op1, op2, dst, opcode);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Unary edge
-    inline UnaryOPPE* addUnaryOPEdge(NodeID src, NodeID dst, u32_t opcode)
+    inline UnaryOPStmt* addUnaryOPEdge(NodeID src, NodeID dst, u32_t opcode)
     {
-        UnaryOPPE *edge = pag->addUnaryOPPE(src, dst, opcode);
+        UnaryOPStmt *edge = pag->addUnaryOPPE(src, dst, opcode);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
@@ -329,21 +329,21 @@ public:
         return edge;
     }
     /// Add Load edge
-    inline LoadPE* addLoadEdge(NodeID src, NodeID dst)
+    inline LoadStmt* addLoadEdge(NodeID src, NodeID dst)
     {
-        LoadPE *edge = pag->addLoadPE(src, dst);
+        LoadStmt *edge = pag->addLoadPE(src, dst);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Store edge
-    inline StorePE* addStoreEdge(NodeID src, NodeID dst)
+    inline StoreStmt* addStoreEdge(NodeID src, NodeID dst)
     {
         IntraBlockNode* node;
         if(const Instruction* inst = SVFUtil::dyn_cast<Instruction>(curVal))
             node = pag->getICFG()->getIntraBlockNode(inst);
         else
             node = nullptr;
-        StorePE *edge = pag->addStorePE(src, dst, node);
+        StoreStmt *edge = pag->addStorePE(src, dst, node);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
@@ -362,23 +362,23 @@ public:
         return edge;
     }
     /// Add Gep edge
-    inline GepPE* addGepEdge(NodeID src, NodeID dst, const LocationSet& ls, bool constGep)
+    inline GepStmt* addGepEdge(NodeID src, NodeID dst, const LocationSet& ls, bool constGep)
     {
-        GepPE *edge = pag->addGepPE(src, dst, ls, constGep);
+        GepStmt *edge = pag->addGepPE(src, dst, ls, constGep);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Offset(Gep) edge
-    inline NormalGepPE* addNormalGepEdge(NodeID src, NodeID dst, const LocationSet& ls)
+    inline NormalGepStmt* addNormalGepEdge(NodeID src, NodeID dst, const LocationSet& ls)
     {
-        NormalGepPE *edge = pag->addNormalGepPE(src, dst, ls);
+        NormalGepStmt *edge = pag->addNormalGepPE(src, dst, ls);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }
     /// Add Variant(Gep) edge
-    inline VariantGepPE* addVariantGepEdge(NodeID src, NodeID dst)
+    inline VariantGepStmt* addVariantGepEdge(NodeID src, NodeID dst)
     {
-        VariantGepPE *edge = pag->addVariantGepPE(src, dst);
+        VariantGepStmt *edge = pag->addVariantGepPE(src, dst);
         setCurrentBBAndValueForPAGEdge(edge);
         return edge;
     }

--- a/lib/DDA/ContextDDA.cpp
+++ b/lib/DDA/ContextDDA.cpp
@@ -140,13 +140,13 @@ CxtPtSet ContextDDA::processGepPts(const GepSVFGNode* gep, const CxtPtSet& srcPt
             tmpDstPts.set(ptd);
         else
         {
-            if (SVFUtil::isa<VariantGepPE>(gep->getPAGEdge()))
+            if (SVFUtil::isa<VariantGepStmt>(gep->getPAGEdge()))
             {
                 setObjFieldInsensitive(ptd.get_id());
                 CxtVar var(ptd.get_cond(),getFIObjNode(ptd.get_id()));
                 tmpDstPts.set(var);
             }
-            else if (const NormalGepPE* normalGep = SVFUtil::dyn_cast<NormalGepPE>(gep->getPAGEdge()))
+            else if (const NormalGepStmt* normalGep = SVFUtil::dyn_cast<NormalGepStmt>(gep->getPAGEdge()))
             {
                 CxtVar var(ptd.get_cond(),getGepObjNode(ptd.get_id(),normalGep->getLocationSet()));
                 tmpDstPts.set(var);
@@ -319,10 +319,10 @@ bool ContextDDA::isHeapCondMemObj(const CxtVar& var, const StoreSVFGNode*)
         if (!mem->getValue()) {
             PAGNode *pnode = _pag->getGNode(getPtrNodeID(var));
             if(GepObjPN* gepobj = SVFUtil::dyn_cast<GepObjPN>(pnode)){
-                assert(SVFUtil::isa<DummyObjPN>(_pag->getGNode(gepobj->getBaseNode())) && "emtpy refVal in a gep object whose base is a non-dummy object");
+                assert(SVFUtil::isa<DummyObjVar>(_pag->getGNode(gepobj->getBaseNode())) && "emtpy refVal in a gep object whose base is a non-dummy object");
             }
             else{
-                assert((SVFUtil::isa<DummyObjPN>(pnode) || SVFUtil::isa<DummyValPN>(pnode)) && "empty refVal in non-dummy object");
+                assert((SVFUtil::isa<DummyObjVar>(pnode) || SVFUtil::isa<DummyValVar>(pnode)) && "empty refVal in non-dummy object");
             }
             return true;
         }

--- a/lib/DDA/DDAStat.cpp
+++ b/lib/DDA/DDAStat.cpp
@@ -208,7 +208,7 @@ void DDAStat::performStat()
     for (SVFIR::const_iterator nodeIt = SVFIR::getPAG()->begin(), nodeEit = SVFIR::getPAG()->end(); nodeIt != nodeEit; nodeIt++)
     {
         PAGNode* pagNode = nodeIt->second;
-        if(SVFUtil::isa<ObjPN>(pagNode))
+        if(SVFUtil::isa<ObjVar>(pagNode))
         {
             if(getPTA()->isLocalVarInRecursiveFun(nodeIt->first))
             {

--- a/lib/DDA/FlowDDA.cpp
+++ b/lib/DDA/FlowDDA.cpp
@@ -126,12 +126,12 @@ PointsTo FlowDDA::processGepPts(const GepSVFGNode* gep, const PointsTo& srcPts)
             tmpDstPts.set(ptd);
         else
         {
-            if (SVFUtil::isa<VariantGepPE>(gep->getPAGEdge()))
+            if (SVFUtil::isa<VariantGepStmt>(gep->getPAGEdge()))
             {
                 setObjFieldInsensitive(ptd);
                 tmpDstPts.set(getFIObjNode(ptd));
             }
-            else if (const NormalGepPE* normalGep = SVFUtil::dyn_cast<NormalGepPE>(gep->getPAGEdge()))
+            else if (const NormalGepStmt* normalGep = SVFUtil::dyn_cast<NormalGepStmt>(gep->getPAGEdge()))
             {
                 NodeID fieldSrcPtdNode = getGepObjNode(ptd,	normalGep->getLocationSet());
                 tmpDstPts.set(fieldSrcPtdNode);

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -69,7 +69,7 @@ void ConstraintGraph::buildCG()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = phis.begin(), eiter =
                 phis.end(); iter != eiter; ++iter)
     {
-        const PhiPE* edge = SVFUtil::cast<PhiPE>(*iter);
+        const PhiStmt* edge = SVFUtil::cast<PhiStmt>(*iter);
         for(const auto opVar : edge->getOpndVars())
             addCopyCGEdge(opVar->getId(),edge->getResID());
     }
@@ -110,7 +110,7 @@ void ConstraintGraph::buildCG()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = ngeps.begin(), eiter =
                 ngeps.end(); iter != eiter; ++iter)
     {
-        NormalGepPE* edge = SVFUtil::cast<NormalGepPE>(*iter);
+        NormalGepStmt* edge = SVFUtil::cast<NormalGepStmt>(*iter);
         addNormalGepCGEdge(edge->getSrcID(),edge->getDstID(),edge->getLocationSet());
     }
 
@@ -118,7 +118,7 @@ void ConstraintGraph::buildCG()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = vgeps.begin(), eiter =
                 vgeps.end(); iter != eiter; ++iter)
     {
-        VariantGepPE* edge = SVFUtil::cast<VariantGepPE>(*iter);
+        VariantGepStmt* edge = SVFUtil::cast<VariantGepStmt>(*iter);
         addVariantGepCGEdge(edge->getSrcID(),edge->getDstID());
     }
 
@@ -156,7 +156,7 @@ AddrCGEdge::AddrCGEdge(ConstraintNode* s, ConstraintNode* d, EdgeID id)
     // Retarget addr edges may lead s to be a dummy node
     PAGNode* node = SVFIR::getPAG()->getGNode(s->getId());
     if (!SVFModule::pagReadFromTXT())
-        assert(!SVFUtil::isa<DummyValPN>(node) && "a dummy node??");
+        assert(!SVFUtil::isa<DummyValVar>(node) && "a dummy node??");
 }
 
 /*!
@@ -643,7 +643,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<SVFIR*>
 
         if (briefDisplay)
         {
-            if (SVFUtil::isa<ValPN>(node))
+            if (SVFUtil::isa<ValVar>(node))
             {
                 if (nameDisplay)
                     rawstr << node->getId() << ":" << node->getValueName();
@@ -656,7 +656,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<SVFIR*>
         else
         {
             // print the whole value
-            if (!SVFUtil::isa<DummyValPN>(node) && !SVFUtil::isa<DummyObjPN>(node))
+            if (!SVFUtil::isa<DummyValVar>(node) && !SVFUtil::isa<DummyObjVar>(node))
                 rawstr << node->getId() << ":" << value2String(node->getValue());
             else
                 rawstr << node->getId() << ":";
@@ -669,22 +669,22 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<SVFIR*>
     static std::string getNodeAttributes(NodeType *n, ConstraintGraph*)
     {
         PAGNode* node = SVFIR::getPAG()->getGNode(n->getId());
-        if (SVFUtil::isa<ValPN>(node))
+        if (SVFUtil::isa<ValVar>(node))
         {
-            if(SVFUtil::isa<GepValPN>(node))
+            if(SVFUtil::isa<GepValVar>(node))
                 return "shape=hexagon";
-            else if (SVFUtil::isa<DummyValPN>(node))
+            else if (SVFUtil::isa<DummyValVar>(node))
                 return "shape=diamond";
             else
                 return "shape=box";
         }
-        else if (SVFUtil::isa<ObjPN>(node))
+        else if (SVFUtil::isa<ObjVar>(node))
         {
             if(SVFUtil::isa<GepObjPN>(node))
                return "shape=doubleoctagon";
-            else if(SVFUtil::isa<FIObjPN>(node))
+            else if(SVFUtil::isa<FIObjVar>(node))
                 return "shape=box3d";
-            else if (SVFUtil::isa<DummyObjPN>(node))
+            else if (SVFUtil::isa<DummyObjVar>(node))
                 return "shape=tab";
             else
                 return "shape=component";

--- a/lib/Graphs/IRGraph.cpp
+++ b/lib/Graphs/IRGraph.cpp
@@ -160,22 +160,22 @@ struct DOTGraphTraits<IRGraph*> : public DefaultDOTGraphTraits
 
     static std::string getNodeAttributes(SVFVar *node, IRGraph*)
     {
-        if (SVFUtil::isa<ValPN>(node))
+        if (SVFUtil::isa<ValVar>(node))
         {
-            if(SVFUtil::isa<GepValPN>(node))
+            if(SVFUtil::isa<GepValVar>(node))
                 return "shape=hexagon";
-            else if (SVFUtil::isa<DummyValPN>(node))
+            else if (SVFUtil::isa<DummyValVar>(node))
                 return "shape=diamond";
             else
                 return "shape=box";
         }
-        else if (SVFUtil::isa<ObjPN>(node))
+        else if (SVFUtil::isa<ObjVar>(node))
         {
             if(SVFUtil::isa<GepObjPN>(node))
                return "shape=doubleoctagon";
-            else if(SVFUtil::isa<FIObjPN>(node))
+            else if(SVFUtil::isa<FIObjVar>(node))
                 return "shape=box3d";
-            else if (SVFUtil::isa<DummyObjPN>(node))
+            else if (SVFUtil::isa<DummyObjVar>(node))
                 return "shape=tab";
             else
                 return "shape=component";
@@ -200,39 +200,39 @@ struct DOTGraphTraits<IRGraph*> : public DefaultDOTGraphTraits
     {
         const SVFStmt* edge = *(EI.getCurrent());
         assert(edge && "No edge found!!");
-        if (SVFUtil::isa<AddrPE>(edge))
+        if (SVFUtil::isa<AddrStmt>(edge))
         {
             return "color=green";
         }
-        else if (SVFUtil::isa<CopyPE>(edge))
+        else if (SVFUtil::isa<CopyStmt>(edge))
         {
             return "color=black";
         }
-        else if (SVFUtil::isa<GepPE>(edge))
+        else if (SVFUtil::isa<GepStmt>(edge))
         {
             return "color=purple";
         }
-        else if (SVFUtil::isa<StorePE>(edge))
+        else if (SVFUtil::isa<StoreStmt>(edge))
         {
             return "color=blue";
         }
-        else if (SVFUtil::isa<LoadPE>(edge))
+        else if (SVFUtil::isa<LoadStmt>(edge))
         {
             return "color=red";
         }
-        else if (SVFUtil::isa<PhiPE>(edge))
+        else if (SVFUtil::isa<PhiStmt>(edge))
         {
             return "color=grey";
         }
-        else if (SVFUtil::isa<CmpPE>(edge))
+        else if (SVFUtil::isa<CmpStmt>(edge))
         {
             return "color=grey";
         }
-        else if (SVFUtil::isa<BinaryOPPE>(edge))
+        else if (SVFUtil::isa<BinaryOPStmt>(edge))
         {
             return "color=grey";
         }
-        else if (SVFUtil::isa<UnaryOPPE>(edge))
+        else if (SVFUtil::isa<UnaryOPStmt>(edge))
         {
             return "color=grey";
         }

--- a/lib/Graphs/OfflineConsG.cpp
+++ b/lib/Graphs/OfflineConsG.cpp
@@ -209,7 +209,7 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<SVFIR*>
 
             if (briefDisplay)
             {
-                if (SVFUtil::isa<ValPN>(node))
+                if (SVFUtil::isa<ValVar>(node))
                 {
                     if (nameDisplay)
                         rawstr << node->getId() << ":" << node->getValueName();
@@ -222,7 +222,7 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<SVFIR*>
             else
             {
                 // print the whole value
-                if (!SVFUtil::isa<DummyValPN>(node) && !SVFUtil::isa<DummyObjPN>(node))
+                if (!SVFUtil::isa<DummyValVar>(node) && !SVFUtil::isa<DummyObjVar>(node))
                     rawstr << *node->getValue();
                 else
                     rawstr << "";
@@ -243,22 +243,22 @@ struct DOTGraphTraits<OfflineConsG*> : public DOTGraphTraits<SVFIR*>
         if (SVFIR::getPAG()->getGNode(n->getId()))
         {
             PAGNode *node = SVFIR::getPAG()->getGNode(n->getId());
-            if (SVFUtil::isa<ValPN>(node))
+            if (SVFUtil::isa<ValVar>(node))
             {
-                if(SVFUtil::isa<GepValPN>(node))
+                if(SVFUtil::isa<GepValVar>(node))
                     return "shape=hexagon";
-                else if (SVFUtil::isa<DummyValPN>(node))
+                else if (SVFUtil::isa<DummyValVar>(node))
                     return "shape=diamond";
                 else
                     return "shape=box";
             }
-            else if (SVFUtil::isa<ObjPN>(node))
+            else if (SVFUtil::isa<ObjVar>(node))
             {
                 if(SVFUtil::isa<GepObjPN>(node))
                     return "shape=doubleoctagon";
-                else if(SVFUtil::isa<FIObjPN>(node))
+                else if(SVFUtil::isa<FIObjVar>(node))
                     return "shape=box3d";
-                else if (SVFUtil::isa<DummyObjPN>(node))
+                else if (SVFUtil::isa<DummyObjVar>(node))
                     return "shape=tab";
                 else
                     return "shape=component";

--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -227,7 +227,7 @@ void SVFG::addSVFGNodesForAddrTakenVars()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = stores.begin(), eiter =
                 stores.end(); iter != eiter; ++iter)
     {
-        StorePE* store = SVFUtil::cast<StorePE>(*iter);
+        StoreStmt* store = SVFUtil::cast<StoreStmt>(*iter);
         const StmtSVFGNode* sNode = getStmtVFGNode(store);
         for(CHISet::iterator pi = mssa->getCHISet(store).begin(), epi = mssa->getCHISet(store).end(); pi!=epi; ++pi)
             setDef((*pi)->getResVer(),sNode);
@@ -297,7 +297,7 @@ void SVFG::connectIndirectSVFGEdges()
         const SVFGNode* node = it->second;
         if(const LoadSVFGNode* loadNode = SVFUtil::dyn_cast<LoadSVFGNode>(node))
         {
-            MUSet& muSet = mssa->getMUSet(SVFUtil::cast<LoadPE>(loadNode->getPAGEdge()));
+            MUSet& muSet = mssa->getMUSet(SVFUtil::cast<LoadStmt>(loadNode->getPAGEdge()));
             for(MUSet::iterator it = muSet.begin(), eit = muSet.end(); it!=eit; ++it)
             {
                 if(LOADMU* mu = SVFUtil::dyn_cast<LOADMU>(*it))
@@ -309,7 +309,7 @@ void SVFG::connectIndirectSVFGEdges()
         }
         else if(const StoreSVFGNode* storeNode = SVFUtil::dyn_cast<StoreSVFGNode>(node))
         {
-            CHISet& chiSet = mssa->getCHISet(SVFUtil::cast<StorePE>(storeNode->getPAGEdge()));
+            CHISet& chiSet = mssa->getCHISet(SVFUtil::cast<StoreStmt>(storeNode->getPAGEdge()));
             for(CHISet::iterator it = chiSet.begin(), eit = chiSet.end(); it!=eit; ++it)
             {
                 if(STORECHI* chi = SVFUtil::dyn_cast<STORECHI>(*it))
@@ -932,11 +932,11 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<SVFIR*>
         if(StmtSVFGNode* stmtNode = SVFUtil::dyn_cast<StmtSVFGNode>(node))
         {
             const PAGEdge* edge = stmtNode->getPAGEdge();
-            if (SVFUtil::isa<AddrPE>(edge))
+            if (SVFUtil::isa<AddrStmt>(edge))
             {
                 rawstr <<  "color=green";
             }
-            else if (SVFUtil::isa<CopyPE>(edge))
+            else if (SVFUtil::isa<CopyStmt>(edge))
             {
                 rawstr <<  "color=black";
             }
@@ -944,15 +944,15 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<SVFIR*>
             {
                 rawstr <<  "color=black,style=dotted";
             }
-            else if (SVFUtil::isa<GepPE>(edge))
+            else if (SVFUtil::isa<GepStmt>(edge))
             {
                 rawstr <<  "color=purple";
             }
-            else if (SVFUtil::isa<StorePE>(edge))
+            else if (SVFUtil::isa<StoreStmt>(edge))
             {
                 rawstr <<  "color=blue";
             }
-            else if (SVFUtil::isa<LoadPE>(edge))
+            else if (SVFUtil::isa<LoadStmt>(edge))
             {
                 rawstr <<  "color=red";
             }

--- a/lib/Graphs/ThreadCallGraph.cpp
+++ b/lib/Graphs/ThreadCallGraph.cpp
@@ -77,7 +77,7 @@ void ThreadCallGraph::updateCallGraph(PointerAnalysis* pta)
             const NodeBS targets = pta->getPts(pag->getValueNode(forkedval)).toNodeBS();
             for (NodeBS::iterator ii = targets.begin(), ie = targets.end(); ii != ie; ii++)
             {
-                if(ObjPN* objPN = SVFUtil::dyn_cast<ObjPN>(pag->getGNode(*ii)))
+                if(ObjVar* objPN = SVFUtil::dyn_cast<ObjVar>(pag->getGNode(*ii)))
                 {
                     const MemObj* obj = pag->getObject(objPN);
                     if(obj->isFunction())
@@ -101,7 +101,7 @@ void ThreadCallGraph::updateCallGraph(PointerAnalysis* pta)
             const NodeBS targets = pta->getPts(pag->getValueNode(forkedval)).toNodeBS();
             for (NodeBS::iterator ii = targets.begin(), ie = targets.end(); ii != ie; ii++)
             {
-                if(ObjPN* objPN = SVFUtil::dyn_cast<ObjPN>(pag->getGNode(*ii)))
+                if(ObjVar* objPN = SVFUtil::dyn_cast<ObjVar>(pag->getGNode(*ii)))
                 {
                     const MemObj* obj = pag->getObject(objPN);
                     if(obj->isFunction())

--- a/lib/Graphs/VFG.cpp
+++ b/lib/Graphs/VFG.cpp
@@ -340,7 +340,7 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = addrs.begin(), eiter =
                 addrs.end(); iter != eiter; ++iter)
     {
-        addAddrVFGNode(SVFUtil::cast<AddrPE>(*iter));
+        addAddrVFGNode(SVFUtil::cast<AddrStmt>(*iter));
     }
 
     // initialize copy nodes
@@ -348,7 +348,7 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = copys.begin(), eiter =
                 copys.end(); iter != eiter; ++iter)
     {
-        const CopyPE* edge = SVFUtil::cast<CopyPE>(*iter);
+        const CopyStmt* edge = SVFUtil::cast<CopyStmt>(*iter);
         assert(!isPhiCopyEdge(edge) && "Copy edges can not be a PhiNode (or from PhiNode)");
         addCopyVFGNode(edge);
     }
@@ -358,14 +358,14 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = ngeps.begin(), eiter =
                 ngeps.end(); iter != eiter; ++iter)
     {
-        addGepVFGNode(SVFUtil::cast<NormalGepPE>(*iter));
+        addGepVFGNode(SVFUtil::cast<NormalGepStmt>(*iter));
     }
 
     PAGEdge::PAGEdgeSetTy& vgeps = getPAGEdgeSet(PAGEdge::VariantGep);
     for (PAGEdge::PAGEdgeSetTy::iterator iter = vgeps.begin(), eiter =
                 vgeps.end(); iter != eiter; ++iter)
     {
-        addGepVFGNode(SVFUtil::cast<VariantGepPE>(*iter));
+        addGepVFGNode(SVFUtil::cast<VariantGepStmt>(*iter));
     }
 
     // initialize load nodes
@@ -373,7 +373,7 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = loads.begin(), eiter =
                 loads.end(); iter != eiter; ++iter)
     {
-        addLoadVFGNode(SVFUtil::cast<LoadPE>(*iter));
+        addLoadVFGNode(SVFUtil::cast<LoadStmt>(*iter));
     }
 
     // initialize store nodes
@@ -381,7 +381,7 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = stores.begin(), eiter =
                 stores.end(); iter != eiter; ++iter)
     {
-        addStoreVFGNode(SVFUtil::cast<StorePE>(*iter));
+        addStoreVFGNode(SVFUtil::cast<StoreStmt>(*iter));
     }
 
     PAGEdge::PAGEdgeSetTy& forks = getPAGEdgeSet(PAGEdge::ThreadFork);
@@ -492,7 +492,7 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = phis.begin(), eiter =
                 phis.end(); iter != eiter; ++iter)
     {
-        const PhiPE* edge = SVFUtil::cast<PhiPE>(*iter);
+        const PhiStmt* edge = SVFUtil::cast<PhiStmt>(*iter);
         if(isInterestedPAGNode(edge->getRes()))
             addIntraPHIVFGNode(edge);
     }
@@ -501,7 +501,7 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = binaryops.begin(), eiter =
                 binaryops.end(); iter != eiter; ++iter)
     {
-        const BinaryOPPE* edge = SVFUtil::cast<BinaryOPPE>(*iter);
+        const BinaryOPStmt* edge = SVFUtil::cast<BinaryOPStmt>(*iter);
         if(isInterestedPAGNode(edge->getRes()))
             addBinaryOPVFGNode(edge);
     }
@@ -510,7 +510,7 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = unaryops.begin(), eiter =
                 unaryops.end(); iter != eiter; ++iter)
     {
-        const UnaryOPPE* edge = SVFUtil::cast<UnaryOPPE>(*iter);
+        const UnaryOPStmt* edge = SVFUtil::cast<UnaryOPStmt>(*iter);
         if(isInterestedPAGNode(edge->getRes()))
             addUnaryOPVFGNode(edge);
     }
@@ -528,7 +528,7 @@ void VFG::addVFGNodes()
     for (PAGEdge::PAGEdgeSetTy::iterator iter = cmps.begin(), eiter =
                 cmps.end(); iter != eiter; ++iter)
     {
-        const CmpPE* edge = SVFUtil::cast<CmpPE>(*iter);
+        const CmpStmt* edge = SVFUtil::cast<CmpStmt>(*iter);
         if(isInterestedPAGNode(edge->getRes()))
             addCmpVFGNode(edge);
     }
@@ -1081,11 +1081,11 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<SVFIR*>
         if(StmtVFGNode* stmtNode = SVFUtil::dyn_cast<StmtVFGNode>(node))
         {
             const PAGEdge* edge = stmtNode->getPAGEdge();
-            if (SVFUtil::isa<AddrPE>(edge))
+            if (SVFUtil::isa<AddrStmt>(edge))
             {
                 rawstr <<  "color=green";
             }
-            else if (SVFUtil::isa<CopyPE>(edge))
+            else if (SVFUtil::isa<CopyStmt>(edge))
             {
                 rawstr <<  "color=black";
             }
@@ -1093,15 +1093,15 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<SVFIR*>
             {
                 rawstr <<  "color=black,style=dotted";
             }
-            else if (SVFUtil::isa<GepPE>(edge))
+            else if (SVFUtil::isa<GepStmt>(edge))
             {
                 rawstr <<  "color=purple";
             }
-            else if (SVFUtil::isa<StorePE>(edge))
+            else if (SVFUtil::isa<StoreStmt>(edge))
             {
                 rawstr <<  "color=blue";
             }
-            else if (SVFUtil::isa<LoadPE>(edge))
+            else if (SVFUtil::isa<LoadStmt>(edge))
             {
                 rawstr << "color=red";
             }

--- a/lib/MSSA/MemRegion.cpp
+++ b/lib/MSSA/MemRegion.cpp
@@ -107,7 +107,7 @@ void MRGenerator::collectGlobals()
     SVFIR* pag = pta->getPAG();
     for (SVFIR::iterator nIter = pag->begin(); nIter != pag->end(); ++nIter)
     {
-        if(ObjPN* obj = SVFUtil::dyn_cast<ObjPN>(nIter->second))
+        if(ObjVar* obj = SVFUtil::dyn_cast<ObjVar>(nIter->second))
         {
             if (obj->getMemObj()->isGlobalObj())
             {
@@ -196,7 +196,7 @@ void MRGenerator::collectModRefForLoadStore()
                 {
                     const PAGEdge* inst = *bit;
                     pagEdgeToFunMap[inst] = &fun;
-                    if (const StorePE *st = SVFUtil::dyn_cast<StorePE>(inst))
+                    if (const StoreStmt *st = SVFUtil::dyn_cast<StoreStmt>(inst))
                     {
                         NodeBS cpts(pta->getPts(st->getDstID()).toNodeBS());
                         // TODO: change this assertion check later when we have conditional points-to set
@@ -206,7 +206,7 @@ void MRGenerator::collectModRefForLoadStore()
                         addCPtsToStore(cpts, st, &fun);
                     }
 
-                    else if (const LoadPE *ld = SVFUtil::dyn_cast<LoadPE>(inst))
+                    else if (const LoadStmt *ld = SVFUtil::dyn_cast<LoadStmt>(inst))
                     {
                         NodeBS cpts(pta->getPts(ld->getSrcID()).toNodeBS());
                         // TODO: change this assertion check later when we have conditional points-to set
@@ -610,7 +610,7 @@ bool MRGenerator::handleCallsiteModRef(NodeBS& mod, NodeBS& ref, const CallBlock
                 ebit = pagEdgeList.end(); bit != ebit; ++bit)
         {
             const PAGEdge* edge = *bit;
-            if (const AddrPE* addr = SVFUtil::dyn_cast<AddrPE>(edge))
+            if (const AddrStmt* addr = SVFUtil::dyn_cast<AddrStmt>(edge))
                 mod.set(addr->getSrcID());
         }
     }
@@ -677,7 +677,7 @@ NodeBS MRGenerator::getModInfoForCall(const CallBlockNode* cs)
                     pagEdgeList.end(); bit != ebit; ++bit)
         {
             const PAGEdge* edge = *bit;
-            if (const StorePE* st = SVFUtil::dyn_cast<StorePE>(edge))
+            if (const StoreStmt* st = SVFUtil::dyn_cast<StoreStmt>(edge))
                 mods |= pta->getPts(st->getDstID()).toNodeBS();
         }
         return mods;
@@ -701,7 +701,7 @@ NodeBS MRGenerator::getRefInfoForCall(const CallBlockNode* cs)
                     pagEdgeList.end(); bit != ebit; ++bit)
         {
             const PAGEdge* edge = *bit;
-            if (const LoadPE* ld = SVFUtil::dyn_cast<LoadPE>(edge))
+            if (const LoadStmt* ld = SVFUtil::dyn_cast<LoadStmt>(edge))
                 refs |= pta->getPts(ld->getSrcID()).toNodeBS();
         }
         return refs;

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -166,9 +166,9 @@ void MemSSA::createMUCHI(const SVFFunction& fun)
                         ebit = pagEdgeList.end(); bit != ebit; ++bit)
                 {
                     const PAGEdge* inst = *bit;
-                    if (const LoadPE* load = SVFUtil::dyn_cast<LoadPE>(inst))
+                    if (const LoadStmt* load = SVFUtil::dyn_cast<LoadStmt>(inst))
                         AddLoadMU(bb, load, mrGen->getLoadMRSet(load));
-                    else if (const StorePE* store = SVFUtil::dyn_cast<StorePE>(inst))
+                    else if (const StoreStmt* store = SVFUtil::dyn_cast<StoreStmt>(inst))
                         AddStoreCHI(bb, store, mrGen->getStoreMRSet(store));
                 }
             }
@@ -308,10 +308,10 @@ void MemSSA::SSARenameBB(const BasicBlock& bb)
                     bit!=ebit; ++bit)
             {
                 const PAGEdge* inst = *bit;
-                if (const LoadPE* load = SVFUtil::dyn_cast<LoadPE>(inst))
+                if (const LoadStmt* load = SVFUtil::dyn_cast<LoadStmt>(inst))
                     RenameMuSet(getMUSet(load));
 
-                else if (const StorePE* store = SVFUtil::dyn_cast<StorePE>(inst))
+                else if (const StoreStmt* store = SVFUtil::dyn_cast<StoreStmt>(inst))
                     RenameChiSet(getCHISet(store),memRegs);
 
             }
@@ -671,7 +671,7 @@ void MemSSA::dumpMSSA(raw_ostream& Out)
                             bit!=ebit; ++bit)
                     {
                         const PAGEdge* edge = *bit;
-                        if (const LoadPE* load = SVFUtil::dyn_cast<LoadPE>(edge))
+                        if (const LoadStmt* load = SVFUtil::dyn_cast<LoadStmt>(edge))
                         {
                             MUSet& muSet = getMUSet(load);
                             for(MUSet::iterator it = muSet.begin(), eit = muSet.end(); it!=eit; ++it)
@@ -693,7 +693,7 @@ void MemSSA::dumpMSSA(raw_ostream& Out)
                             bit!=ebit; ++bit)
                     {
                         const PAGEdge* edge = *bit;
-                        if (const StorePE* store = SVFUtil::dyn_cast<StorePE>(edge))
+                        if (const StoreStmt* store = SVFUtil::dyn_cast<StoreStmt>(edge))
                         {
                             CHISet& chiSet = getCHISet(store);
                             for(CHISet::iterator it = chiSet.begin(), eit = chiSet.end(); it!=eit; ++it)

--- a/lib/MemoryModel/PAGBuilderFromFile.cpp
+++ b/lib/MemoryModel/PAGBuilderFromFile.cpp
@@ -152,11 +152,11 @@ void PAGBuilderFromFile::addEdge(NodeID srcID, NodeID dstID,
     PAGNode* dstNode = pag->getGNode(dstID);
 
     /// sanity check for SVFIR from txt
-    assert(SVFUtil::isa<ValPN>(dstNode) && "dst not an value node?");
+    assert(SVFUtil::isa<ValVar>(dstNode) && "dst not an value node?");
     if(edge=="addr")
-        assert(SVFUtil::isa<ObjPN>(srcNode) && "src not an value node?");
+        assert(SVFUtil::isa<ObjVar>(srcNode) && "src not an value node?");
     else
-        assert(!SVFUtil::isa<ObjPN>(srcNode) && "src not an object node?");
+        assert(!SVFUtil::isa<ObjVar>(srcNode) && "src not an object node?");
 
     if (edge == "addr")
     {

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -185,7 +185,7 @@ void PointerAnalysis::resetObjFieldSensitive()
 {
     for (SVFIR::iterator nIter = pag->begin(); nIter != pag->end(); ++nIter)
     {
-        if(ObjPN* node = SVFUtil::dyn_cast<ObjPN>(nIter->second))
+        if(ObjVar* node = SVFUtil::dyn_cast<ObjVar>(nIter->second))
             const_cast<MemObj*>(node->getMemObj())->setFieldSensitive();
     }
 }
@@ -290,7 +290,7 @@ void PointerAnalysis::dumpAllTypes()
             nIter != this->getAllValidPtrs().end(); ++nIter)
     {
         const PAGNode* node = getPAG()->getGNode(*nIter);
-        if (SVFUtil::isa<DummyObjPN>(node) || SVFUtil::isa<DummyValPN>(node))
+        if (SVFUtil::isa<DummyObjVar>(node) || SVFUtil::isa<DummyValVar>(node))
             continue;
 
         outs() << "##<" << node->getValue()->getName() << "> ";
@@ -305,18 +305,18 @@ void PointerAnalysis::dumpAllTypes()
 }
 
 /*!
- * Dump points-to of top-level pointers (ValPN)
+ * Dump points-to of top-level pointers (ValVar)
  */
 void PointerAnalysis::dumpPts(NodeID ptr, const PointsTo& pts)
 {
 
     const PAGNode* node = pag->getGNode(ptr);
     /// print the points-to set of node which has the maximum pts size.
-    if (SVFUtil::isa<DummyObjPN> (node))
+    if (SVFUtil::isa<DummyObjVar> (node))
     {
         outs() << "##<Dummy Obj > id:" << node->getId();
     }
-    else if (!SVFUtil::isa<DummyValPN>(node) && !SVFModule::pagReadFromTXT()) {
+    else if (!SVFUtil::isa<DummyValVar>(node) && !SVFModule::pagReadFromTXT()) {
 		if (node->hasValue()) {
 			outs() << "##<" << node->getValue()->getName() << "> ";
 			outs() << "Source Loc: " << getSourceLoc(node->getValue());
@@ -342,14 +342,14 @@ void PointerAnalysis::dumpPts(NodeID ptr, const PointsTo& pts)
     for (PointsTo::iterator it = pts.begin(), eit = pts.end(); it != eit; ++it)
     {
         const PAGNode* node = pag->getGNode(*it);
-        if(SVFUtil::isa<ObjPN>(node) == false)
+        if(SVFUtil::isa<ObjVar>(node) == false)
             continue;
         NodeID ptd = node->getId();
         outs() << "!!Target NodeID " << ptd << "\t [";
         const PAGNode* pagNode = pag->getGNode(ptd);
-        if (SVFUtil::isa<DummyValPN>(node))
+        if (SVFUtil::isa<DummyValVar>(node))
             outs() << "DummyVal\n";
-        else if (SVFUtil::isa<DummyObjPN>(node))
+        else if (SVFUtil::isa<DummyObjVar>(node))
             outs() << "Dummy Obj id: " << node->getId() << "]\n";
 		else {
 			if (!SVFModule::pagReadFromTXT()) {
@@ -445,7 +445,7 @@ void PointerAnalysis::resolveIndCalls(const CallBlockNode* cs, const PointsTo& t
             return;
         }
 
-        if(ObjPN* objPN = SVFUtil::dyn_cast<ObjPN>(pag->getGNode(*ii)))
+        if(ObjVar* objPN = SVFUtil::dyn_cast<ObjVar>(pag->getGNode(*ii)))
         {
             const MemObj* obj = pag->getObject(objPN);
 

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -164,7 +164,7 @@ void BVDataPTAImpl::writeToFile(const string& filename)
     for (auto it = pag->begin(), ie = pag->end(); it != ie; ++it)
     {
         PAGNode* pagNode = it->second;
-        if (!isa<ObjPN>(pagNode)) continue;
+        if (!isa<ObjVar>(pagNode)) continue;
         NodeID n = pag->getBaseObjNode(it->first);
         if (NodeIDs.test(n)) continue;
         F.os() << n << " ";
@@ -353,7 +353,7 @@ void BVDataPTAImpl::dumpTopLevelPtsTo()
 
 
 /*!
- * Dump all points-to including top-level (ValPN) and address-taken (ObjPN) variables
+ * Dump all points-to including top-level (ValVar) and address-taken (ObjVar) variables
  */
 void BVDataPTAImpl::dumpAllPts()
 {

--- a/lib/MemoryModel/SVFIR.cpp
+++ b/lib/MemoryModel/SVFIR.cpp
@@ -48,15 +48,15 @@ SVFIR::SVFIR(bool buildFromFile) : IRGraph(buildFromFile)
 /*!
  * Add Address edge
  */
-AddrPE* SVFIR::addAddrPE(NodeID src, NodeID dst)
+AddrStmt* SVFIR::addAddrPE(NodeID src, NodeID dst)
 {
     SVFVar* srcNode = getGNode(src);
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasNonlabeledEdge(srcNode,dstNode, SVFStmt::Addr))
-        return SVFUtil::cast<AddrPE>(edge);
+        return SVFUtil::cast<AddrStmt>(edge);
     else
     {
-        AddrPE* addrPE = new AddrPE(srcNode, dstNode);
+        AddrStmt* addrPE = new AddrStmt(srcNode, dstNode);
         addToStmt2TypeMap(addrPE);
         addEdge(srcNode,dstNode, addrPE);
         return addrPE;
@@ -66,15 +66,15 @@ AddrPE* SVFIR::addAddrPE(NodeID src, NodeID dst)
 /*!
  * Add Copy edge
  */
-CopyPE* SVFIR::addCopyPE(NodeID src, NodeID dst)
+CopyStmt* SVFIR::addCopyPE(NodeID src, NodeID dst)
 {
     SVFVar* srcNode = getGNode(src);
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasNonlabeledEdge(srcNode,dstNode, SVFStmt::Copy))
-        return SVFUtil::cast<CopyPE>(edge);
+        return SVFUtil::cast<CopyStmt>(edge);
     else
     {
-        CopyPE* copyPE = new CopyPE(srcNode, dstNode);
+        CopyStmt* copyPE = new CopyStmt(srcNode, dstNode);
         addToStmt2TypeMap(copyPE);
         addEdge(srcNode,dstNode, copyPE);
         return copyPE;
@@ -84,13 +84,13 @@ CopyPE* SVFIR::addCopyPE(NodeID src, NodeID dst)
 /*!
  * Add Phi statement 
  */
-PhiPE* SVFIR::addPhiNode(NodeID res, NodeID opnd)
+PhiStmt* SVFIR::addPhiNode(NodeID res, NodeID opnd)
 {
     SVFVar* opNode = getGNode(opnd);
     SVFVar* resNode = getGNode(res);
     PHINodeMap::iterator it = phiNodeMap.find(resNode);
     if(it == phiNodeMap.end()){
-        PhiPE* phi = new PhiPE(resNode, {opNode});
+        PhiStmt* phi = new PhiStmt(resNode, {opNode});
         addToStmt2TypeMap(phi);
         addEdge(opNode, resNode, phi);
         phiNodeMap[resNode] = phi;
@@ -105,17 +105,17 @@ PhiPE* SVFIR::addPhiNode(NodeID res, NodeID opnd)
 /*!
  * Add Compare edge
  */
-CmpPE* SVFIR::addCmpPE(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
+CmpStmt* SVFIR::addCmpPE(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
 {
     SVFVar* op1Node = getGNode(op1);
     SVFVar* op2Node = getGNode(op2);
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasLabeledEdge(op1Node, dstNode, SVFStmt::Cmp, op2Node))
-        return SVFUtil::cast<CmpPE>(edge);
+        return SVFUtil::cast<CmpStmt>(edge);
     else
     {
         std::vector<SVFVar*> opnds = {op1Node, op2Node};
-        CmpPE* cmp = new CmpPE(dstNode, opnds, opcode);
+        CmpStmt* cmp = new CmpStmt(dstNode, opnds, opcode);
         addToStmt2TypeMap(cmp);
         addEdge(op1Node, dstNode, cmp);
         return cmp;
@@ -126,17 +126,17 @@ CmpPE* SVFIR::addCmpPE(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
 /*!
  * Add Compare edge
  */
-BinaryOPPE* SVFIR::addBinaryOPPE(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
+BinaryOPStmt* SVFIR::addBinaryOPPE(NodeID op1, NodeID op2, NodeID dst, u32_t opcode)
 {
     SVFVar* op1Node = getGNode(op1);
     SVFVar* op2Node = getGNode(op2);
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasLabeledEdge(op1Node, dstNode, SVFStmt::BinaryOp, op2Node))
-        return SVFUtil::cast<BinaryOPPE>(edge);
+        return SVFUtil::cast<BinaryOPStmt>(edge);
     else
     {
         std::vector<SVFVar*> opnds = {op1Node, op2Node};
-        BinaryOPPE* binaryOP = new BinaryOPPE(dstNode, opnds, opcode);
+        BinaryOPStmt* binaryOP = new BinaryOPStmt(dstNode, opnds, opcode);
         addToStmt2TypeMap(binaryOP);
         addEdge(op1Node,dstNode, binaryOP);
         return binaryOP;
@@ -146,15 +146,15 @@ BinaryOPPE* SVFIR::addBinaryOPPE(NodeID op1, NodeID op2, NodeID dst, u32_t opcod
 /*!
  * Add Unary edge
  */
-UnaryOPPE* SVFIR::addUnaryOPPE(NodeID src, NodeID dst, u32_t opcode)
+UnaryOPStmt* SVFIR::addUnaryOPPE(NodeID src, NodeID dst, u32_t opcode)
 {
     SVFVar* srcNode = getGNode(src);
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasNonlabeledEdge(srcNode,dstNode, SVFStmt::UnaryOp))
-        return SVFUtil::cast<UnaryOPPE>(edge);
+        return SVFUtil::cast<UnaryOPStmt>(edge);
     else
     {
-        UnaryOPPE* unaryOP = new UnaryOPPE(srcNode, dstNode, opcode);
+        UnaryOPStmt* unaryOP = new UnaryOPStmt(srcNode, dstNode, opcode);
         addToStmt2TypeMap(unaryOP);
         addEdge(srcNode,dstNode, unaryOP);
         return unaryOP;
@@ -182,15 +182,15 @@ BranchStmt* SVFIR::addBranchStmt(NodeID br, NodeID cond, std::vector<const ICFGN
 /*!
  * Add Load edge
  */
-LoadPE* SVFIR::addLoadPE(NodeID src, NodeID dst)
+LoadStmt* SVFIR::addLoadPE(NodeID src, NodeID dst)
 {
     SVFVar* srcNode = getGNode(src);
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasNonlabeledEdge(srcNode,dstNode, SVFStmt::Load))
-        return SVFUtil::cast<LoadPE>(edge);
+        return SVFUtil::cast<LoadStmt>(edge);
     else
     {
-        LoadPE* loadPE = new LoadPE(srcNode, dstNode);
+        LoadStmt* loadPE = new LoadStmt(srcNode, dstNode);
         addToStmt2TypeMap(loadPE);
         addEdge(srcNode,dstNode, loadPE);
         return loadPE;
@@ -201,15 +201,15 @@ LoadPE* SVFIR::addLoadPE(NodeID src, NodeID dst)
  * Add Store edge
  * Note that two store instructions may share the same Store SVFStmt
  */
-StorePE* SVFIR::addStorePE(NodeID src, NodeID dst, const IntraBlockNode* curVal)
+StoreStmt* SVFIR::addStorePE(NodeID src, NodeID dst, const IntraBlockNode* curVal)
 {
     SVFVar* srcNode = getGNode(src);
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasLabeledEdge(srcNode,dstNode, SVFStmt::Store, curVal))
-        return SVFUtil::cast<StorePE>(edge);
+        return SVFUtil::cast<StoreStmt>(edge);
     else
     {
-        StorePE* storePE = new StorePE(srcNode, dstNode, curVal);
+        StoreStmt* storePE = new StoreStmt(srcNode, dstNode, curVal);
         addToStmt2TypeMap(storePE);
         addEdge(srcNode,dstNode, storePE);
         return storePE;
@@ -305,14 +305,14 @@ TDJoinPE* SVFIR::addThreadJoinPE(NodeID src, NodeID dst, const CallBlockNode* cs
  * Find the base node id of src and connect base node to dst node
  * Create gep offset:  (offset + baseOff <nested struct gep size>)
  */
-GepPE* SVFIR::addGepPE(NodeID src, NodeID dst, const LocationSet& ls, bool constGep)
+GepStmt* SVFIR::addGepPE(NodeID src, NodeID dst, const LocationSet& ls, bool constGep)
 {
 
     SVFVar* node = getGNode(src);
     if (!constGep || node->hasIncomingVariantGepEdge())
     {
         /// Since the offset from base to src is variant,
-        /// the new gep edge being created is also a VariantGepPE edge.
+        /// the new gep edge being created is also a VariantGepStmt edge.
         return addVariantGepPE(src, dst);
     }
     else
@@ -324,16 +324,16 @@ GepPE* SVFIR::addGepPE(NodeID src, NodeID dst, const LocationSet& ls, bool const
 /*!
  * Add normal (Gep) edge
  */
-NormalGepPE* SVFIR::addNormalGepPE(NodeID src, NodeID dst, const LocationSet& ls)
+NormalGepStmt* SVFIR::addNormalGepPE(NodeID src, NodeID dst, const LocationSet& ls)
 {
     const LocationSet& baseLS = getLocationSetFromBaseNode(src);
     SVFVar* baseNode = getGNode(getBaseValNode(src));
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasNonlabeledEdge(baseNode, dstNode, SVFStmt::NormalGep))
-        return SVFUtil::cast<NormalGepPE>(edge);
+        return SVFUtil::cast<NormalGepStmt>(edge);
     else
     {
-        NormalGepPE* gepPE = new NormalGepPE(baseNode, dstNode, ls+baseLS);
+        NormalGepStmt* gepPE = new NormalGepStmt(baseNode, dstNode, ls+baseLS);
         addToStmt2TypeMap(gepPE);
         addEdge(baseNode, dstNode, gepPE);
         return gepPE;
@@ -344,16 +344,16 @@ NormalGepPE* SVFIR::addNormalGepPE(NodeID src, NodeID dst, const LocationSet& ls
  * Add variant(Gep) edge
  * Find the base node id of src and connect base node to dst node
  */
-VariantGepPE* SVFIR::addVariantGepPE(NodeID src, NodeID dst)
+VariantGepStmt* SVFIR::addVariantGepPE(NodeID src, NodeID dst)
 {
 
     SVFVar* baseNode = getGNode(getBaseValNode(src));
     SVFVar* dstNode = getGNode(dst);
     if(SVFStmt* edge = hasNonlabeledEdge(baseNode, dstNode, SVFStmt::VariantGep))
-        return SVFUtil::cast<VariantGepPE>(edge);
+        return SVFUtil::cast<VariantGepStmt>(edge);
     else
     {
-        VariantGepPE* gepPE = new VariantGepPE(baseNode, dstNode);
+        VariantGepStmt* gepPE = new VariantGepStmt(baseNode, dstNode);
         addToStmt2TypeMap(gepPE);
         addEdge(baseNode, dstNode, gepPE);
         return gepPE;
@@ -364,7 +364,7 @@ VariantGepPE* SVFIR::addVariantGepPE(NodeID src, NodeID dst)
 
 /*!
  * Add a temp field value node, this method can only invoked by getGepValNode
- * due to constaint expression, curInst is used to distinguish different instructions (e.g., memorycpy) when creating GepValPN.
+ * due to constaint expression, curInst is used to distinguish different instructions (e.g., memorycpy) when creating GepValVar.
  */
 NodeID SVFIR::addGepValNode(const Value* curInst,const Value* gepVal, const LocationSet& ls, NodeID i, const Type *type, u32_t fieldidx)
 {
@@ -373,7 +373,7 @@ NodeID SVFIR::addGepValNode(const Value* curInst,const Value* gepVal, const Loca
     assert(0==GepValNodeMap[curInst].count(std::make_pair(base, ls))
            && "this node should not be created before");
     GepValNodeMap[curInst][std::make_pair(base, ls)] = i;
-    GepValPN *node = new GepValPN(gepVal, i, ls, type, fieldidx);
+    GepValVar *node = new GepValVar(gepVal, i, ls, type, fieldidx);
     return addValNode(gepVal, node, i);
 }
 
@@ -385,9 +385,9 @@ NodeID SVFIR::getGepObjNode(NodeID id, const LocationSet& ls)
     SVFVar* node = pag->getGNode(id);
     if (GepObjPN* gepNode = SVFUtil::dyn_cast<GepObjPN>(node))
         return getGepObjNode(gepNode->getMemObj(), gepNode->getLocationSet() + ls);
-    else if (FIObjPN* baseNode = SVFUtil::dyn_cast<FIObjPN>(node))
+    else if (FIObjVar* baseNode = SVFUtil::dyn_cast<FIObjVar>(node))
         return getGepObjNode(baseNode->getMemObj(), ls);
-    else if (DummyObjPN* baseNode = SVFUtil::dyn_cast<DummyObjPN>(node))
+    else if (DummyObjVar* baseNode = SVFUtil::dyn_cast<DummyObjVar>(node))
         return getGepObjNode(baseNode->getMemObj(), ls);
     else
     {
@@ -448,7 +448,7 @@ NodeID SVFIR::addFIObjNode(const MemObj* obj)
     //assert(findPAGNode(i) == false && "this node should not be created before");
     NodeID base = obj->getId();
     memToFieldsMap[base].set(obj->getId());
-    FIObjPN *node = new FIObjPN(obj->getValue(), obj->getId(), obj);
+    FIObjVar *node = new FIObjVar(obj->getValue(), obj->getId(), obj);
     return addObjNode(obj->getValue(), node, obj->getId());
 }
 
@@ -467,8 +467,8 @@ NodeBS& SVFIR::getAllFieldsObjNode(const MemObj* obj)
 NodeBS& SVFIR::getAllFieldsObjNode(NodeID id)
 {
     const SVFVar* node = pag->getGNode(id);
-    assert(SVFUtil::isa<ObjPN>(node) && "need an object node");
-    const ObjPN* obj = SVFUtil::cast<ObjPN>(node);
+    assert(SVFUtil::isa<ObjVar>(node) && "need an object node");
+    const ObjVar* obj = SVFUtil::cast<ObjVar>(node);
     return getAllFieldsObjNode(obj->getMemObj());
 }
 
@@ -480,8 +480,8 @@ NodeBS& SVFIR::getAllFieldsObjNode(NodeID id)
 NodeBS SVFIR::getFieldsAfterCollapse(NodeID id)
 {
     const SVFVar* node = pag->getGNode(id);
-    assert(SVFUtil::isa<ObjPN>(node) && "need an object node");
-    const MemObj* mem = SVFUtil::cast<ObjPN>(node)->getMemObj();
+    assert(SVFUtil::isa<ObjVar>(node) && "need an object node");
+    const MemObj* mem = SVFUtil::cast<ObjVar>(node)->getMemObj();
     if(mem->isFieldInsensitive())
     {
         NodeBS bs;
@@ -513,7 +513,7 @@ NodeID SVFIR::getBaseValNode(NodeID nodeId)
         else
             it = vgeps.begin();
 
-        assert(SVFUtil::isa<GepPE>(*it) && "not a gep edge??");
+        assert(SVFUtil::isa<GepStmt>(*it) && "not a gep edge??");
         return (*it)->getSrcID();
     }
     else
@@ -537,8 +537,8 @@ LocationSet SVFIR::getLocationSetFromBaseNode(NodeID nodeId)
     assert(geps.size()==1 && "one node can only be connected by at most one gep edge!");
     SVFVar::iterator it = geps.begin();
     const SVFStmt* edge = *it;
-    assert(SVFUtil::isa<NormalGepPE>(edge) && "not a get edge??");
-    const NormalGepPE* gepEdge = SVFUtil::cast<NormalGepPE>(edge);
+    assert(SVFUtil::isa<NormalGepStmt>(edge) && "not a get edge??");
+    const NormalGepStmt* gepEdge = SVFUtil::cast<NormalGepStmt>(edge);
     return gepEdge->getLocationSet();
 }
 
@@ -610,7 +610,7 @@ void SVFIR::print()
     for (SVFStmt::PAGEdgeSetTy::iterator iter = ngeps.begin(), eiter =
                 ngeps.end(); iter != eiter; ++iter)
     {
-        NormalGepPE* gep = SVFUtil::cast<NormalGepPE>(*iter);
+        NormalGepStmt* gep = SVFUtil::cast<NormalGepStmt>(*iter);
         outs() << gep->getSrcID() << " -- NormalGep (" << gep->getOffset()
                << ") --> " << gep->getDstID() << "\n";
     }

--- a/lib/MemoryModel/SVFStatements.cpp
+++ b/lib/MemoryModel/SVFStatements.cpp
@@ -65,10 +65,10 @@ const std::string SVFStmt::toString() const {
     return rawstr.str();
 }
 
-const std::string AddrPE::toString() const{
+const std::string AddrStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "AddrPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "AddrStmt: [" << getDstID() << "<--" << getSrcID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -76,10 +76,10 @@ const std::string AddrPE::toString() const{
     return rawstr.str();
 }
 
-const std::string CopyPE::toString() const{
+const std::string CopyStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "CopyPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "CopyStmt: [" << getDstID() << "<--" << getSrcID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -87,10 +87,10 @@ const std::string CopyPE::toString() const{
     return rawstr.str();
 }
 
-const std::string PhiPE::toString() const{
+const std::string PhiStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "PhiPE: [" << getResID() << "<--(" << getOpVarID(0) << "," << getOpVarID(1) << ")]\t";
+    rawstr << "PhiStmt: [" << getResID() << "<--(" << getOpVarID(0) << "," << getOpVarID(1) << ")]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -98,10 +98,10 @@ const std::string PhiPE::toString() const{
     return rawstr.str();
 }
 
-const std::string CmpPE::toString() const{
+const std::string CmpStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "CmpPE: [" << getResID() << "<--(" << getOpVarID(0) << "," << getOpVarID(1) << ")]\t";
+    rawstr << "CmpStmt: [" << getResID() << "<--(" << getOpVarID(0) << "," << getOpVarID(1) << ")]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -109,10 +109,10 @@ const std::string CmpPE::toString() const{
     return rawstr.str();
 }
 
-const std::string BinaryOPPE::toString() const{
+const std::string BinaryOPStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "BinaryOPPE: [" << getResID() << "<--(" << getOpVarID(0) << "," << getOpVarID(1) << ")]\t";
+    rawstr << "BinaryOPStmt: [" << getResID() << "<--(" << getOpVarID(0) << "," << getOpVarID(1) << ")]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -120,10 +120,10 @@ const std::string BinaryOPPE::toString() const{
     return rawstr.str();
 }
 
-const std::string UnaryOPPE::toString() const{
+const std::string UnaryOPStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "UnaryOPPE: [" << getResID() << "<--" << getOpVarID() << "]\t";
+    rawstr << "UnaryOPStmt: [" << getResID() << "<--" << getOpVarID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -146,10 +146,10 @@ const std::string BranchStmt::toString() const {
 }
 
 
-const std::string LoadPE::toString() const{
+const std::string LoadStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "LoadPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "LoadStmt: [" << getDstID() << "<--" << getSrcID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -157,10 +157,10 @@ const std::string LoadPE::toString() const{
     return rawstr.str();
 }
 
-const std::string StorePE::toString() const{
+const std::string StoreStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "StorePE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "StoreStmt: [" << getDstID() << "<--" << getSrcID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -168,10 +168,10 @@ const std::string StorePE::toString() const{
     return rawstr.str();
 }
 
-const std::string GepPE::toString() const{
+const std::string GepStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "GepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "GepStmt: [" << getDstID() << "<--" << getSrcID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -179,10 +179,10 @@ const std::string GepPE::toString() const{
     return rawstr.str();
 }
 
-const std::string NormalGepPE::toString() const{
+const std::string NormalGepStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "NormalGepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "NormalGepStmt: [" << getDstID() << "<--" << getSrcID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -190,10 +190,10 @@ const std::string NormalGepPE::toString() const{
     return rawstr.str();
 }
 
-const std::string VariantGepPE::toString() const{
+const std::string VariantGepStmt::toString() const{
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "VariantGepPE: [" << getDstID() << "<--" << getSrcID() << "]\t";
+    rawstr << "VariantGepStmt: [" << getDstID() << "<--" << getSrcID() << "]\t";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -256,10 +256,10 @@ NodeID MultiOpndStmt::getResID() const
     return getRes()->getId();
 }
 
-NodeID UnaryOPPE::getOpVarID() const{
+NodeID UnaryOPStmt::getOpVarID() const{
     return getOpVar()->getId();
 }
-NodeID UnaryOPPE::getResID() const{
+NodeID UnaryOPStmt::getResID() const{
     return getRes()->getId();
 }
 

--- a/lib/MemoryModel/SVFVariables.cpp
+++ b/lib/MemoryModel/SVFVariables.cpp
@@ -48,7 +48,7 @@ SVFVar::SVFVar(const Value* val, NodeID i, PNODEK k) :
     case ValNode:
     case GepValNode:
     {
-        assert(val != nullptr && "value is nullptr for ValPN or GepValNode");
+        assert(val != nullptr && "value is nullptr for ValVar or GepValNode");
         isTLPointer = val->getType()->isPointerTy();
         isATPointer = false;
         break;
@@ -108,10 +108,10 @@ void SVFVar::dump() const {
     outs() << this->toString() << "\n";
 }
 
-const std::string ValPN::toString() const {
+const std::string ValVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "ValPN ID: " << getId();
+    rawstr << "ValVar ID: " << getId();
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -119,10 +119,10 @@ const std::string ValPN::toString() const {
     return rawstr.str();
 }
 
-const std::string ObjPN::toString() const {
+const std::string ObjVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "ObjPN ID: " << getId();
+    rawstr << "ObjVar ID: " << getId();
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -130,10 +130,10 @@ const std::string ObjPN::toString() const {
     return rawstr.str();
 }
 
-const std::string GepValPN::toString() const {
+const std::string GepValVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "GepValPN ID: " << getId() << " with offset_" + llvm::utostr(getOffset());
+    rawstr << "GepValVar ID: " << getId() << " with offset_" + llvm::utostr(getOffset());
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -152,10 +152,10 @@ const std::string GepObjPN::toString() const {
     return rawstr.str();
 }
 
-const std::string FIObjPN::toString() const {
+const std::string FIObjVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "FIObjPN ID: " << getId() << " (base object)";
+    rawstr << "FIObjVar ID: " << getId() << " (base object)";
     if (Options::PAGDotGraphShorter) {
         rawstr << "\n";
     }
@@ -177,38 +177,38 @@ const std::string VarArgPN::toString() const {
     return rawstr.str();
 }
 
-const std::string DummyValPN::toString() const {
+const std::string DummyValVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "DummyValPN ID: " << getId();
+    rawstr << "DummyValVar ID: " << getId();
     return rawstr.str();
 }
 
-const std::string DummyObjPN::toString() const {
+const std::string DummyObjVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "DummyObjPN ID: " << getId();
+    rawstr << "DummyObjVar ID: " << getId();
     return rawstr.str();
 }
 
-const std::string CloneDummyObjPN::toString() const {
+const std::string CloneDummyObjVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "CloneDummyObjPN ID: " << getId();
+    rawstr << "CloneDummyObjVar ID: " << getId();
     return rawstr.str();
 }
 
-const std::string CloneGepObjPN::toString() const {
+const std::string CloneGepObjVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "CloneGepObjPN ID: " << getId();
+    rawstr << "CloneGepObjVar ID: " << getId();
     return rawstr.str();
 }
 
-const std::string CloneFIObjPN::toString() const {
+const std::string CloneFIObjVar::toString() const {
     std::string str;
     raw_string_ostream rawstr(str);
-    rawstr << "CloneFIObjPN ID: " << getId();
+    rawstr << "CloneFIObjVar ID: " << getId();
     return rawstr.str();
 }
 

--- a/lib/SABER/SaberSVFGBuilder.cpp
+++ b/lib/SABER/SaberSVFGBuilder.cpp
@@ -70,11 +70,11 @@ void SaberSVFGBuilder::collectGlobals(BVDataPTAImpl* pta)
     for(SVFIR::iterator it = pag->begin(), eit = pag->end(); it!=eit; it++)
     {
         PAGNode* pagNode = it->second;
-        if(SVFUtil::isa<DummyValPN>(pagNode) || SVFUtil::isa<DummyObjPN>(pagNode))
+        if(SVFUtil::isa<DummyValVar>(pagNode) || SVFUtil::isa<DummyObjVar>(pagNode))
             continue;
 
         if(GepObjPN* gepobj = SVFUtil::dyn_cast<GepObjPN>(pagNode)) {
-            if(SVFUtil::isa<DummyObjPN>(pag->getGNode(gepobj->getBaseNode())))
+            if(SVFUtil::isa<DummyObjVar>(pag->getGNode(gepobj->getBaseNode())))
                 continue;
         }
         if(const Value* val = pagNode->getValue())

--- a/lib/SVF-FE/Graph2Json.cpp
+++ b/lib/SVF-FE/Graph2Json.cpp
@@ -52,7 +52,7 @@ void ICFGPrinter::printICFGToJson(const std::string& filename)
                 edge_obj["dstValueName"] = edge->getDstNode()->getValueName();
                 if(edge->getEdgeKind()==PAGEdge::NormalGep)
                 {
-                    const NormalGepPE* gepEdge = SVFUtil::cast<NormalGepPE>(edge);
+                    const NormalGepStmt* gepEdge = SVFUtil::cast<NormalGepStmt>(edge);
                     edge_obj["offset"] = gepEdge->getOffset();
                 }
                 llvm::json::Value edge_value = llvm::json::Object{edge_obj};

--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -617,7 +617,7 @@ void SVFIRBuilder::visitBinaryOperator(BinaryOperator &inst)
     Value* op2 = inst.getOperand(1);
     NodeID op2Node = getValueNode(op2);
     u32_t opcode = inst.getOpcode();
-    const BinaryOPPE* binayPE = addBinaryOPEdge(op1Node, op2Node, dst, opcode);
+    const BinaryOPStmt* binayPE = addBinaryOPEdge(op1Node, op2Node, dst, opcode);
 }
 
 /*!
@@ -630,7 +630,7 @@ void SVFIRBuilder::visitUnaryOperator(UnaryOperator &inst)
     Value* opnd = inst.getOperand(0);
     NodeID src = getValueNode(opnd);
     u32_t opcode = inst.getOpcode();
-    const UnaryOPPE* unaryPE = addUnaryOPEdge(src, dst, opcode);
+    const UnaryOPStmt* unaryPE = addUnaryOPEdge(src, dst, opcode);
 }
 
 /*!
@@ -645,7 +645,7 @@ void SVFIRBuilder::visitCmpInst(CmpInst &inst)
     Value* op2 = inst.getOperand(1);
     NodeID op2Node = getValueNode(op2);
     u32_t opcode = inst.getOpcode();
-    const CmpPE* cmpPE = addCmpEdge(op1Node, op2Node, dst, opcode);
+    const CmpStmt* cmpPE = addCmpEdge(op1Node, op2Node, dst, opcode);
 }
 
 
@@ -1468,8 +1468,8 @@ void SVFIRBuilder::setCurrentBBAndValueForPAGEdge(PAGEdge* edge)
             assert(dstFun==curInst->getFunction() && "DstNode of the PAGEdge not in the same function?");
         }
 
-        /// We assume every GepValPN and its GepPE are unique across whole program
-        if (!(SVFUtil::isa<GepPE>(edge) && SVFUtil::isa<GepValPN>(edge->getDstNode())))
+        /// We assume every GepValVar and its GepStmt are unique across whole program
+        if (!(SVFUtil::isa<GepStmt>(edge) && SVFUtil::isa<GepValVar>(edge->getDstNode())))
             assert(curBB && "instruction does not have a basic block??");
 
         /// We will have one unique function exit ICFGNode for all returns

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -151,7 +151,7 @@ void PTAStat::performStat()
     for(SVFIR::iterator it = pag->begin(), eit = pag->end(); it!=eit; ++it)
     {
         PAGNode* node = it->second;
-        if(ObjPN* obj = SVFUtil::dyn_cast<ObjPN>(node))
+        if(ObjVar* obj = SVFUtil::dyn_cast<ObjVar>(node))
         {
             const MemObj* mem = obj->getMemObj();
             if (memObjSet.insert(mem->getId()).second == false)

--- a/lib/WPA/AndersenSFR.cpp
+++ b/lib/WPA/AndersenSFR.cpp
@@ -135,7 +135,7 @@ void AndersenSFR::fieldExpand(NodeSet& initials, Size_t offset, NodeBS& strides,
             Size_t initOffset;
             if (GepObjPN *gepNode = SVFUtil::dyn_cast<GepObjPN>(initPN))
                 initOffset = gepNode->getLocationSet().getOffset();
-            else if (SVFUtil::isa<FIObjPN>(initPN) || SVFUtil::isa<DummyObjPN>(initPN))
+            else if (SVFUtil::isa<FIObjVar>(initPN) || SVFUtil::isa<DummyObjVar>(initPN))
                 initOffset = 0;
             else
                 assert(false && "Not an object node!!");

--- a/lib/WPA/AndersenStat.cpp
+++ b/lib/WPA/AndersenStat.cpp
@@ -74,7 +74,7 @@ void AndersenStat::collectCycleInfo(ConstraintGraph* consCG)
         {
             NodeID nodeId = *it;
             PAGNode* pagNode = pta->getPAG()->getGNode(nodeId);
-            if (SVFUtil::isa<ObjPN>(pagNode) && pta->isFieldInsensitive(nodeId))
+            if (SVFUtil::isa<ObjVar>(pagNode) && pta->isFieldInsensitive(nodeId))
             {
                 NodeID baseId = consCG->getBaseObjNode(nodeId);
                 clone.reset(nodeId);
@@ -145,7 +145,7 @@ void AndersenStat::constraintGraphStat()
         if(nodeIt->second->getInEdges().empty() && nodeIt->second->getOutEdges().empty())
             continue;
         cgNodeNumber++;
-        if(SVFUtil::isa<ObjPN>(pta->getPAG()->getGNode(nodeIt->first)))
+        if(SVFUtil::isa<ObjVar>(pta->getPAG()->getGNode(nodeIt->first)))
             objNodeNumber++;
 
         u32_t nCopyIn = nodeIt->second->getDirectInEdges().size();
@@ -244,7 +244,7 @@ void AndersenStat::statNullPtr()
             {
                 std::string str;
                 raw_string_ostream rawstr(str);
-                if (!SVFUtil::isa<DummyValPN>(pagNode) && !SVFUtil::isa<DummyObjPN>(pagNode) )
+                if (!SVFUtil::isa<DummyValVar>(pagNode) && !SVFUtil::isa<DummyObjVar>(pagNode) )
                 {
                     // if a pointer is in dead function, we do not care
                     if(isPtrInDeadFunction(pagNode->getValue()) == false)

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -472,7 +472,7 @@ bool FlowSensitive::processGep(const GepSVFGNode* edge)
     const PointsTo& srcPts = getPts(edge->getPAGSrcNodeID());
 
     PointsTo tmpDstPts;
-    if (SVFUtil::isa<VariantGepPE>(edge->getPAGEdge()))
+    if (SVFUtil::isa<VariantGepStmt>(edge->getPAGEdge()))
     {
         for (NodeID o : srcPts)
         {
@@ -486,7 +486,7 @@ bool FlowSensitive::processGep(const GepSVFGNode* edge)
             tmpDstPts.set(getFIObjNode(o));
         }
     }
-    else if (const NormalGepPE* normalGep = SVFUtil::dyn_cast<NormalGepPE>(edge->getPAGEdge()))
+    else if (const NormalGepStmt* normalGep = SVFUtil::dyn_cast<NormalGepStmt>(edge->getPAGEdge()))
     {
         for (NodeID o : srcPts)
         {

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -107,7 +107,7 @@ void FlowSensitiveStat::performStat()
     {
         NodeID nodeId = nodeIt->first;
         PAGNode* pagNode = nodeIt->second;
-        if(SVFUtil::isa<ObjPN>(pagNode))
+        if(SVFUtil::isa<ObjVar>(pagNode))
         {
             const MemObj * memObj = pag->getBaseObj(nodeId);
             SymID baseId = memObj->getId();
@@ -294,7 +294,7 @@ void FlowSensitiveStat::statNullPtr()
             {
                 std::string str;
                 raw_string_ostream rawstr(str);
-                if (!SVFUtil::isa<DummyValPN>(pagNode) && !SVFUtil::isa<DummyObjPN>(pagNode))
+                if (!SVFUtil::isa<DummyValVar>(pagNode) && !SVFUtil::isa<DummyObjVar>(pagNode))
                 {
                     // if a pointer is in dead function, we do not care
                     if(isPtrInDeadFunction(pagNode->getValue()) == false)

--- a/lib/WPA/FlowSensitiveTBHC.cpp
+++ b/lib/WPA/FlowSensitiveTBHC.cpp
@@ -69,7 +69,7 @@ void FlowSensitiveTBHC::backPropagate(NodeID clone)
     assert(cloneObj && "FSTBHC: original object does not exist in SVFIR?");
     // Check the original object too because when reuse of a gep occurs, the new object
     // is an FI object.
-    if (SVFUtil::isa<CloneGepObjPN>(cloneObj) || SVFUtil::isa<GepObjPN>(originalObj))
+    if (SVFUtil::isa<CloneGepObjVar>(cloneObj) || SVFUtil::isa<GepObjPN>(originalObj))
     {
         // Since getGepObjClones is updated, some GEP nodes need to be redone.
         const NodeBS &retrievers = gepToSVFGRetrievers[getOriginalObj(clone)];
@@ -78,7 +78,7 @@ void FlowSensitiveTBHC::backPropagate(NodeID clone)
             pushIntoWorklist(r);
         }
     }
-    else if (SVFUtil::isa<CloneFIObjPN>(cloneObj) || SVFUtil::isa<CloneDummyObjPN>(cloneObj))
+    else if (SVFUtil::isa<CloneFIObjVar>(cloneObj) || SVFUtil::isa<CloneDummyObjVar>(cloneObj))
     {
         pushIntoWorklist(getAllocationSite(getOriginalObj(clone)));
     }
@@ -299,7 +299,7 @@ bool FlowSensitiveTBHC::processGep(const GepSVFGNode* gep)
         }
         else
         {
-            if (SVFUtil::isa<VariantGepPE>(gep->getPAGEdge()))
+            if (SVFUtil::isa<VariantGepStmt>(gep->getPAGEdge()))
             {
                 setObjFieldInsensitive(oq);
                 tmpDstPts.set(oq);
@@ -314,7 +314,7 @@ bool FlowSensitiveTBHC::processGep(const GepSVFGNode* gep)
                     }
                 }
             }
-            else if (const NormalGepPE* normalGep = SVFUtil::dyn_cast<NormalGepPE>(gep->getPAGEdge()))
+            else if (const NormalGepStmt* normalGep = SVFUtil::dyn_cast<NormalGepStmt>(gep->getPAGEdge()))
             {
                 const DIType *baseType = getType(oq);
 

--- a/lib/WPA/VersionedFlowSensitive.cpp
+++ b/lib/WPA/VersionedFlowSensitive.cpp
@@ -36,7 +36,7 @@ VersionedFlowSensitive::VersionedFlowSensitive(SVFIR *_pag, PTATY type)
 
     for (SVFIR::const_iterator it = pag->begin(); it != pag->end(); ++it)
     {
-        if (SVFUtil::isa<ObjPN>(it->second)) equivalentObject[it->first] = it->first;
+        if (SVFUtil::isa<ObjVar>(it->second)) equivalentObject[it->first] = it->first;
     }
 
     assert(!Options::OPTSVFG && "VFS: -opt-svfg not currently supported with VFS.");

--- a/lib/WPA/VersionedFlowSensitiveStat.cpp
+++ b/lib/WPA/VersionedFlowSensitiveStat.cpp
@@ -53,7 +53,7 @@ void VersionedFlowSensitiveStat::performStat()
     {
         NodeID nodeId = it->first;
         PAGNode* pagNode = it->second;
-        if (SVFUtil::isa<ObjPN>(pagNode))
+        if (SVFUtil::isa<ObjVar>(pagNode))
         {
             const MemObj *memObj = pag->getBaseObj(nodeId);
             SymID baseId = memObj->getId();


### PR DESCRIPTION

include "SVF-FE/PAGBuilder.h" => include "SVF-FE/SVFIRBuilder.h"
include "Graphs/PAG.h" ==> include "MemoryModel/SVFIR.h"
PAGBuilder => SVFIRBuilder
pag->getPAGNode => pag->getGNode


AddrPE => AddrStmt
CopyPE => CopyStmt
CmpPE => CmpStmt
BinaryOPPE => BinaryOPStmt
UnaryOPPE => UnaryOPStmt
StorePE => StoreStmt
LoadPE => LoadStmt
GepPE => GepStmt
VariantGepPE => VariantGepStmt
NormalGepPE => NormalGepStmt



ValPN => ValVar
ObjPN => ObjVar
GepValPN => GepValVar
GepObjPN => GepObjVar
FIObjPN => FIObjVar
DummyValPN => DummyValVar
DummyObjPN => DummyObjVar



