### PR TITLE
Remove some LLVM dependencies

### DIFF
--- a/include/DDA/DDAPass.h
+++ b/include/DDA/DDAPass.h
@@ -21,7 +21,7 @@ namespace SVF
  * Demand-Driven Pointer Analysis.
  * This class performs various pointer analysis on the given module.
  */
-class DDAPass: public ModulePass
+class DDAPass
 {
 
 public:
@@ -31,20 +31,8 @@ public:
     typedef OrderedSet<const SVFGEdge*> SVFGEdgeSet;
     typedef std::vector<PointerAnalysis*> PTAVector;
 
-    DDAPass() : ModulePass(ID), _pta(nullptr), _client(nullptr) {}
+    DDAPass() : _pta(nullptr), _client(nullptr) {}
     ~DDAPass();
-
-    virtual inline void getAnalysisUsage(AnalysisUsage &au) const
-    {
-        // declare your dependencies here.
-        /// do not intend to change the IR in this pass,
-        au.setPreservesAll();
-    }
-
-    virtual inline void* getAdjustedAnalysisPointer(AnalysisID)
-    {
-        return this;
-    }
 
     /// Interface expose to users of our pointer analysis, given Location infos
     virtual inline AliasResult alias(const MemoryLocation &LocA, const MemoryLocation &LocB)

--- a/include/Graphs/GraphPrinter.h
+++ b/include/Graphs/GraphPrinter.h
@@ -54,7 +54,7 @@ public:
      *  Write the graph into dot file for debugging purpose
      */
     template<class GraphType>
-    static void WriteGraphToFile(llvm::raw_ostream &O,
+    static void WriteGraphToFile(SVF::OutStream &O,
                                  const std::string &GraphName, const GraphType &GT, bool simple = false)
     {
         // Filename of the output dot file
@@ -83,7 +83,7 @@ public:
      * Print the graph to command line
      */
     template<class GraphType>
-    static void PrintGraph(llvm::raw_ostream &O, const std::string &GraphName,
+    static void PrintGraph(SVF::OutStream &O, const std::string &GraphName,
                            const GraphType &GT)
     {
         ///Define the GTraits and node iterator for printing

--- a/include/Graphs/ICFGEdge.h
+++ b/include/Graphs/ICFGEdge.h
@@ -96,7 +96,7 @@ public:
 
     /// Overloading operator << for dumping ICFG node ID
     //@{
-    friend raw_ostream& operator<< (raw_ostream &o, const ICFGEdge &edge)
+    friend OutStream& operator<< (OutStream &o, const ICFGEdge &edge)
     {
         o << edge.toString();
         return o;

--- a/include/Graphs/ICFGNode.h
+++ b/include/Graphs/ICFGNode.h
@@ -91,7 +91,7 @@ public:
 
     /// Overloading operator << for dumping ICFG node ID
     //@{
-    friend raw_ostream &operator<<(raw_ostream &o, const ICFGNode &node)
+    friend OutStream &operator<<(OutStream &o, const ICFGNode &node)
     {
         o << node.toString();
         return o;

--- a/include/Graphs/ICFGStat.h
+++ b/include/Graphs/ICFGStat.h
@@ -145,16 +145,16 @@ public:
     void printStat(string statname)
     {
 
-        std::cout << "\n************ " << statname << " ***************\n";
-        std::cout.flags(std::ios::left);
+        SVFUtil::outs() << "\n************ " << statname << " ***************\n";
+        SVFUtil::outs().flags(std::ios::left);
         unsigned field_width = 20;
         for(NUMStatMap::iterator it = PTNumStatMap.begin(), eit = PTNumStatMap.end(); it!=eit; ++it)
         {
             // format out put with width 20 space
-            std::cout << std::setw(field_width) << it->first << it->second << "\n";
+            SVFUtil::outs() << std::setw(field_width) << it->first << it->second << "\n";
         }
         PTNumStatMap.clear();
-        std::cout.flush();
+        SVFUtil::outs().flush();
     }
 };
 

--- a/include/Graphs/PTACallGraph.h
+++ b/include/Graphs/PTACallGraph.h
@@ -154,7 +154,7 @@ public:
 
     /// Overloading operator << for dumping ICFG node ID
     //@{
-    friend raw_ostream& operator<< (raw_ostream &o, const PTACallGraphEdge &edge)
+    friend OutStream& operator<< (OutStream &o, const PTACallGraphEdge &edge)
     {
         o << edge.toString();
         return o;
@@ -201,7 +201,7 @@ public:
 
     /// Overloading operator << for dumping ICFG node ID
     //@{
-    friend raw_ostream& operator<< (raw_ostream &o, const PTACallGraphNode &node)
+    friend OutStream& operator<< (OutStream &o, const PTACallGraphNode &node)
     {
         o << node.toString();
         return o;

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -555,7 +555,7 @@ protected:
 		/// we will set this phi node's def later
 		/// Ideally, every function uniqueFunRet should be a PhiNode (SVFIRBuilder.cpp), unless it does not have ret instruction
 		if (!pag->isPhiNode(uniqueFunRet)){
-			std::string warn = fun->getName().str();
+			std::string warn = fun->getName();
 			SVFUtil::writeWrnMsg(warn + " does not have any ret instruction!");
 			setDef(uniqueFunRet, sNode);
 		}

--- a/include/Graphs/VFGEdge.h
+++ b/include/Graphs/VFGEdge.h
@@ -124,7 +124,7 @@ public:
 
     /// Overloading operator << for dumping ICFG node ID
     //@{
-    friend raw_ostream& operator<< (raw_ostream &o, const VFGEdge &edge)
+    friend OutStream& operator<< (OutStream &o, const VFGEdge &edge)
     {
         o << edge.toString();
         return o;

--- a/include/Graphs/VFGNode.h
+++ b/include/Graphs/VFGNode.h
@@ -94,7 +94,7 @@ public:
 
     /// Overloading operator << for dumping ICFG node ID
     //@{
-    friend raw_ostream& operator<< (raw_ostream &o, const VFGNode &node)
+    friend OutStream& operator<< (OutStream &o, const VFGNode &node)
     {
         o << node.toString();
         return o;

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -451,7 +451,7 @@ public:
     //@}
 
     /// Print Memory SSA
-    void dumpMSSA(raw_ostream & Out = SVFUtil::outs());
+    void dumpMSSA(OutStream & Out = SVFUtil::outs());
 };
 
 } // End namespace SVF

--- a/include/MTA/MTA.h
+++ b/include/MTA/MTA.h
@@ -68,14 +68,6 @@ public:
 
     void dump(Module &module, MHP *mhp, LockAnalysis *lsa);
 
-    /// Get analysis usage
-    inline virtual void getAnalysisUsage(AnalysisUsage& au) const
-    {
-        /// do not intend to change the IR in this pass,
-        au.setPreservesAll();
-        au.addRequired<ScalarEvolutionWrapperPass>();
-    }
-
     // Get ScalarEvolution for Function F.
     static inline ScalarEvolution* getSE(const Function *F)
     {

--- a/include/MemoryModel/ConditionalPT.h
+++ b/include/MemoryModel/ConditionalPT.h
@@ -31,7 +31,6 @@
 #define CONDVAR_H_
 
 #include "Util/SVFUtil.h"
-#include "llvm/Support/raw_ostream.h"
 #include "MemoryModel/PointsTo.h"
 
 namespace SVF
@@ -114,7 +113,7 @@ public:
         return rawstr.str();
     }
 
-    friend raw_ostream& operator<< (raw_ostream &o, const CondVar<Cond> &cvar)
+    friend OutStream& operator<< (OutStream &o, const CondVar<Cond> &cvar)
     {
         o << cvar.toString();
         return o;
@@ -708,7 +707,7 @@ public:
 
     // Print all points-to targets
     //@{
-    inline void dump(raw_ostream & O) const
+    inline void dump(OutStream & O) const
     {
         CondPtsConstIter it = cptsBegin();
         CondPtsConstIter eit = cptsEnd();

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -4,6 +4,8 @@
 #ifndef MUTABLE_POINTSTO_H_
 #define MUTABLE_POINTSTO_H_
 
+#include<fstream>
+
 #include "MemoryModel/AbstractPointsToDS.h"
 #include "Util/SVFBasicTypes.h"
 #include "Util/SVFUtil.h"
@@ -581,10 +583,9 @@ public:
         mutPTData.dumpPTData();
         /// dump points-to of address-taken variables
         std::error_code ErrInfo;
-        ToolOutputFile F("svfg_pts.data", ErrInfo, llvm::sys::fs::OF_None);
-        if (!ErrInfo)
+        std::fstream f("svfg_pts.data", std::ios_base::out);
+        if (f.good())
         {
-            raw_fd_ostream & osm = F.os();
             NodeBS locs;
             for(DFPtsMapconstIter it = dfInPtsMap.begin(), eit = dfInPtsMap.end(); it!=eit; ++it)
                 locs.set(it->first);
@@ -597,28 +598,26 @@ public:
                 LocID loc = *it;
                 if (this->hasDFInSet(loc))
                 {
-                    osm << "Loc:" << loc << " IN:{";
-                    // TODO-os this->dumpPts(this->getDFInPtsMap(loc), osm);
-                    osm << "}\n";
+                    f << "Loc:" << loc << " IN:{";
+                    this->dumpPts(this->getDFInPtsMap(loc), f);
+                    f << "}\n";
                 }
 
                 if (this->hasDFOutSet(loc))
                 {
-                    osm << "Loc:" << loc << " OUT:{";
-                    // TODO-os this->dumpPts(this->getDFOutPtsMap(loc), osm);
-                    osm << "}\n";
+                    f << "Loc:" << loc << " OUT:{";
+                    this->dumpPts(this->getDFOutPtsMap(loc), f);
+                    f << "}\n";
                 }
             }
-            F.os().close();
-            if (!F.os().has_error())
+            f.close();
+            if (f.good())
             {
                 SVFUtil::outs() << "\n";
-                F.keep();
                 return;
             }
         }
         SVFUtil::outs() << "  error opening file for writing!\n";
-        F.os().clear_error();
     }
 
     virtual inline void dumpPts(const PtsMap & ptsSet,OutStream & O = SVFUtil::outs()) const

--- a/include/MemoryModel/MutablePointsToDS.h
+++ b/include/MemoryModel/MutablePointsToDS.h
@@ -124,7 +124,7 @@ public:
     ///@}
 
 protected:
-    virtual inline void dumpPts(const PtsMap & ptsSet,raw_ostream & O = SVFUtil::outs()) const
+    virtual inline void dumpPts(const PtsMap & ptsSet,OutStream & O = SVFUtil::outs()) const
     {
         for (PtsMapConstIter nodeIt = ptsSet.begin(); nodeIt != ptsSet.end(); nodeIt++)
         {
@@ -598,14 +598,14 @@ public:
                 if (this->hasDFInSet(loc))
                 {
                     osm << "Loc:" << loc << " IN:{";
-                    this->dumpPts(this->getDFInPtsMap(loc), osm);
+                    // TODO-os this->dumpPts(this->getDFInPtsMap(loc), osm);
                     osm << "}\n";
                 }
 
                 if (this->hasDFOutSet(loc))
                 {
                     osm << "Loc:" << loc << " OUT:{";
-                    this->dumpPts(this->getDFOutPtsMap(loc), osm);
+                    // TODO-os this->dumpPts(this->getDFOutPtsMap(loc), osm);
                     osm << "}\n";
                 }
             }
@@ -621,7 +621,7 @@ public:
         F.os().clear_error();
     }
 
-    virtual inline void dumpPts(const PtsMap & ptsSet,raw_ostream & O = SVFUtil::outs()) const
+    virtual inline void dumpPts(const PtsMap & ptsSet,OutStream & O = SVFUtil::outs()) const
     {
         for (PtsMapConstIter nodeIt = ptsSet.begin(); nodeIt != ptsSet.end(); nodeIt++)
         {

--- a/include/MemoryModel/PersistentPointsToCache.h
+++ b/include/MemoryModel/PersistentPointsToCache.h
@@ -296,31 +296,31 @@ public:
     void printStats(const std::string subtitle) const
     {
         static const unsigned fieldWidth = 25;
-        std::cout.flags(std::ios::left);
+        SVFUtil::outs().flags(std::ios::left);
 
-        std::cout << "****Persistent Points-To Cache Statistics: " << subtitle << "****\n";
+        SVFUtil::outs() << "****Persistent Points-To Cache Statistics: " << subtitle << "****\n";
 
-        std::cout << std::setw(fieldWidth) << "UniquePointsToSets"      << idToPts.size()          << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "UniquePointsToSets"      << idToPts.size()          << "\n";
 
-        std::cout << std::setw(fieldWidth) << "TotalUnions"             << totalUnions             << "\n";
-        std::cout << std::setw(fieldWidth) << "PropertyUnions"          << propertyUnions          << "\n";
-        std::cout << std::setw(fieldWidth) << "UniqueUnions"            << uniqueUnions            << "\n";
-        std::cout << std::setw(fieldWidth) << "LookupUnions"            << lookupUnions            << "\n";
-        std::cout << std::setw(fieldWidth) << "PreemptiveUnions"        << preemptiveUnions        << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "TotalUnions"             << totalUnions             << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "PropertyUnions"          << propertyUnions          << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "UniqueUnions"            << uniqueUnions            << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "LookupUnions"            << lookupUnions            << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "PreemptiveUnions"        << preemptiveUnions        << "\n";
 
-        std::cout << std::setw(fieldWidth) << "TotalComplements"        << totalComplements        << "\n";
-        std::cout << std::setw(fieldWidth) << "PropertyComplements"     << propertyComplements     << "\n";
-        std::cout << std::setw(fieldWidth) << "UniqueComplements"       << uniqueComplements       << "\n";
-        std::cout << std::setw(fieldWidth) << "LookupComplements"       << lookupComplements       << "\n";
-        std::cout << std::setw(fieldWidth) << "PreemptiveComplements"   << preemptiveComplements   << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "TotalComplements"        << totalComplements        << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "PropertyComplements"     << propertyComplements     << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "UniqueComplements"       << uniqueComplements       << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "LookupComplements"       << lookupComplements       << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "PreemptiveComplements"   << preemptiveComplements   << "\n";
 
-        std::cout << std::setw(fieldWidth) << "TotalIntersections"      << totalIntersections      << "\n";
-        std::cout << std::setw(fieldWidth) << "PropertyIntersections"   << propertyIntersections   << "\n";
-        std::cout << std::setw(fieldWidth) << "UniqueIntersections"     << uniqueIntersections     << "\n";
-        std::cout << std::setw(fieldWidth) << "LookupIntersections"     << lookupIntersections     << "\n";
-        std::cout << std::setw(fieldWidth) << "PreemptiveIntersections" << preemptiveIntersections << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "TotalIntersections"      << totalIntersections      << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "PropertyIntersections"   << propertyIntersections   << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "UniqueIntersections"     << uniqueIntersections     << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "LookupIntersections"     << lookupIntersections     << "\n";
+        SVFUtil::outs() << std::setw(fieldWidth) << "PreemptiveIntersections" << preemptiveIntersections << "\n";
 
-        std::cout.flush();
+        SVFUtil::outs().flush();
     }
 
     /// Returns all points-to sets stored by this cache as keys to a map.

--- a/include/MemoryModel/PointerAnalysis.h
+++ b/include/MemoryModel/PointerAnalysis.h
@@ -400,7 +400,7 @@ public:
     //@}
 
     /// Resolve indirect call edges
-    virtual void resolveIndCalls(const CallICFGNode* cs, const PointsTo& target, CallEdgeMap& newEdges,LLVMCallGraph* callgraph = nullptr);
+    virtual void resolveIndCalls(const CallICFGNode* cs, const PointsTo& target, CallEdgeMap& newEdges);
     /// Match arguments for callsite at caller and callee
     bool matchArgs(const CallICFGNode* cs, const SVFFunction* callee);
 

--- a/include/MemoryModel/PointerAnalysisImpl.h
+++ b/include/MemoryModel/PointerAnalysisImpl.h
@@ -536,15 +536,15 @@ public:
         CPtSet cpts2;
         expandFIObjs(pts2,cpts2);
         if (containBlackHoleNode(cpts1) || containBlackHoleNode(cpts2))
-            return llvm::AliasResult::MayAlias;
+            return AliasResult::MayAlias;
         else if(this->getAnalysisTy()==PathS_DDA && contains(cpts1,cpts2) && contains(cpts2,cpts1))
         {
-            return llvm::AliasResult::MustAlias;
+            return AliasResult::MustAlias;
         }
         else if(overlap(cpts1,cpts2))
-            return llvm::AliasResult::MayAlias;
+            return AliasResult::MayAlias;
         else
-            return llvm::AliasResult::NoAlias;
+            return AliasResult::NoAlias;
     }
     /// Test blk node for cpts
     inline bool containBlackHoleNode(const CPtSet& cpts)
@@ -583,7 +583,7 @@ public:
                 }
                 else if (!SVFUtil::isa<DummyValVar>(node))
                 {
-                    SVFUtil::outs() << "##<" << node->getValue()->getName() << "> ";
+                    SVFUtil::outs() << "##<" << node->getValue()->getName().str() << "> ";
                     //SVFUtil::outs() << "Source Loc: " << SVFUtil::getSourceLoc(node->getValue());
                 }
 

--- a/include/MemoryModel/SVFStatements.h
+++ b/include/MemoryModel/SVFStatements.h
@@ -167,7 +167,7 @@ public:
     //@}
     /// Overloading operator << for dumping SVFVar value
     //@{
-    friend raw_ostream& operator<< (raw_ostream &o, const SVFStmt &edge)
+    friend OutStream& operator<< (OutStream &o, const SVFStmt &edge)
     {
         o << edge.toString();
         return o;

--- a/include/MemoryModel/SVFVariables.h
+++ b/include/MemoryModel/SVFVariables.h
@@ -250,7 +250,7 @@ public:
     //@}
     /// Overloading operator << for dumping SVFVar value
     //@{
-    friend raw_ostream& operator<< (raw_ostream &o, const SVFVar &node)
+    friend OutStream& operator<< (OutStream &o, const SVFVar &node)
     {
         o << node.toString();
         return o;

--- a/include/MemoryModel/SymbolTableInfo.h
+++ b/include/MemoryModel/SymbolTableInfo.h
@@ -173,12 +173,6 @@ public:
         return dl;
     }
 
-    /// Helper method to get the size of the type from target data layout
-    //@{
-    u32_t getTypeSizeInBytes(const Type* type);
-    u32_t getTypeSizeInBytes(const StructType *sty, u32_t field_index);
-    //@}
-
     /// special value
     // @{
     static bool isNullPtrSym(const Value *val);

--- a/include/SABER/SaberCheckerAPI.h
+++ b/include/SABER/SaberCheckerAPI.h
@@ -77,7 +77,7 @@ private:
     {
         if(F)
         {
-            TDAPIMap::const_iterator it= tdAPIMap.find(F->getName().str());
+            TDAPIMap::const_iterator it= tdAPIMap.find(F->getName());
             if(it != tdAPIMap.end())
                 return it->second;
         }

--- a/include/SVF-FE/BasicTypes.h
+++ b/include/SVF-FE/BasicTypes.h
@@ -1,0 +1,19 @@
+#ifndef SVF_FE_BASIC_TYPES_H
+#define SVF_FE_BASIC_TYPES_H
+
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Metadata.h>
+
+#include <llvm/Support/SourceMgr.h>
+
+typedef llvm::SMDiagnostic SMDiagnostic;
+
+typedef llvm::ExtractValueInst  ExtractValueInst;
+typedef llvm::ExtractElementInst ExtractElementInst;
+typedef llvm::MetadataAsValue MetadataAsValue;
+typedef llvm::BlockAddress BlockAddress;
+
+typedef llvm::ConstantAggregate ConstantAggregate;
+typedef llvm::ConstantAggregateZero ConstantAggregateZero;
+
+#endif  // SVF_FE_BASIC_TYPES_H

--- a/include/SVF-FE/BreakConstantExpr.h
+++ b/include/SVF-FE/BreakConstantExpr.h
@@ -42,11 +42,6 @@ public:
         return "Remove Constant GEP Expressions";
     }
     virtual bool runOnModule (Module & M);
-    virtual void getAnalysisUsage(AnalysisUsage &AU) const
-    {
-        // This pass does not modify the control-flow graph of the function
-        AU.setPreservesCFG();
-    }
 };
 
 
@@ -91,12 +86,6 @@ public:
     {
         assert(!fn.isDeclaration() && "external function does not have DF");
         return &getAnalysis<UnifyFunctionExitNodes>(const_cast<Function&>(fn));
-    }
-    virtual void getAnalysisUsage(AnalysisUsage &AU) const
-    {
-        // This pass does not modify the control-flow graph of the function
-        AU.addRequired<UnifyFunctionExitNodes>();
-        AU.addPreserved<BreakConstantGEPs>();
     }
 };
 

--- a/include/SVF-FE/DataFlowUtil.h
+++ b/include/SVF-FE/DataFlowUtil.h
@@ -169,12 +169,6 @@ public:
     {
     }
 
-    virtual void getAnalysisUsage(AnalysisUsage &AU) const
-    {
-        AU.setPreservesAll();
-        // AU.addRequired<DominanceFrontier>();
-    }
-
 //	virtual bool runOnFunction(Function &m) {
 //		Frontiers.clear();
 //		DF = &getAnalysis<DominanceFrontier>();

--- a/include/SVF-FE/LLVMUtil.h
+++ b/include/SVF-FE/LLVMUtil.h
@@ -638,6 +638,12 @@ bool isIRFile(const std::string &filename);
 void processArguments(int argc, char **argv, int &arg_num, char **arg_value,
                       std::vector<std::string> &moduleNameVec);
 
+/// Helper method to get the size of the type from target data layout
+//@{
+u32_t getTypeSizeInBytes(const Type* type);
+u32_t getTypeSizeInBytes(const StructType *sty, u32_t field_index);
+//@}
+
 } // End namespace SVFUtil
 
 } // End namespace SVF

--- a/include/SVF-FE/LLVMUtil.h
+++ b/include/SVF-FE/LLVMUtil.h
@@ -644,6 +644,8 @@ u32_t getTypeSizeInBytes(const Type* type);
 u32_t getTypeSizeInBytes(const StructType *sty, u32_t field_index);
 //@}
 
+const std::string type2String(const Type* type);
+
 } // End namespace SVFUtil
 
 } // End namespace SVF

--- a/include/SVF-FE/LLVMUtil.h
+++ b/include/SVF-FE/LLVMUtil.h
@@ -30,7 +30,9 @@
 #ifndef INCLUDE_SVF_FE_LLVMUTIL_H_
 #define INCLUDE_SVF_FE_LLVMUTIL_H_
 
+#include "SVF-FE/BasicTypes.h"
 #include "Util/SVFUtil.h"
+#include "SVF-FE/BasicTypes.h"
 #include "Util/BasicTypes.h"
 #include "Util/ExtAPI.h"
 #include "Util/ThreadAPI.h"
@@ -416,12 +418,12 @@ inline bool ArgInDeadFunction (const Value * val)
 /// Return true if this is a program entry function (e.g. main)
 inline bool isProgEntryFunction (const SVFFunction * fun)
 {
-    return fun && fun->getName().str() == "main";
+    return fun && fun->getName() == "main";
 }
 
 inline bool isProgEntryFunction (const Function * fun)
 {
-    return fun && fun->getName().str() == "main";
+    return fun && fun->getName() == "main";
 }
 
 /// Get program entry function from module.
@@ -462,9 +464,9 @@ bool isPtrInDeadFunction (const Value * value);
 //@{
 inline bool isProgExitFunction (const SVFFunction * fun)
 {
-    return fun && (fun->getName().str() == "exit" ||
-                   fun->getName().str() == "__assert_rtn" ||
-                   fun->getName().str() == "__assert_fail" );
+    return fun && (fun->getName() == "exit" ||
+                   fun->getName() == "__assert_rtn" ||
+                   fun->getName() == "__assert_fail" );
 }
 
 inline bool isProgExitCall(const CallSite cs)

--- a/include/SVF-FE/SVFIRBuilder.h
+++ b/include/SVF-FE/SVFIRBuilder.h
@@ -32,6 +32,7 @@
 
 #include "MemoryModel/SVFIR.h"
 #include "Util/ExtAPI.h"
+#include "SVF-FE/BasicTypes.h"
 #include "SVF-FE/ICFGBuilder.h"
 
 namespace SVF

--- a/include/Util/BasicTypes.h
+++ b/include/Util/BasicTypes.h
@@ -46,7 +46,6 @@
 #include <llvm/Analysis/CallGraph.h>	// call graph
 #include <llvm/IR/GlobalVariable.h>	// for GlobalVariable
 
-#include <llvm/Support/SourceMgr.h> // for SMDiagnostic
 #include <llvm/Bitcode/BitcodeWriter.h>		// for WriteBitcodeToFile
 #include <llvm/Bitcode/BitcodeReader.h>     /// for isBitcode
 #include <llvm/IRReader/IRReader.h>	// IR reader for bit file
@@ -70,7 +69,6 @@ class BddCond;
 
 
 /// LLVM Basic classes
-typedef llvm::SMDiagnostic SMDiagnostic;
 typedef llvm::LLVMContext LLVMContext;
 typedef llvm::Type Type;
 typedef llvm::Function Function;
@@ -82,7 +80,6 @@ typedef llvm::GlobalObject GlobalObject;
 typedef llvm::GlobalValue GlobalValue;
 typedef llvm::GlobalVariable GlobalVariable;
 typedef llvm::Module Module;
-typedef llvm::CallGraph LLVMCallGraph;
 typedef llvm::User User;
 typedef llvm::Use Use;
 typedef llvm::Loop Loop;
@@ -93,10 +90,8 @@ typedef llvm::LoopInfo LoopInfo;
     typedef llvm::UnifyFunctionExitNodes UnifyFunctionExitNodes;
 #endif
 typedef llvm::ModulePass ModulePass;
-typedef llvm::AnalysisUsage AnalysisUsage;
 
 /// LLVM outputs
-typedef llvm::raw_ostream raw_ostream;
 typedef llvm::raw_string_ostream raw_string_ostream;
 typedef llvm::raw_fd_ostream raw_fd_ostream;
 typedef llvm::StringRef StringRef;
@@ -108,8 +103,6 @@ typedef llvm::ArrayType ArrayType;
 typedef llvm::PointerType PointerType;
 typedef llvm::FunctionType FunctionType;
 typedef llvm::VectorType VectorType;
-typedef llvm::MetadataAsValue MetadataAsValue;
-typedef llvm::BlockAddress BlockAddress;
 
 /// LLVM data layout
 typedef llvm::DataLayout DataLayout;
@@ -122,8 +115,6 @@ typedef llvm::MemoryLocation MemoryLocation;
 typedef llvm::Argument Argument;
 typedef llvm::Constant Constant;
 typedef llvm::ConstantData ConstantData;
-typedef llvm::ConstantAggregate ConstantAggregate;
-typedef llvm::ConstantAggregateZero ConstantAggregateZero;
 typedef llvm::ConstantDataSequential ConstantDataSequential;
 typedef llvm::ConstantInt ConstantInt;
 typedef llvm::ConstantFP ConstantFP;
@@ -132,9 +123,6 @@ typedef llvm::ConstantExpr ConstantExpr;
 typedef llvm::ConstantPointerNull ConstantPointerNull;
 typedef llvm::ConstantArray ConstantArray;
 typedef llvm::GlobalAlias GlobalAlias;
-typedef llvm::AliasResult AliasResult;
-typedef llvm::ModRefInfo ModRefInfo;
-typedef llvm::AnalysisID AnalysisID;
 typedef llvm::ConstantDataArray ConstantDataArray;
 
 /// LLVM metadata
@@ -160,13 +148,11 @@ typedef llvm::IntToPtrInst IntToPtrInst;
 typedef llvm::CmpInst CmpInst;
 typedef llvm::BranchInst BranchInst;
 typedef llvm::SwitchInst SwitchInst;
-typedef llvm::ExtractValueInst  ExtractValueInst;
 typedef llvm::InsertValueInst InsertValueInst;
 typedef llvm::BinaryOperator BinaryOperator;
 typedef llvm::UnaryOperator UnaryOperator;
 typedef llvm::PtrToIntInst PtrToIntInst;
 typedef llvm::VAArgInst VAArgInst;
-typedef llvm::ExtractElementInst ExtractElementInst;
 typedef llvm::InsertElementInst InsertElementInst;
 typedef llvm::ShuffleVectorInst ShuffleVectorInst;
 typedef llvm::LandingPadInst LandingPadInst;
@@ -332,7 +318,7 @@ public:
 };
 
 template <typename F, typename S>
-raw_ostream& operator<< (raw_ostream &o, const std::pair<F, S> &var)
+OutStream& operator<< (OutStream &o, const std::pair<F, S> &var)
 {
     o << "<" << var.first << ", " << var.second << ">";
     return o;

--- a/include/Util/Conditions.h
+++ b/include/Util/Conditions.h
@@ -162,7 +162,7 @@ public:
     void ddClearFlag(BranchCond * f) const;
     void BddSupportStep( BranchCond * f,  NodeBS &support) const;
     void extractSubConds( BranchCond * f,  NodeBS &support) const;
-    void dump(BranchCond* lhs, raw_ostream & O);
+    void dump(BranchCond* lhs, OutStream & O);
     std::string dumpStr(BranchCond* lhs) const;
 
 private:

--- a/include/Util/CxtStmt.h
+++ b/include/Util/CxtStmt.h
@@ -108,7 +108,7 @@ public:
     /// Dump CxtStmt
     inline void dump() const
     {
-        SVFUtil::outs() << "[ Current Stmt: " << SVFUtil::getSourceLoc(inst) << " " << *inst << "\t Contexts: " << cxtToStr() << "  ]\n";
+        // TODO-os SVFUtil::outs() << "[ Current Stmt: " << SVFUtil::getSourceLoc(inst) << " " << *inst << "\t Contexts: " << cxtToStr() << "  ]\n";
     }
 
 protected:
@@ -174,7 +174,7 @@ public:
     /// Dump CxtThreadStmt
     inline void dump() const
     {
-        SVFUtil::outs() << "[ Current Thread id: " << tid << "  Stmt: " << SVFUtil::getSourceLoc(inst) << " " << *inst << "\t Contexts: " << cxtToStr() << "  ]\n";
+        // TODO-os SVFUtil::outs() << "[ Current Thread id: " << tid << "  Stmt: " << SVFUtil::getSourceLoc(inst) << " " << *inst << "\t Contexts: " << cxtToStr() << "  ]\n";
     }
 
 private:
@@ -281,11 +281,15 @@ public:
         std::string cycle = incycle?", incycle":"";
 
         if(forksite)
-            SVFUtil::outs() << "[ Thread: $" << SVFUtil::getSourceLoc(forksite) << "$ " << *forksite  << "\t Contexts: " << cxtToStr()
-                            << loop << cycle <<"  ]\n";
+        {
+            //TODO-os SVFUtil::outs() << "[ Thread: $" << SVFUtil::getSourceLoc(forksite) << "$ " << *forksite  << "\t Contexts: " << cxtToStr()
+            //TODO-os                << loop << cycle <<"  ]\n";
+        }
         else
+        {
             SVFUtil::outs() << "[ Thread: " << "main   "  << "\t Contexts: " << cxtToStr()
                             << loop << cycle <<"  ]\n";
+        }
     }
 protected:
     CallStrCxt cxt;

--- a/include/Util/CxtStmt.h
+++ b/include/Util/CxtStmt.h
@@ -108,7 +108,7 @@ public:
     /// Dump CxtStmt
     inline void dump() const
     {
-        // TODO-os SVFUtil::outs() << "[ Current Stmt: " << SVFUtil::getSourceLoc(inst) << " " << *inst << "\t Contexts: " << cxtToStr() << "  ]\n";
+        SVFUtil::outs() << "[ Current Stmt: " << SVFUtil::getSourceLoc(inst) << " " << SVFUtil::value2String(inst) << "\t Contexts: " << cxtToStr() << "  ]\n";
     }
 
 protected:
@@ -174,7 +174,7 @@ public:
     /// Dump CxtThreadStmt
     inline void dump() const
     {
-        // TODO-os SVFUtil::outs() << "[ Current Thread id: " << tid << "  Stmt: " << SVFUtil::getSourceLoc(inst) << " " << *inst << "\t Contexts: " << cxtToStr() << "  ]\n";
+        SVFUtil::outs() << "[ Current Thread id: " << tid << "  Stmt: " << SVFUtil::getSourceLoc(inst) << " " << SVFUtil::value2String(inst) << "\t Contexts: " << cxtToStr() << "  ]\n";
     }
 
 private:
@@ -282,8 +282,8 @@ public:
 
         if(forksite)
         {
-            //TODO-os SVFUtil::outs() << "[ Thread: $" << SVFUtil::getSourceLoc(forksite) << "$ " << *forksite  << "\t Contexts: " << cxtToStr()
-            //TODO-os                << loop << cycle <<"  ]\n";
+            SVFUtil::outs() << "[ Thread: $" << SVFUtil::getSourceLoc(forksite) << "$ " << SVFUtil::value2String(forksite)  << "\t Contexts: " << cxtToStr()
+                            << loop << cycle <<"  ]\n";
         }
         else
         {

--- a/include/Util/DPItem.h
+++ b/include/Util/DPItem.h
@@ -32,7 +32,6 @@
 
 #include "Util/Conditions.h"
 #include "MemoryModel/ConditionalPT.h"
-#include "llvm/Support/raw_ostream.h"
 #include <algorithm>    // std::sort
 
 namespace SVF

--- a/include/Util/ExtAPI.h
+++ b/include/Util/ExtAPI.h
@@ -133,10 +133,12 @@ public:
     extf_t get_type(const SVFFunction* F) const
     {
         assert(F);
-        std::string funName = F->getName().str();
+        std::string funName = F->getName();
         if(F->isIntrinsic())
         {
-            funName = "llvm." + F->getName().split('.').second.split('.').first.str();
+            unsigned start = funName.find('.');
+            unsigned end = funName.substr(start + 1).find('.');
+            funName = "llvm." + funName.substr(start + 1, end);
         }
         llvm::StringMap<extf_t>::const_iterator it= info.find(funName);
         if(it == info.end())

--- a/include/Util/IRAnnotator.h
+++ b/include/Util/IRAnnotator.h
@@ -138,8 +138,8 @@ private:
         }
         else
         {
-            std::cout << "Value is NOT a Instruction, Argument, Function, GlobalVariable, BasicBlock, Constant or InlineAsm" << std::endl;
-            SVFUtil::outs() << *value << "\n";
+            SVFUtil::outs() << "Value is NOT a Instruction, Argument, Function, GlobalVariable, BasicBlock, Constant or InlineAsm" << std::endl;
+            SVFUtil::outs() << SVFUtil::value2String(value) << "\n";
         }
     }
 

--- a/include/Util/SVFBasicTypes.h
+++ b/include/Util/SVFBasicTypes.h
@@ -32,10 +32,10 @@
 #define INCLUDE_UTIL_SVFBASICTYPES_H_
 
 #include <llvm/ADT/SparseBitVector.h>	// for points-to
-#include <llvm/Support/raw_ostream.h>	// for output
 #include <llvm/Support/CommandLine.h>	// for command line options
 #include <llvm/ADT/StringMap.h>	// for StringMap
 
+#include <iostream>
 #include <vector>
 #include <list>
 #include <set>
@@ -71,6 +71,8 @@ template <class T> struct Hash {
         return h(t);
     }
 };
+
+typedef std::ostream OutStream;
 
 typedef unsigned u32_t;
 typedef signed s32_t;
@@ -179,6 +181,22 @@ template <> struct Hash<NodePair>
 /// Size of native integer that we'll use for bit vectors, in bits.
 #define NATIVE_INT_SIZE (sizeof(unsigned long long) * CHAR_BIT)
 
+enum ModRefInfo
+{
+    ModRef,
+    Ref,
+    Mod,
+    NoModRef,
+};
+
+enum AliasResult
+{
+    MustAlias,
+    MayAlias,
+    PartialAlias,
+    NoAlias,
+};
+
 class SVFValue
 {
 
@@ -228,7 +246,7 @@ public:
     }
     //@}
 
-    const llvm::StringRef getName() const
+    const std::string getName() const
     {
         return value;
     }
@@ -240,7 +258,7 @@ public:
 
     /// Overloading operator << for dumping ICFG node ID
     //@{
-    friend llvm::raw_ostream& operator<< (llvm::raw_ostream &o, const SVFValue &node)
+    friend OutStream& operator<< (OutStream &o, const SVFValue &node)
     {
         o << node.getName();
         return o;

--- a/include/Util/SVFUtil.h
+++ b/include/Util/SVFUtil.h
@@ -46,20 +46,20 @@ namespace SVFUtil
 {
 
 /// Overwrite llvm::outs()
-inline raw_ostream &outs()
+inline std::ostream &outs()
 {
-    return llvm::outs();
+    return std::cout;
 }
 
 /// Overwrite llvm::errs()
-inline raw_ostream &errs()
+inline std::ostream  &errs()
 {
-    return llvm::errs();
+    return std::cerr;
 }
 
 /// Dump sparse bitvector set
-void dumpSet(NodeBS To, raw_ostream & O = SVFUtil::outs());
-void dumpSet(PointsTo To, raw_ostream & O = SVFUtil::outs());
+void dumpSet(NodeBS To, OutStream & O = SVFUtil::outs());
+void dumpSet(PointsTo To, OutStream & O = SVFUtil::outs());
 
 /// Dump points-to set
 void dumpPointsToSet(unsigned node, NodeBS To) ;
@@ -89,7 +89,7 @@ std::string  bugMsg3(std::string msg);
 std::string  pasMsg(std::string msg);
 
 /// Print memory usage in KB.
-void reportMemoryUsageKB(const std::string& infor, raw_ostream & O = SVFUtil::outs());
+void reportMemoryUsageKB(const std::string& infor, OutStream & O = SVFUtil::outs());
 
 /// Get memory usage from system file. Return TRUE if succeed.
 bool getMemoryUsageKB(u32_t* vmrss_kb, u32_t* vmsize_kb);

--- a/include/Util/ThreadAPI.h
+++ b/include/Util/ThreadAPI.h
@@ -90,7 +90,7 @@ private:
     {
         if(F)
         {
-            TDAPIMap::const_iterator it= tdAPIMap.find(F->getName().str());
+            TDAPIMap::const_iterator it= tdAPIMap.find(F->getName());
             if(it != tdAPIMap.end())
                 return it->second;
         }

--- a/include/WPA/WPAPass.h
+++ b/include/WPA/WPAPass.h
@@ -51,7 +51,7 @@ class SVFG;
  */
 // excised ", public llvm::AliasAnalysis" as that has a very light interface
 // and I want to see what breaks.
-class WPAPass : public ModulePass
+class WPAPass
 {
     typedef std::vector<PointerAnalysis*> PTAVector;
 
@@ -67,27 +67,13 @@ public:
     };
 
     /// Constructor needs TargetLibraryInfo to be passed to the AliasAnalysis
-    WPAPass() : ModulePass(ID)
+    WPAPass()
     {
 
     }
 
     /// Destructor
     virtual ~WPAPass();
-
-    /// LLVM analysis usage
-    virtual inline void getAnalysisUsage(AnalysisUsage &au) const
-    {
-        // declare your dependencies here.
-        /// do not intend to change the IR in this pass,
-        au.setPreservesAll();
-    }
-
-    /// Get adjusted analysis for alias analysis
-    virtual inline void* getAdjustedAnalysisPointer(AnalysisID)
-    {
-        return this;
-    }
 
     /// Interface expose to users of our pointer analysis, given Location infos
     virtual inline AliasResult alias(const MemoryLocation  &LocA, const MemoryLocation  &LocB)

--- a/lib/DDA/DDAClient.cpp
+++ b/lib/DDA/DDAClient.cpp
@@ -124,8 +124,8 @@ void FunptrDDAClient::performStat(PointerAnalysis* pta)
 
         ++morePreciseCallsites;
         outs() << "============more precise callsite =================\n";
-        outs() << *(nIter->second)->getCallSite() << "\n";
-        outs() << getSourceLoc((nIter->second)->getCallSite()) << "\n";
+        // TODO-os outs() << *(nIter->second)->getCallSite() << "\n";
+        // TODO-os outs() << getSourceLoc((nIter->second)->getCallSite()) << "\n";
         outs() << "\n";
         outs() << "------ander pts or vtable num---(" << anderPts.count()  << ")--\n";
         outs() << "------DDA vfn num---(" << ander_vfns.size() << ")--\n";
@@ -197,8 +197,8 @@ void AliasDDAClient::performStat(PointerAnalysis* pta)
                 AliasResult result = pta->alias(node1->getId(),node2->getId());
 
                 outs() << "\n=================================================\n";
-                outs() << "Alias Query for (" << *node1->getValue() << ",";
-                outs() << *node2->getValue() << ") \n";
+                outs() << "Alias Query for (" << SVFUtil::value2String(node1->getValue()) << ",";
+                outs() << SVFUtil::value2String(node2->getValue()) << ") \n";
                 outs() << "[NodeID:" << node1->getId() <<  ", NodeID:" << node2->getId() << " " << result << "]\n";
                 outs() << "=================================================\n";
 

--- a/lib/DDA/DDAClient.cpp
+++ b/lib/DDA/DDAClient.cpp
@@ -124,8 +124,8 @@ void FunptrDDAClient::performStat(PointerAnalysis* pta)
 
         ++morePreciseCallsites;
         outs() << "============more precise callsite =================\n";
-        // TODO-os outs() << *(nIter->second)->getCallSite() << "\n";
-        // TODO-os outs() << getSourceLoc((nIter->second)->getCallSite()) << "\n";
+        outs() << SVFUtil::value2String((nIter->second)->getCallSite()) << "\n";
+        outs() << getSourceLoc((nIter->second)->getCallSite()) << "\n";
         outs() << "\n";
         outs() << "------ander pts or vtable num---(" << anderPts.count()  << ")--\n";
         outs() << "------DDA vfn num---(" << ander_vfns.size() << ")--\n";

--- a/lib/DDA/DDAPass.cpp
+++ b/lib/DDA/DDAPass.cpp
@@ -21,8 +21,6 @@ using namespace SVFUtil;
 
 char DDAPass::ID = 0;
 
-static llvm::RegisterPass<DDAPass> DDAPA("dda", "Demand-driven Pointer Analysis Pass");
-
 DDAPass::~DDAPass()
 {
     // _pta->dumpStat();
@@ -304,7 +302,7 @@ AliasResult DDAPass::alias(const Value* V1, const Value* V2)
         return _pta->alias(V1,V2);
     }
 
-    return llvm::AliasResult::MayAlias;
+    return AliasResult::MayAlias;
 }
 
 /*!

--- a/lib/DDA/DDAStat.cpp
+++ b/lib/DDA/DDAStat.cpp
@@ -254,18 +254,18 @@ void DDAStat::printStatPerQuery(NodeID ptr, const PointsTo& pts)
 
     if (timeStatMap.empty() == false && NumPerQueryStatMap.empty() == false)
     {
-        std::cout.flags(std::ios::left);
+        SVFUtil::outs().flags(std::ios::left);
         unsigned field_width = 20;
-        std::cout << "---------------------Stat Per Query--------------------------------\n";
+        SVFUtil::outs() << "---------------------Stat Per Query--------------------------------\n";
         for (TIMEStatMap::iterator it = timeStatMap.begin(), eit = timeStatMap.end(); it != eit; ++it)
         {
             // format out put with width 20 space
-            std::cout << std::setw(field_width) << it->first << it->second << "\n";
+            SVFUtil::outs() << std::setw(field_width) << it->first << it->second << "\n";
         }
         for (NUMStatMap::iterator it = NumPerQueryStatMap.begin(), eit = NumPerQueryStatMap.end(); it != eit; ++it)
         {
             // format out put with width 20 space
-            std::cout << std::setw(field_width) << it->first << it->second << "\n";
+            SVFUtil::outs() << std::setw(field_width) << it->first << it->second << "\n";
         }
     }
     getPTA()->dumpPts(ptr, pts);
@@ -285,6 +285,6 @@ void DDAStat::printStat()
         contextDDA->getSVFG()->getStat()->performSCCStat(contextDDA->getInsensitiveEdgeSet());
     }
 
-    std::cout << "\n****Demand-Driven Pointer Analysis Statistics****\n";
+    SVFUtil::outs() << "\n****Demand-Driven Pointer Analysis Statistics****\n";
     PTAStat::printStat();
 }

--- a/lib/Graphs/CHG.cpp
+++ b/lib/Graphs/CHG.cpp
@@ -120,7 +120,7 @@ void CHGraph::getVFnsFromVtbls(CallSite cs, const VTableSet &vtbls, VFunSet &vir
                 if (!checkArgTypes(cs, callee->getLLVMFun()))
                     continue;
 
-                cppUtil::DemangledName dname = cppUtil::demangle(callee->getName().str());
+                cppUtil::DemangledName dname = cppUtil::demangle(callee->getName());
                 string calleeName = dname.funcName;
 
                 /*

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -209,7 +209,7 @@ ICFGNode* ICFG::getICFGNode(const Instruction* inst)
 CallICFGNode* ICFG::getCallICFGNode(const Instruction* inst)
 {
 	if(SVFUtil::isCallSite(inst) ==false)
-		outs() << *inst << "\n";
+    // TODO-os outs() << *inst << "\n";
     assert(SVFUtil::isCallSite(inst) && "not a call instruction?");
     assert(SVFUtil::isNonInstricCallSite(inst) && "associating an intrinsic debug instruction with an ICFGNode!");
     CallICFGNode* node = getCallBlock(inst);

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -209,7 +209,7 @@ ICFGNode* ICFG::getICFGNode(const Instruction* inst)
 CallICFGNode* ICFG::getCallICFGNode(const Instruction* inst)
 {
 	if(SVFUtil::isCallSite(inst) ==false)
-    // TODO-os outs() << *inst << "\n";
+    outs() << SVFUtil::value2String(inst) << "\n";
     assert(SVFUtil::isCallSite(inst) && "not a call instruction?");
     assert(SVFUtil::isNonInstricCallSite(inst) && "associating an intrinsic debug instruction with an ICFGNode!");
     CallICFGNode* node = getCallBlock(inst);

--- a/lib/Graphs/PTACallGraph.cpp
+++ b/lib/Graphs/PTACallGraph.cpp
@@ -272,7 +272,7 @@ void PTACallGraph::verifyCallGraph()
             const CallICFGNode* cs = it->first;
             const SVFFunction* func = cs->getCaller();
             if (getCallGraphNode(func)->isReachableFromProgEntry() == false)
-                writeWrnMsg(func->getName().str() + " has indirect call site but not reachable from main");
+                writeWrnMsg(func->getName() + " has indirect call site but not reachable from main");
         }
     }
 }

--- a/lib/Graphs/SVFGStat.cpp
+++ b/lib/Graphs/SVFGStat.cpp
@@ -127,7 +127,7 @@ void MemSSAStat::performStat()
 void MemSSAStat::printStat()
 {
 
-    std::cout << "\n****Memory SSA Statistics****\n";
+    SVFUtil::outs() << "\n****Memory SSA Statistics****\n";
     PTAStat::printStat();
 }
 
@@ -491,7 +491,7 @@ void SVFGStat::performSCCStat(SVFGEdgeSet insensitiveCalRetEdges)
     PTNumStatMap["InsenRetEdge"] = insensitiveRetEdge;
 
 
-    std::cout << "\n****SVFG SCC Stat****\n";
+    SVFUtil::outs() << "\n****SVFG SCC Stat****\n";
     PTAStat::printStat();
 
     delete svfgSCC;
@@ -500,6 +500,6 @@ void SVFGStat::performSCCStat(SVFGEdgeSet insensitiveCalRetEdges)
 
 void SVFGStat::printStat()
 {
-    std::cout << "\n****SVFG Statistics****\n";
+    SVFUtil::outs() << "\n****SVFG Statistics****\n";
     PTAStat::printStat();
 }

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -592,7 +592,7 @@ u32_t MemSSA::getBBPhiNum() const
 /*!
  * Print SSA
  */
-void MemSSA::dumpMSSA(raw_ostream& Out)
+void MemSSA::dumpMSSA(OutStream& Out)
 {
     SVFIR* pag = pta->getPAG();
 
@@ -619,7 +619,7 @@ void MemSSA::dumpMSSA(raw_ostream& Out)
         {
             BasicBlock& bb = *bit;
             if (bb.hasName())
-                Out << bb.getName() << "\n";
+                Out << bb.getName().str() << "\n";
             PHISet& phiSet = getPHISet(&bb);
             for(PHISet::iterator pi = phiSet.begin(), epi = phiSet.end(); pi !=epi; ++pi)
             {
@@ -648,7 +648,7 @@ void MemSSA::dumpMSSA(raw_ostream& Out)
                         }
                     }
 
-                    Out << inst << "\n";
+                    // TODO-os Out << inst << "\n";
 
                     if(hasCHI(cs))
                     {
@@ -686,7 +686,7 @@ void MemSSA::dumpMSSA(raw_ostream& Out)
                         }
                     }
 
-                    Out << inst << "\n";
+                    // TODO-os Out << inst << "\n";
 
                     bool has_chi = false;
                     for(SVFStmtList::const_iterator bit = pagEdgeList.begin(), ebit= pagEdgeList.end();

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -648,7 +648,7 @@ void MemSSA::dumpMSSA(OutStream& Out)
                         }
                     }
 
-                    // TODO-os Out << inst << "\n";
+                    Out << SVFUtil::value2String(&inst) << "\n";
 
                     if(hasCHI(cs))
                     {
@@ -686,7 +686,7 @@ void MemSSA::dumpMSSA(OutStream& Out)
                         }
                     }
 
-                    // TODO-os Out << inst << "\n";
+                    Out << SVFUtil::value2String(&inst) << "\n";
 
                     bool has_chi = false;
                     for(SVFStmtList::const_iterator bit = pagEdgeList.begin(), ebit= pagEdgeList.end();

--- a/lib/MTA/MHP.cpp
+++ b/lib/MTA/MHP.cpp
@@ -294,7 +294,7 @@ void MHP::handleJoin(const CxtThreadStmt& cts, NodeID rootTid)
         else
         {
             rmInterleavingThread(cts,joinedTids,call);
-            DBOUT(DMTA,outs() << "\n\t match join site " << *call <<  " for thread " << rootTid << "\n");
+            // TODO-os DBOUT(DMTA,outs() << "\n\t match join site " << *call <<  " for thread " << rootTid << "\n");
         }
     }
     /// for the join site in a loop loop which does not join the current thread
@@ -689,7 +689,7 @@ void MHP::printInterleaving()
 {
     for(ThreadStmtToThreadInterleav::const_iterator it = threadStmtToTheadInterLeav.begin(), eit = threadStmtToTheadInterLeav.end(); it!=eit; ++it)
     {
-        outs() << "( t" << it->first.getTid() << " , $" << SVFUtil::getSourceLoc(it->first.getStmt()) << "$" << *(it->first.getStmt()) << " ) ==> [";
+        // TODO-os outs() << "( t" << it->first.getTid() << " , $" << SVFUtil::getSourceLoc(it->first.getStmt()) << "$" << *(it->first.getStmt()) << " ) ==> [";
         for (NodeBS::iterator ii = it->second.begin(), ie = it->second.end();
                 ii != ie; ii++)
         {
@@ -886,7 +886,7 @@ void ForkJoinAnalysis::handleJoin(const CxtStmt& cts, NodeID rootTid)
             {
                 markCxtStmtFlag(cts,TDDead);
                 addDirectlyJoinTID(cts,rootTid);
-                DBOUT(DMTA,outs() << "\n\t match join site " << *call <<  "for thread " << rootTid << "\n");
+                // TODO-os DBOUT(DMTA,outs() << "\n\t match join site " << *call <<  "for thread " << rootTid << "\n");
             }
         }
         /// for the join site in a loop loop which does not join the current thread

--- a/lib/MTA/MHP.cpp
+++ b/lib/MTA/MHP.cpp
@@ -294,7 +294,7 @@ void MHP::handleJoin(const CxtThreadStmt& cts, NodeID rootTid)
         else
         {
             rmInterleavingThread(cts,joinedTids,call);
-            // TODO-os DBOUT(DMTA,outs() << "\n\t match join site " << *call <<  " for thread " << rootTid << "\n");
+            DBOUT(DMTA,outs() << "\n\t match join site " << SVFUtil::value2String(call) <<  " for thread " << rootTid << "\n");
         }
     }
     /// for the join site in a loop loop which does not join the current thread
@@ -689,7 +689,7 @@ void MHP::printInterleaving()
 {
     for(ThreadStmtToThreadInterleav::const_iterator it = threadStmtToTheadInterLeav.begin(), eit = threadStmtToTheadInterLeav.end(); it!=eit; ++it)
     {
-        // TODO-os outs() << "( t" << it->first.getTid() << " , $" << SVFUtil::getSourceLoc(it->first.getStmt()) << "$" << *(it->first.getStmt()) << " ) ==> [";
+        outs() << "( t" << it->first.getTid() << " , $" << SVFUtil::getSourceLoc(it->first.getStmt()) << "$" << SVFUtil::value2String(it->first.getStmt()) << " ) ==> [";
         for (NodeBS::iterator ii = it->second.begin(), ie = it->second.end();
                 ii != ie; ii++)
         {
@@ -886,7 +886,7 @@ void ForkJoinAnalysis::handleJoin(const CxtStmt& cts, NodeID rootTid)
             {
                 markCxtStmtFlag(cts,TDDead);
                 addDirectlyJoinTID(cts,rootTid);
-                // TODO-os DBOUT(DMTA,outs() << "\n\t match join site " << *call <<  "for thread " << rootTid << "\n");
+                DBOUT(DMTA,outs() << "\n\t match join site " << SVFUtil::value2String(call) <<  "for thread " << rootTid << "\n");
             }
         }
         /// for the join site in a loop loop which does not join the current thread

--- a/lib/MTA/MTAStat.cpp
+++ b/lib/MTA/MTAStat.cpp
@@ -63,7 +63,7 @@ void MTAStat::performThreadCallGraphStat(ThreadCallGraph* tcg)
     PTNumStatMap["NumOfIndForkEdge"] = numOfIndForkEdge;
     PTNumStatMap["NumOfIndCallEdge"] = tcg->getNumOfResolvedIndCallEdge();
 
-    std::cout << "\n****Thread Call Graph Statistics****\n";
+    SVFUtil::outs() << "\n****Thread Call Graph Statistics****\n";
     PTAStat::printStat();
 }
 
@@ -79,7 +79,7 @@ void MTAStat::performTCTStat(TCT* tct)
     PTNumStatMap["NumOfTCTEdge"] = tct->getTCTEdgeNum();
     PTNumStatMap["MaxCxtSize"] = tct->getMaxCxtSize();
     timeStatMap["BuildingTCTTime"] = TCTTime;
-    std::cout << "\n****Thread Creation Tree Statistics****\n";
+    SVFUtil::outs() << "\n****Thread Creation Tree Statistics****\n";
     PTAStat::printStat();
 }
 
@@ -148,7 +148,7 @@ void MTAStat::performMHPPairStat(MHP* mhp, LockAnalysis* lsa)
     timeStatMap["MHPAnalysisTime"] = MHPTime;
     timeStatMap["MFSPTATime"] = FSMPTATime;
 
-    std::cout << "\n****MHP Stmt Pairs Statistics****\n";
+    SVFUtil::outs() << "\n****MHP Stmt Pairs Statistics****\n";
     PTAStat::printStat();
 }
 
@@ -169,7 +169,7 @@ void MTAStat::performAnnotationStat(MTAAnnotator* anno)
     PTNumStatMap["NumOfAnnotatedLoad"] = anno->numOfAnnotatedLd;
     timeStatMap["AnnotationTime"] = AnnotationTime;
 
-    std::cout << "\n****Annotation Statistics****\n";
+    SVFUtil::outs() << "\n****Annotation Statistics****\n";
     PTAStat::printStat();
 }
 

--- a/lib/MTA/PCG.cpp
+++ b/lib/MTA/PCG.cpp
@@ -86,7 +86,7 @@ void PCG::initFromThreadAPI(SVFModule* module)
                 else
                 {
                     writeWrnMsg("pthread create");
-                    // TODO-os outs() << *inst << "\n";
+                    outs() << SVFUtil::value2String(inst) << "\n";
                     writeWrnMsg("invoke spawnee indirectly");
                 }
             }

--- a/lib/MTA/PCG.cpp
+++ b/lib/MTA/PCG.cpp
@@ -86,7 +86,7 @@ void PCG::initFromThreadAPI(SVFModule* module)
                 else
                 {
                     writeWrnMsg("pthread create");
-                    outs() << *inst << "\n";
+                    // TODO-os outs() << *inst << "\n";
                     writeWrnMsg("invoke spawnee indirectly");
                 }
             }
@@ -334,6 +334,6 @@ void PCG::printTDFuns()
         std::string isSpawner = isSpawnerFun(fun) ? " SPAWNER " : "";
         std::string isSpawnee = isSpawneeFun(fun) ? " CHILDREN " : "";
         std::string isFollower = isFollowerFun(fun) ? " FOLLOWER " : "";
-        outs() << fun->getName() << " [" << isSpawner << isSpawnee << isFollower << "]\n";
+        outs() << fun->getName().str() << " [" << isSpawner << isSpawnee << isFollower << "]\n";
     }
 }

--- a/lib/MemoryModel/LocationSet.cpp
+++ b/lib/MemoryModel/LocationSet.cpp
@@ -74,7 +74,7 @@ u32_t LocationSet::getElementNum(const Type* type) const{
             return 1;
     }
     else{
-        SVFUtil::outs() << "GepIter Type" << *type << "\n";
+        // TODO-os SVFUtil::outs() << "GepIter Type" << *type << "\n";
         assert(false && "What other types for this gep?");
         abort();
     }

--- a/lib/MemoryModel/LocationSet.cpp
+++ b/lib/MemoryModel/LocationSet.cpp
@@ -74,7 +74,7 @@ u32_t LocationSet::getElementNum(const Type* type) const{
             return 1;
     }
     else{
-        // TODO-os SVFUtil::outs() << "GepIter Type" << *type << "\n";
+        SVFUtil::outs() << "GepIter Type" << type2String(type) << "\n";
         assert(false && "What other types for this gep?");
         abort();
     }

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -343,7 +343,7 @@ void PointerAnalysis::printIndCSTargets(const CallICFGNode* cs, const FunctionSe
 {
     outs() << "\nNodeID: " << getFunPtr(cs);
     outs() << "\nCallSite: ";
-    // TODO-os cs->getCallSite()->print(outs());
+    outs() << SVFUtil::value2String(cs->getCallSite());
     outs() << "\tLocation: " << SVFUtil::getSourceLoc(cs->getCallSite());
     outs() << "\t with Targets: ";
 
@@ -391,7 +391,7 @@ void PointerAnalysis::printIndCSTargets()
         {
             outs() << "\nNodeID: " << csIt->second;
             outs() << "\nCallSite: ";
-            // TODO-os cs->getCallSite()->print(outs());
+            outs() << SVFUtil::value2String(cs->getCallSite());
             outs() << "\tLocation: " << SVFUtil::getSourceLoc(cs->getCallSite());
             outs() << "\n\t!!!has no targets!!!\n";
         }

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -266,7 +266,7 @@ void PointerAnalysis::dumpAllTypes()
         if (SVFUtil::isa<DummyObjVar>(node) || SVFUtil::isa<DummyValVar>(node))
             continue;
 
-        outs() << "##<" << node->getValue()->getName() << "> ";
+        outs() << "##<" << node->getValue()->getName().str() << "> ";
         outs() << "Source Loc: " << getSourceLoc(node->getValue());
         outs() << "\nNodeID " << node->getId() << "\n";
 
@@ -291,7 +291,7 @@ void PointerAnalysis::dumpPts(NodeID ptr, const PointsTo& pts)
     }
     else if (!SVFUtil::isa<DummyValVar>(node) && !SVFModule::pagReadFromTXT()) {
 		if (node->hasValue()) {
-			outs() << "##<" << node->getValue()->getName() << "> ";
+			outs() << "##<" << node->getValue()->getName().str() << "> ";
 			outs() << "Source Loc: " << getSourceLoc(node->getValue());
 		}
 	}
@@ -327,7 +327,7 @@ void PointerAnalysis::dumpPts(NodeID ptr, const PointsTo& pts)
 		else {
 			if (!SVFModule::pagReadFromTXT()) {
 				if (node->hasValue()) {
-					outs() << "<" << pagNode->getValue()->getName() << "> ";
+					outs() << "<" << pagNode->getValue()->getName().str() << "> ";
 					outs() << "Source Loc: "
 							<< getSourceLoc(pagNode->getValue()) << "] \n";
 				}
@@ -343,7 +343,7 @@ void PointerAnalysis::printIndCSTargets(const CallICFGNode* cs, const FunctionSe
 {
     outs() << "\nNodeID: " << getFunPtr(cs);
     outs() << "\nCallSite: ";
-    cs->getCallSite()->print(outs());
+    // TODO-os cs->getCallSite()->print(outs());
     outs() << "\tLocation: " << SVFUtil::getSourceLoc(cs->getCallSite());
     outs() << "\t with Targets: ";
 
@@ -391,7 +391,7 @@ void PointerAnalysis::printIndCSTargets()
         {
             outs() << "\nNodeID: " << csIt->second;
             outs() << "\nCallSite: ";
-            cs->getCallSite()->print(outs());
+            // TODO-os cs->getCallSite()->print(outs());
             outs() << "\tLocation: " << SVFUtil::getSourceLoc(cs->getCallSite());
             outs() << "\n\t!!!has no targets!!!\n";
         }
@@ -403,7 +403,7 @@ void PointerAnalysis::printIndCSTargets()
 /*!
  * Resolve indirect calls
  */
-void PointerAnalysis::resolveIndCalls(const CallICFGNode* cs, const PointsTo& target, CallEdgeMap& newEdges, LLVMCallGraph*)
+void PointerAnalysis::resolveIndCalls(const CallICFGNode* cs, const PointsTo& target, CallEdgeMap& newEdges)
 {
 
     assert(pag->isIndirectCallSites(cs) && "not an indirect callsite?");
@@ -559,24 +559,24 @@ void PointerAnalysis::validateSuccessTests(std::string fun)
                 bool checkSuccessful = false;
                 if (fun == aliasTestMayAlias || fun == aliasTestMayAliasMangled)
                 {
-                    if (aliasRes == llvm::AliasResult::MayAlias || aliasRes == llvm::AliasResult::MustAlias)
+                    if (aliasRes == AliasResult::MayAlias || aliasRes == AliasResult::MustAlias)
                         checkSuccessful = true;
                 }
                 else if (fun == aliasTestNoAlias || fun == aliasTestNoAliasMangled)
                 {
-                    if (aliasRes == llvm::AliasResult::NoAlias)
+                    if (aliasRes == AliasResult::NoAlias)
                         checkSuccessful = true;
                 }
                 else if (fun == aliasTestMustAlias || fun == aliasTestMustAliasMangled)
                 {
                     // change to must alias when our analysis support it
-                    if (aliasRes == llvm::AliasResult::MayAlias || aliasRes == llvm::AliasResult::MustAlias)
+                    if (aliasRes == AliasResult::MayAlias || aliasRes == AliasResult::MustAlias)
                         checkSuccessful = true;
                 }
                 else if (fun == aliasTestPartialAlias || fun == aliasTestPartialAliasMangled)
                 {
                     // change to partial alias when our analysis support it
-                    if (aliasRes == llvm::AliasResult::MayAlias)
+                    if (aliasRes == AliasResult::MayAlias)
                         checkSuccessful = true;
                 }
                 else
@@ -627,13 +627,13 @@ void PointerAnalysis::validateExpectedFailureTests(std::string fun)
                 if (fun == aliasTestFailMayAlias || fun == aliasTestFailMayAliasMangled)
                 {
                     // change to must alias when our analysis support it
-                    if (aliasRes == llvm::AliasResult::NoAlias)
+                    if (aliasRes == AliasResult::NoAlias)
                         expectedFailure = true;
                 }
                 else if (fun == aliasTestFailNoAlias || fun == aliasTestFailNoAliasMangled)
                 {
                     // change to partial alias when our analysis support it
-                    if (aliasRes == llvm::AliasResult::MayAlias || aliasRes == llvm::AliasResult::PartialAlias || aliasRes == llvm::AliasResult::MustAlias)
+                    if (aliasRes == AliasResult::MayAlias || aliasRes == AliasResult::PartialAlias || aliasRes == AliasResult::MustAlias)
                         expectedFailure = true;
                 }
                 else

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -484,7 +484,7 @@ AliasResult BVDataPTAImpl::alias(const PointsTo& p1, const PointsTo& p2)
     expandFIObjs(p2,pts2);
 
     if (containBlackHoleNode(pts1) || containBlackHoleNode(pts2) || pts1.intersects(pts2))
-        return llvm::AliasResult::MayAlias;
+        return AliasResult::MayAlias;
     else
-        return llvm::AliasResult::NoAlias;
+        return AliasResult::NoAlias;
 }

--- a/lib/MemoryModel/SymbolTableInfo.cpp
+++ b/lib/MemoryModel/SymbolTableInfo.cpp
@@ -460,7 +460,7 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     if(const ArrayType *at = SVFUtil::dyn_cast<ArrayType> (type))
     {
         outs() <<"  {Type: ";
-        // TODO-os at->print(outs());
+        outs() << type2String(at);
         outs() << "}\n";
         outs() << "\tarray type ";
         outs() << "\t [element size = " << getNumOfFlattenElements(at) << "]\n";
@@ -470,7 +470,7 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     else if(const StructType *st = SVFUtil::dyn_cast<StructType> (type))
     {
         outs() <<"  {Type: ";
-        // TODO-os st->print(outs());
+        outs() << type2String(st);
         outs() << "}\n";
         std::vector<const Type*>& finfo = getStructInfo(st)->getFlattenFieldTypes();
         int field_idx = 0;
@@ -479,7 +479,7 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
         {
             outs() << " \tField_idx = " << field_idx;
             outs() << ", field type: ";
-            // TODO-os (*it)->print(outs());
+            outs() << type2String(*it);
             outs() << "\n";
         }
         outs() << "\n";
@@ -489,7 +489,7 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     {
         u32_t eSize = getNumOfFlattenElements(pt->getElementType());
         outs() << "  {Type: ";
-        // TODO-os pt->print(outs());
+        outs() << type2String(pt);
         outs() << "}\n";
         outs() <<"\t [target size = " << eSize << "]\n";
         outs() << "\n";
@@ -498,7 +498,7 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     else if ( const FunctionType* fu= SVFUtil::dyn_cast<FunctionType> (type))
     {
         outs() << "  {Type: ";
-        // TODO-os fu->getReturnType()->print(outs());
+        outs() << type2String(fu->getReturnType());
         outs() << "(Function)}\n\n";
     }
 
@@ -508,7 +508,7 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
         /// All rest types are scalar type?
         u32_t eSize = getNumOfFlattenElements(type);
         outs() <<"  {Type: ";
-        // TODO-os type->print(outs());
+        outs() << type2String(type);
         outs() << "}\n";
         outs() <<"\t [object size = " << eSize << "]\n";
         outs() << "\n";

--- a/lib/MemoryModel/SymbolTableInfo.cpp
+++ b/lib/MemoryModel/SymbolTableInfo.cpp
@@ -450,17 +450,17 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     if(const ArrayType *at = SVFUtil::dyn_cast<ArrayType> (type))
     {
         outs() <<"  {Type: ";
-        at->print(outs());
+        // TODO-os at->print(outs());
         outs() << "}\n";
         outs() << "\tarray type ";
-        outs() << "\t [element size = " << getTypeSizeInBytes(at->getElementType()) << "]\n";
+        outs() << "\t [element size = " << getNumOfFlattenElements(at) << "]\n";
         outs() << "\n";
     }
 
     else if(const StructType *st = SVFUtil::dyn_cast<StructType> (type))
     {
         outs() <<"  {Type: ";
-        st->print(outs());
+        // TODO-os st->print(outs());
         outs() << "}\n";
         std::vector<FlattenedFieldInfo>& finfo = getStructInfo(st)->getFlattenedFieldInfoVec();
         int field_idx = 0;
@@ -469,8 +469,8 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
         {
             outs() << " \tField_idx = " << (*it).getFlattenFldIdx();
             outs() << ", field type: ";
-            (*it).getFlattenElemTy()->print(outs());
-            outs() << ", field size: " << getTypeSizeInBytes((*it).getFlattenElemTy());
+            // TODO-os (*it).getFlattenElemTy()->print(outs());
+            outs() << ", field size: " << getNumOfFlattenElements((*it).getFlattenElemTy());
             outs() << "\n";
         }
         outs() << "\n";
@@ -478,12 +478,10 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
 
     else if (const PointerType* pt= SVFUtil::dyn_cast<PointerType> (type))
     {
-        u32_t sizeInBits = getTypeSizeInBytes(type);
-        u32_t eSize = getTypeSizeInBytes(pt->getElementType());
+        u32_t eSize = getNumOfFlattenElements(pt->getElementType());
         outs() << "  {Type: ";
-        pt->print(outs());
+        // TODO-os pt->print(outs());
         outs() << "}\n";
-        outs() <<"\t [pointer size = " << sizeInBits << "]";
         outs() <<"\t [target size = " << eSize << "]\n";
         outs() << "\n";
     }
@@ -491,7 +489,7 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     else if ( const FunctionType* fu= SVFUtil::dyn_cast<FunctionType> (type))
     {
         outs() << "  {Type: ";
-        fu->getReturnType()->print(outs());
+        // TODO-os fu->getReturnType()->print(outs());
         outs() << "(Function)}\n\n";
     }
 
@@ -499,9 +497,9 @@ void SymbolTableInfo::printFlattenFields(const Type* type)
     {
         assert(type->isSingleValueType() && "not a single value type, then what else!!");
         /// All rest types are scalar type?
-        u32_t eSize = getTypeSizeInBytes(type);
+        u32_t eSize = getNumOfFlattenElements(type);
         outs() <<"  {Type: ";
-        type->print(outs());
+        // TODO-os type->print(outs());
         outs() << "}\n";
         outs() <<"\t [object size = " << eSize << "]\n";
         outs() << "\n";
@@ -583,31 +581,6 @@ void SymbolTableInfo::dump()
     }
     outs() << "}\n";
 }
-
-/*
- * Get the type size given a target data layout
- */
-u32_t SymbolTableInfo::getTypeSizeInBytes(const Type* type)
-{
-
-    // if the type has size then simply return it, otherwise just return 0
-    if(type->isSized())
-        return  getDataLayout(LLVMModuleSet::getLLVMModuleSet()->getMainLLVMModule())->getTypeStoreSize(const_cast<Type*>(type));
-    else
-        return 0;
-}
-
-u32_t SymbolTableInfo::getTypeSizeInBytes(const StructType *sty, u32_t field_idx)
-{
-
-    const StructLayout *stTySL = getDataLayout(LLVMModuleSet::getLLVMModuleSet()->getMainLLVMModule())->getStructLayout( const_cast<StructType *>(sty) );
-    /// if this struct type does not have any element, i.e., opaque
-    if(sty->isOpaque())
-        return 0;
-    else
-        return stTySL->getElementOffset(field_idx);
-}
-
 
 /*!
  * Whether a location set is a pointer type or not

--- a/lib/SABER/LeakChecker.cpp
+++ b/lib/SABER/LeakChecker.cpp
@@ -223,17 +223,19 @@ void LeakChecker::validateSuccessTests(const SVFGNode* source, const SVFFunction
         return;
     }
 
-    std::string funName = source->getFun()->getName().str();
+    std::string funName = source->getFun()->getName();
 
     if (success)
-        outs() << sucMsg("\t SUCCESS :") << funName << " check <src id:" << source->getId()
-               << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
-               << getSourceLoc(cs->getCallSite()) << ")\n";
+    {
+        // TODO-os outs() << sucMsg("\t SUCCESS :") << funName << " check <src id:" << source->getId()
+        // TODO-os        << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
+        // TODO-os        << getSourceLoc(cs->getCallSite()) << ")\n";
+    }
     else
     {
-        SVFUtil::errs() << errMsg("\t FAILURE :") << funName << " check <src id:" << source->getId()
-                        << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
-                        << getSourceLoc(cs->getCallSite()) << ")\n";
+        // TODO-os SVFUtil::errs() << errMsg("\t FAILURE :") << funName << " check <src id:" << source->getId()
+        // TODO-os                 << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
+        // TODO-os                 << getSourceLoc(cs->getCallSite()) << ")\n";
         assert(false && "test case failed!");
     }
 }
@@ -271,18 +273,20 @@ void LeakChecker::validateExpectedFailureTests(const SVFGNode* source, const SVF
         return;
     }
 
-    std::string funName = source->getFun()->getName().str();
+    std::string funName = source->getFun()->getName();
 
     if (expectedFailure)
-        outs() << sucMsg("\t EXPECTED-FAILURE :") << funName << " check <src id:" << source->getId()
-               << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
-               << getSourceLoc(cs->getCallSite()) << ")\n";
+    {
+        // TODO-os outs() << sucMsg("\t EXPECTED-FAILURE :") << funName << " check <src id:" << source->getId()
+        // TODO-os        << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
+        // TODO-os        << getSourceLoc(cs->getCallSite()) << ")\n";
+    }
     else
     {
-        SVFUtil::errs() << errMsg("\t UNEXPECTED FAILURE :") << funName
-                        << " check <src id:" << source->getId()
-                        << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
-                        << getSourceLoc(cs->getCallSite()) << ")\n";
+        // TODO-os SVFUtil::errs() << errMsg("\t UNEXPECTED FAILURE :") << funName
+        // TODO-os                 << " check <src id:" << source->getId()
+        // TODO-os                 << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
+        // TODO-os                 << getSourceLoc(cs->getCallSite()) << ")\n";
         assert(false && "test case failed!");
     }
 }

--- a/lib/SABER/LeakChecker.cpp
+++ b/lib/SABER/LeakChecker.cpp
@@ -227,15 +227,15 @@ void LeakChecker::validateSuccessTests(const SVFGNode* source, const SVFFunction
 
     if (success)
     {
-        // TODO-os outs() << sucMsg("\t SUCCESS :") << funName << " check <src id:" << source->getId()
-        // TODO-os        << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
-        // TODO-os        << getSourceLoc(cs->getCallSite()) << ")\n";
+        outs() << sucMsg("\t SUCCESS :") << funName << " check <src id:" << source->getId()
+               << ", cs id:" << SVFUtil::value2String(getSrcCSID(source)->getCallSite()) << "> at ("
+               << getSourceLoc(cs->getCallSite()) << ")\n";
     }
     else
     {
-        // TODO-os SVFUtil::errs() << errMsg("\t FAILURE :") << funName << " check <src id:" << source->getId()
-        // TODO-os                 << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
-        // TODO-os                 << getSourceLoc(cs->getCallSite()) << ")\n";
+        SVFUtil::errs() << errMsg("\t FAILURE :") << funName << " check <src id:" << source->getId()
+                        << ", cs id:" << SVFUtil::value2String(getSrcCSID(source)->getCallSite()) << "> at ("
+                        << getSourceLoc(cs->getCallSite()) << ")\n";
         assert(false && "test case failed!");
     }
 }
@@ -277,16 +277,16 @@ void LeakChecker::validateExpectedFailureTests(const SVFGNode* source, const SVF
 
     if (expectedFailure)
     {
-        // TODO-os outs() << sucMsg("\t EXPECTED-FAILURE :") << funName << " check <src id:" << source->getId()
-        // TODO-os        << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
-        // TODO-os        << getSourceLoc(cs->getCallSite()) << ")\n";
+        outs() << sucMsg("\t EXPECTED-FAILURE :") << funName << " check <src id:" << source->getId()
+               << ", cs id:" << SVFUtil::value2String(getSrcCSID(source)->getCallSite()) << "> at ("
+               << getSourceLoc(cs->getCallSite()) << ")\n";
     }
     else
     {
-        // TODO-os SVFUtil::errs() << errMsg("\t UNEXPECTED FAILURE :") << funName
-        // TODO-os                 << " check <src id:" << source->getId()
-        // TODO-os                 << ", cs id:" << *getSrcCSID(source)->getCallSite() << "> at ("
-        // TODO-os                 << getSourceLoc(cs->getCallSite()) << ")\n";
+        SVFUtil::errs() << errMsg("\t UNEXPECTED FAILURE :") << funName
+                        << " check <src id:" << source->getId()
+                        << ", cs id:" << SVFUtil::value2String(getSrcCSID(source)->getCallSite()) << "> at ("
+                        << getSourceLoc(cs->getCallSite()) << ")\n";
         assert(false && "test case failed!");
     }
 }

--- a/lib/SABER/PathCondAllocator.cpp
+++ b/lib/SABER/PathCondAllocator.cpp
@@ -513,16 +513,16 @@ PathCondAllocator::Condition* PathCondAllocator::ComputeIntraVFGGuard(const Basi
             else
                 brCond = getEvalBrCond(bb, succ);
 
-            DBOUT(DSaber, outs() << " bb (" << bb->getName() <<
-                                 ") --> " << "succ_bb (" << succ->getName() << ") condition: " << brCond << "\n");
+            DBOUT(DSaber, outs() << " bb (" << bb->getName().str() <<
+                                 ") --> " << "succ_bb (" << succ->getName().str() << ") condition: " << brCond << "\n");
             Condition* succPathCond = condAnd(cond, brCond);
             if(setCFCond(succ, condOr(getCFCond(succ), succPathCond)))
                 worklist.push(succ);
         }
     }
 
-    DBOUT(DSaber, outs() << " src_bb (" << srcBB->getName() <<
-                         ") --> " << "dst_bb (" << dstBB->getName() << ") condition: " << getCFCond(dstBB) << "\n");
+    DBOUT(DSaber, outs() << " src_bb (" << srcBB->getName().str() <<
+                         ") --> " << "dst_bb (" << dstBB->getName().str() << ") condition: " << getCFCond(dstBB) << "\n");
 
     return getCFCond(dstBB);
 }
@@ -547,7 +547,7 @@ void PathCondAllocator::printPathCond()
                 if (i == cit.first)
                 {
                     Condition* cond = cit.second;
-                    outs() << bb->getName() << "-->" << succ->getName() << ":";
+                    outs() << bb->getName().str() << "-->" << succ->getName().str() << ":";
                     outs() << dumpCond(cond) << "\n";
                     break;
                 }

--- a/lib/SVF-FE/BreakConstantExpr.cpp
+++ b/lib/SVF-FE/BreakConstantExpr.cpp
@@ -65,11 +65,6 @@ char MergeFunctionRets::ID = 0;
 STATISTIC (GEPChanges,   "Number of Converted GEP Constant Expressions");
 STATISTIC (TotalChanges, "Number of Converted Constant Expressions");
 
-// Register the pass
-static llvm::RegisterPass<BreakConstantGEPs> BP ("break-constgeps",
-        "Remove GEP Constant Expressions");
-static llvm::RegisterPass<MergeFunctionRets> MP ("merge-rets",
-        "Merge function rets into one");
 //
 // Function: hasConstantGEP()
 //

--- a/lib/SVF-FE/CHGBuilder.cpp
+++ b/lib/SVF-FE/CHGBuilder.cpp
@@ -192,7 +192,7 @@ void CHGBuilder::connectInheritEdgeViaCall(const SVFFunction* callerfun, CallSit
 
 void CHGBuilder::connectInheritEdgeViaStore(const SVFFunction* caller, const StoreInst* storeInst)
 {
-    struct DemangledName dname = demangle(caller->getName().str());
+    struct DemangledName dname = demangle(caller->getName());
     if (const ConstantExpr *ce = SVFUtil::dyn_cast<ConstantExpr>(storeInst->getValueOperand()))
     {
         if (ce->getOpcode() == Instruction::BitCast)
@@ -459,7 +459,7 @@ void CHGBuilder::analyzeVTables(const Module &M)
                             {
                                 const SVFFunction* func = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(f);
                                 addFuncToFuncVector(virtualFunctions, func);
-                                if (func->getName().str().compare(pureVirtualFunName) == 0)
+                                if (func->getName().compare(pureVirtualFunName) == 0)
                                 {
                                     pure_abstract &= true;
                                 }
@@ -467,7 +467,7 @@ void CHGBuilder::analyzeVTables(const Module &M)
                                 {
                                     pure_abstract &= false;
                                 }
-                                struct DemangledName dname = demangle(func->getName().str());
+                                struct DemangledName dname = demangle(func->getName());
                                 if (dname.className.size() > 0 &&
                                         vtblClassName.compare(dname.className) != 0)
                                 {
@@ -625,7 +625,7 @@ void CHGBuilder::buildVirtualFunctionToIDMap()
                 feit = virtualFunctions.end(); fit != feit; ++fit)
         {
             const SVFFunction* f = *fit;
-            struct DemangledName dname = demangle(f->getName().str());
+            struct DemangledName dname = demangle(f->getName());
             fNameSet.insert(pair<string, const SVFFunction*>(dname.funcName, f));
         }
         for (set<pair<string, const SVFFunction*>>::iterator it = fNameSet.begin(),

--- a/lib/SVF-FE/CPPUtil.cpp
+++ b/lib/SVF-FE/CPPUtil.cpp
@@ -343,11 +343,11 @@ bool cppUtil::isSameThisPtrInConstructor(const Argument* thisPtr1, const Value* 
     }
     else
     {
-        for (const User *thisU : thisPtr1->users())
+        for (const Value *thisU : thisPtr1->users())
         {
             if (const StoreInst *store = SVFUtil::dyn_cast<StoreInst>(thisU))
             {
-                for (const User *storeU : store->getPointerOperand()->users())
+                for (const Value *storeU : store->getPointerOperand()->users())
                 {
                     if (const LoadInst *load = SVFUtil::dyn_cast<LoadInst>(storeU))
                     {

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -185,7 +185,7 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
         if (mod == nullptr)
         {
             SVFUtil::errs() << "load module: " << moduleName << "failed!!\n\n";
-            // TODO-os Err.print("SVFModuleLoader", SVFUtil::errs());
+            Err.print("SVFModuleLoader", llvm::errs());
             continue;
         }
         modules.emplace_back(*mod);

--- a/lib/SVF-FE/LLVMModule.cpp
+++ b/lib/SVF-FE/LLVMModule.cpp
@@ -31,6 +31,7 @@
 #include <queue>
 #include "Util/SVFModule.h"
 #include "Util/SVFUtil.h"
+#include "SVF-FE/BasicTypes.h"
 #include "SVF-FE/LLVMUtil.h"
 #include "SVF-FE/BreakConstantExpr.h"
 
@@ -184,7 +185,7 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
         if (mod == nullptr)
         {
             SVFUtil::errs() << "load module: " << moduleName << "failed!!\n\n";
-            Err.print("SVFModuleLoader", SVFUtil::errs());
+            // TODO-os Err.print("SVFModuleLoader", SVFUtil::errs());
             continue;
         }
         modules.emplace_back(*mod);

--- a/lib/SVF-FE/LLVMUtil.cpp
+++ b/lib/SVF-FE/LLVMUtil.cpp
@@ -414,3 +414,12 @@ u32_t SVFUtil::getTypeSizeInBytes(const StructType *sty, u32_t field_idx)
     else
         return stTySL->getElementOffset(field_idx);
 }
+
+const std::string SVFUtil::type2String(const Type* type)
+{
+    std::string str;
+    llvm::raw_string_ostream rawstr(str);
+    assert(type != nullptr && "Given null type!");
+    rawstr << *type;
+    return rawstr.str();
+}

--- a/lib/SVF-FE/LLVMUtil.cpp
+++ b/lib/SVF-FE/LLVMUtil.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "SVF-FE/LLVMUtil.h"
+#include "MemoryModel/SymbolTableInfo.h"
 
 using namespace SVF;
 
@@ -393,3 +394,23 @@ void SVFUtil::processArguments(int argc, char **argv, int &arg_num, char **arg_v
     }
 }
 
+u32_t SVFUtil::getTypeSizeInBytes(const Type* type)
+{
+
+    // if the type has size then simply return it, otherwise just return 0
+    if(type->isSized())
+        return SymbolTableInfo::getDataLayout(LLVMModuleSet::getLLVMModuleSet()->getMainLLVMModule())->getTypeStoreSize(const_cast<Type*>(type));
+    else
+        return 0;
+}
+
+u32_t SVFUtil::getTypeSizeInBytes(const StructType *sty, u32_t field_idx)
+{
+
+    const StructLayout *stTySL = SymbolTableInfo::getDataLayout(LLVMModuleSet::getLLVMModuleSet()->getMainLLVMModule())->getStructLayout( const_cast<StructType *>(sty) );
+    /// if this struct type does not have any element, i.e., opaque
+    if(sty->isOpaque())
+        return 0;
+    else
+        return stTySL->getElementOffset(field_idx);
+}

--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -30,6 +30,7 @@
 #include "SVF-FE/SVFIRBuilder.h"
 #include "Util/SVFModule.h"
 #include "Util/SVFUtil.h"
+#include "SVF-FE/BasicTypes.h"
 #include "SVF-FE/LLVMUtil.h"
 #include "SVF-FE/CPPUtil.h"
 #include "Util/BasicTypes.h"
@@ -324,8 +325,7 @@ void SVFIRBuilder::processCE(const Value *val)
     {
         if (const ConstantExpr* gepce = isGepConstantExpr(ref))
         {
-            DBOUT(DPAGBuild,
-                  outs() << "handle gep constant expression " << *ref << "\n");
+            DBOUT(DPAGBuild, outs() << "handle gep constant expression " << SVFUtil::value2String(ref) << "\n");
             const Constant* opnd = gepce->getOperand(0);
             // handle recursive constant express case (gep (bitcast (gep X 1)) 1)
             processCE(opnd);
@@ -344,8 +344,7 @@ void SVFIRBuilder::processCE(const Value *val)
         }
         else if (const ConstantExpr* castce = isCastConstantExpr(ref))
         {
-            DBOUT(DPAGBuild,
-                  outs() << "handle cast constant expression " << *ref << "\n");
+            DBOUT(DPAGBuild, outs() << "handle cast constant expression " << SVFUtil::value2String(ref) << "\n");
             const Constant* opnd = castce->getOperand(0);
             processCE(opnd);
             const Value* cval = getCurrentValue();
@@ -356,8 +355,7 @@ void SVFIRBuilder::processCE(const Value *val)
         }
         else if (const ConstantExpr* selectce = isSelectConstantExpr(ref))
         {
-            DBOUT(DPAGBuild,
-                  outs() << "handle select constant expression " << *ref << "\n");
+            DBOUT(DPAGBuild, outs() << "handle select constant expression " << SVFUtil::value2String(ref) << "\n");
             const Constant* src1 = selectce->getOperand(1);
             const Constant* src2 = selectce->getOperand(2);
             processCE(src1);
@@ -477,10 +475,7 @@ NodeID SVFIRBuilder::getGlobalVarField(const GlobalVariable *gvar, u32_t offset)
 void SVFIRBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
                                u32_t offset)
 {
-    DBOUT(DPAGBuild,
-          outs() << "global " << *gvar << " constant initializer: " << *C
-          << "\n");
-
+    // TODO-os DBOUT(DPAGBuild, outs() << "global " << gvar << " constant initializer: " << *C << "\n"); 
     if (C->getType()->isSingleValueType())
     {
         NodeID src = getValueNode(C);
@@ -564,7 +559,7 @@ void SVFIRBuilder::visitGlobal(SVFModule* svfModule)
         if (gvar->hasInitializer())
         {
             Constant *C = gvar->getInitializer();
-            DBOUT(DPAGBuild, outs() << "add global var node " << *gvar << "\n");
+            DBOUT(DPAGBuild, outs() << "add global var node " << SVFUtil::value2String(gvar) << "\n");
             InitialGlobal(gvar, C, 0);
         }
     }
@@ -577,7 +572,7 @@ void SVFIRBuilder::visitGlobal(SVFModule* svfModule)
         NodeID idx = getValueNode(fun);
         NodeID obj = getObjectNode(fun);
 
-        DBOUT(DPAGBuild, outs() << "add global function node " << fun->getName() << "\n");
+        DBOUT(DPAGBuild, outs() << "add global function node " << fun->getName().str() << "\n");
         setCurrentLocation(fun, nullptr);
         addAddrEdge(obj, idx);
     }
@@ -603,7 +598,7 @@ void SVFIRBuilder::visitAllocaInst(AllocaInst &inst)
     // AllocaInst should always be a pointer type
     assert(SVFUtil::isa<PointerType>(inst.getType()));
 
-    DBOUT(DPAGBuild, outs() << "process alloca  " << inst << " \n");
+    // TODO-os DBOUT(DPAGBuild, outs() << "process alloca  " << inst << " \n");
     NodeID dst = getValueNode(&inst);
 
     NodeID src = getObjectNode(&inst);
@@ -618,7 +613,7 @@ void SVFIRBuilder::visitAllocaInst(AllocaInst &inst)
 void SVFIRBuilder::visitPHINode(PHINode &inst)
 {
 
-    DBOUT(DPAGBuild, outs() << "process phi " << inst << "  \n");
+    // TODO-os DBOUT(DPAGBuild, outs() << "process phi " << inst << "  \n");
 
     NodeID dst = getValueNode(&inst);
 
@@ -639,7 +634,7 @@ void SVFIRBuilder::visitPHINode(PHINode &inst)
  */
 void SVFIRBuilder::visitLoadInst(LoadInst &inst)
 {
-    DBOUT(DPAGBuild, outs() << "process load  " << inst << " \n");
+    // TODO-os DBOUT(DPAGBuild, outs() << "process load  " << inst << " \n");
 
     NodeID dst = getValueNode(&inst);
 
@@ -656,7 +651,7 @@ void SVFIRBuilder::visitStoreInst(StoreInst &inst)
     // StoreInst itself should always not be a pointer type
     assert(!SVFUtil::isa<PointerType>(inst.getType()));
 
-    DBOUT(DPAGBuild, outs() << "process store " << inst << " \n");
+    // TODO-os DBOUT(DPAGBuild, outs() << "process store " << inst << " \n");
 
     NodeID dst = getValueNode(inst.getPointerOperand());
 
@@ -683,7 +678,7 @@ void SVFIRBuilder::visitGetElementPtrInst(GetElementPtrInst &inst)
 
     assert(SVFUtil::isa<PointerType>(inst.getType()));
 
-    DBOUT(DPAGBuild, outs() << "process gep  " << inst << " \n");
+    // TODO-os DBOUT(DPAGBuild, outs() << "process gep  " << inst << " \n");
 
     NodeID src = getValueNode(inst.getPointerOperand());
 
@@ -698,7 +693,7 @@ void SVFIRBuilder::visitGetElementPtrInst(GetElementPtrInst &inst)
 void SVFIRBuilder::visitCastInst(CastInst &inst)
 {
 
-    DBOUT(DPAGBuild, outs() << "process cast  " << inst << " \n");
+    // TODO-os DBOUT(DPAGBuild, outs() << "process cast  " << inst << " \n");
     NodeID dst = getValueNode(&inst);
 
     if (SVFUtil::isa<IntToPtrInst>(&inst))
@@ -766,7 +761,7 @@ void SVFIRBuilder::visitCmpInst(CmpInst &inst)
 void SVFIRBuilder::visitSelectInst(SelectInst &inst)
 {
 
-    DBOUT(DPAGBuild, outs() << "process select  " << inst << " \n");
+    // TODO-os DBOUT(DPAGBuild, outs() << "process select  " << inst << " \n");
 
     NodeID dst = getValueNode(&inst);
     NodeID src1 = getValueNode(inst.getTrueValue());
@@ -786,8 +781,8 @@ void SVFIRBuilder::visitCallSite(CallSite cs)
     if(isIntrinsicInst(cs.getInstruction()))
         return;
 
-    DBOUT(DPAGBuild,
-          outs() << "process callsite " << *cs.getInstruction() << "\n");
+    // TODO-os DBOUT(DPAGBuild,
+    //      outs() << "process callsite " << *cs.getInstruction() << "\n");
 
     CallICFGNode* callBlockNode = pag->getICFG()->getCallICFGNode(cs.getInstruction());
     RetICFGNode* retBlockNode = pag->getICFG()->getRetICFGNode(cs.getInstruction());
@@ -831,7 +826,7 @@ void SVFIRBuilder::visitReturnInst(ReturnInst &inst)
     // ReturnInst itself should always not be a pointer type
     assert(!SVFUtil::isa<PointerType>(inst.getType()));
 
-    DBOUT(DPAGBuild, outs() << "process return  " << inst << " \n");
+    // TODO-os DBOUT(DPAGBuild, outs() << "process return  " << inst << " \n");
 
     if(Value *src = inst.getReturnValue())
     {
@@ -950,8 +945,8 @@ void SVFIRBuilder::handleDirectCall(CallSite cs, const SVFFunction *F)
 
     assert(F);
 
-    DBOUT(DPAGBuild,
-          outs() << "handle direct call " << *cs.getInstruction() << " callee " << *F << "\n");
+    // TODO-os DBOUT(DPAGBuild,
+    //       outs() << "handle direct call " << *cs.getInstruction() << " callee " << *F << "\n");
 
     //Only handle the ret.val. if it's used as a ptr.
     NodeID dstrec = getValueNode(cs.getInstruction());
@@ -978,7 +973,7 @@ void SVFIRBuilder::handleDirectCall(CallSite cs, const SVFFunction *F)
         }
         const Value *AA = *itA, *FA = &*itF; //current actual/formal arg
 
-        DBOUT(DPAGBuild, outs() << "process actual parm  " << *AA << " \n");
+        DBOUT(DPAGBuild, outs() << "process actual parm  " << SVFUtil::value2String(AA) << " \n");
 
         NodeID dstFA = getValueNode(FA);
         NodeID srcAA = getValueNode(AA);

--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -443,7 +443,7 @@ NodeID SVFIRBuilder::getGlobalVarField(const GlobalVariable *gvar, u32_t offset,
 void SVFIRBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
                                u32_t offset)
 {
-    // TODO-os DBOUT(DPAGBuild, outs() << "global " << gvar << " constant initializer: " << *C << "\n"); 
+    DBOUT(DPAGBuild, outs() << "global " << SVFUtil::value2String(gvar) << " constant initializer: " << SVFUtil::value2String(C) << "\n"); 
     if (C->getType()->isSingleValueType())
     {
         NodeID src = getValueNode(C);

--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -566,7 +566,7 @@ void SVFIRBuilder::visitAllocaInst(AllocaInst &inst)
     // AllocaInst should always be a pointer type
     assert(SVFUtil::isa<PointerType>(inst.getType()));
 
-    // TODO-os DBOUT(DPAGBuild, outs() << "process alloca  " << inst << " \n");
+    DBOUT(DPAGBuild, outs() << "process alloca  " << SVFUtil::value2String(&inst) << " \n");
     NodeID dst = getValueNode(&inst);
 
     NodeID src = getObjectNode(&inst);
@@ -581,7 +581,7 @@ void SVFIRBuilder::visitAllocaInst(AllocaInst &inst)
 void SVFIRBuilder::visitPHINode(PHINode &inst)
 {
 
-    // TODO-os DBOUT(DPAGBuild, outs() << "process phi " << inst << "  \n");
+    DBOUT(DPAGBuild, outs() << "process phi " << SVFUtil::value2String(&inst) << "  \n");
 
     NodeID dst = getValueNode(&inst);
 
@@ -602,7 +602,7 @@ void SVFIRBuilder::visitPHINode(PHINode &inst)
  */
 void SVFIRBuilder::visitLoadInst(LoadInst &inst)
 {
-    // TODO-os DBOUT(DPAGBuild, outs() << "process load  " << inst << " \n");
+    DBOUT(DPAGBuild, outs() << "process load  " << SVFUtil::value2String(&inst) << " \n");
 
     NodeID dst = getValueNode(&inst);
 
@@ -619,7 +619,7 @@ void SVFIRBuilder::visitStoreInst(StoreInst &inst)
     // StoreInst itself should always not be a pointer type
     assert(!SVFUtil::isa<PointerType>(inst.getType()));
 
-    // TODO-os DBOUT(DPAGBuild, outs() << "process store " << inst << " \n");
+    DBOUT(DPAGBuild, outs() << "process store " << SVFUtil::value2String(&inst) << " \n");
 
     NodeID dst = getValueNode(inst.getPointerOperand());
 
@@ -646,7 +646,7 @@ void SVFIRBuilder::visitGetElementPtrInst(GetElementPtrInst &inst)
 
     assert(SVFUtil::isa<PointerType>(inst.getType()));
 
-    // TODO-os DBOUT(DPAGBuild, outs() << "process gep  " << inst << " \n");
+    DBOUT(DPAGBuild, outs() << "process gep  " << SVFUtil::value2String(&inst) << " \n");
 
     NodeID src = getValueNode(inst.getPointerOperand());
 
@@ -661,7 +661,7 @@ void SVFIRBuilder::visitGetElementPtrInst(GetElementPtrInst &inst)
 void SVFIRBuilder::visitCastInst(CastInst &inst)
 {
 
-    // TODO-os DBOUT(DPAGBuild, outs() << "process cast  " << inst << " \n");
+    DBOUT(DPAGBuild, outs() << "process cast  " << SVFUtil::value2String(&inst) << " \n");
     NodeID dst = getValueNode(&inst);
 
     if (SVFUtil::isa<IntToPtrInst>(&inst))
@@ -729,7 +729,7 @@ void SVFIRBuilder::visitCmpInst(CmpInst &inst)
 void SVFIRBuilder::visitSelectInst(SelectInst &inst)
 {
 
-    // TODO-os DBOUT(DPAGBuild, outs() << "process select  " << inst << " \n");
+    DBOUT(DPAGBuild, outs() << "process select  " << SVFUtil::value2String(&inst) << " \n");
 
     NodeID dst = getValueNode(&inst);
     NodeID src1 = getValueNode(inst.getTrueValue());
@@ -749,8 +749,8 @@ void SVFIRBuilder::visitCallSite(CallSite cs)
     if(isIntrinsicInst(cs.getInstruction()))
         return;
 
-    // TODO-os DBOUT(DPAGBuild,
-    //      outs() << "process callsite " << *cs.getInstruction() << "\n");
+    DBOUT(DPAGBuild,
+          outs() << "process callsite " << SVFUtil::value2String(cs.getInstruction()) << "\n");
 
     CallICFGNode* callBlockNode = pag->getICFG()->getCallICFGNode(cs.getInstruction());
     RetICFGNode* retBlockNode = pag->getICFG()->getRetICFGNode(cs.getInstruction());
@@ -794,7 +794,7 @@ void SVFIRBuilder::visitReturnInst(ReturnInst &inst)
     // ReturnInst itself should always not be a pointer type
     assert(!SVFUtil::isa<PointerType>(inst.getType()));
 
-    // TODO-os DBOUT(DPAGBuild, outs() << "process return  " << inst << " \n");
+    DBOUT(DPAGBuild, outs() << "process return  " << SVFUtil::value2String(&inst) << " \n");
 
     if(Value *src = inst.getReturnValue())
     {
@@ -913,8 +913,8 @@ void SVFIRBuilder::handleDirectCall(CallSite cs, const SVFFunction *F)
 
     assert(F);
 
-    // TODO-os DBOUT(DPAGBuild,
-    //       outs() << "handle direct call " << *cs.getInstruction() << " callee " << *F << "\n");
+    DBOUT(DPAGBuild,
+           outs() << "handle direct call " << SVFUtil::value2String(cs.getInstruction()) << " callee " << *F << "\n");
 
     //Only handle the ret.val. if it's used as a ptr.
     NodeID dstrec = getValueNode(cs.getInstruction());

--- a/lib/SVF-FE/SymbolTableBuilder.cpp
+++ b/lib/SVF-FE/SymbolTableBuilder.cpp
@@ -34,6 +34,7 @@
 #include "Util/Options.h"
 #include "Util/SVFModule.h"
 #include "Util/SVFUtil.h"
+#include "SVF-FE/BasicTypes.h"
 #include "SVF-FE/LLVMUtil.h"
 #include "SVF-FE/CPPUtil.h"
 #include "SVF-FE/GEPTypeBridgeIterator.h" // include bridge_gep_iterator
@@ -202,7 +203,7 @@ void SymbolTableBuilder::collectSym(const Value *val)
 
     //TODO: filter the non-pointer type // if (!SVFUtil::isa<PointerType>(val->getType()))  return;
 
-    DBOUT(DMemModel, outs() << "collect sym from ##" << *val << " \n");
+    DBOUT(DMemModel, outs() << "collect sym from ##" << SVFUtil::value2String(val) << " \n");
 
     // special sym here
     if (symInfo->isNullPtrSym(val) || symInfo->isBlackholeSym(val))
@@ -316,7 +317,7 @@ void SymbolTableBuilder::handleCE(const Value *val)
         if (const ConstantExpr* ce = isGepConstantExpr(ref))
         {
             DBOUT(DMemModelCE,
-                  outs() << "handle constant expression " << *ref << "\n");
+                  outs() << "handle constant expression " << SVFUtil::value2String(ref) << "\n");
             collectVal(ce);
             collectVal(ce->getOperand(0));
             // handle the recursive constant express case
@@ -326,7 +327,7 @@ void SymbolTableBuilder::handleCE(const Value *val)
         else if (const ConstantExpr* ce = isCastConstantExpr(ref))
         {
             DBOUT(DMemModelCE,
-                  outs() << "handle constant expression " << *ref << "\n");
+                  outs() << "handle constant expression " << SVFUtil::value2String(ref) << "\n");
             collectVal(ce);
             collectVal(ce->getOperand(0));
             // handle the recursive constant express case
@@ -336,7 +337,7 @@ void SymbolTableBuilder::handleCE(const Value *val)
         else if (const ConstantExpr* ce = isSelectConstantExpr(ref))
         {
             DBOUT(DMemModelCE,
-                  outs() << "handle constant expression " << *ref << "\n");
+                  outs() << "handle constant expression " << SVFUtil::value2String(ref) << "\n");
             collectVal(ce);
             collectVal(ce->getOperand(0));
             collectVal(ce->getOperand(1));

--- a/lib/Util/Conditions.cpp
+++ b/lib/Util/Conditions.cpp
@@ -178,12 +178,12 @@ CondExpr* CondManager::NEG(CondExpr* lhs){
  */
 void CondManager::printModel()
 {
-    std::cout << sol.check() << "\n";
+    SVFUtil::outs() << sol.check() << "\n";
     z3::model m = sol.get_model();
     for (u32_t i = 0; i < m.size(); i++)
     {
         z3::func_decl v = m[static_cast<s64_t>(i)];
-        std::cout << v.name() << " = " << m.get_const_interp(v) << "\n";
+        SVFUtil::outs() << v.name() << " = " << m.get_const_interp(v) << "\n";
     }
 }
 
@@ -241,7 +241,7 @@ bool CondManager::isAllPathReachable(const CondExpr* e){
  */
 inline void CondManager::printDbg(const CondExpr *e)
 {
-    std::cout << e->getExpr() << "\n";
+    SVFUtil::outs() << e->getExpr() << "\n";
 }
 
 /*!
@@ -360,7 +360,7 @@ void BranchCondManager::extractSubConds(BranchCond * f, NodeBS &support) const
 /*!
  * Dump BDD
  */
-void BranchCondManager::dump(BranchCond* lhs, raw_ostream & O)
+void BranchCondManager::dump(BranchCond* lhs, OutStream & O)
 {
     if (lhs == getTrueCond())
         O << "T";

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -700,18 +700,18 @@ namespace SVF
               EvalTime, TotalTime, BestCandidate };
 
         const unsigned fieldWidth = 20;
-        std::cout.flags(std::ios::left);
-        std::cout << "****Clusterer Statistics: " << subtitle << "****\n";
+        SVFUtil::outs().flags(std::ios::left);
+        SVFUtil::outs() << "****Clusterer Statistics: " << subtitle << "****\n";
         for (const std::string &statKey : statKeys)
         {
             Map<std::string, std::string>::const_iterator stat = stats.find(statKey);
             if (stat != stats.end())
             {
-                std::cout << std::setw(fieldWidth) << statKey << " " << stat->second << "\n";
+                SVFUtil::outs() << std::setw(fieldWidth) << statKey << " " << stat->second << "\n";
             }
         }
 
-        std::cout.flush();
+        SVFUtil::outs().flush();
     }
 
 };  // namespace SVF.

--- a/lib/Util/PTAStat.cpp
+++ b/lib/Util/PTAStat.cpp
@@ -294,29 +294,29 @@ void PTAStat::printStat(string statname)
     StringRef name = fullName.split('/').second;
     moduleName = name.split('.').first.str();
 
-    std::cout << "\n*********" << statname << "***************\n";
-    std::cout << "################ (program : " << moduleName << ")###############\n";
-    std::cout.flags(std::ios::left);
+    SVFUtil::outs() << "\n*********" << statname << "***************\n";
+    SVFUtil::outs() << "################ (program : " << moduleName << ")###############\n";
+    SVFUtil::outs().flags(std::ios::left);
     unsigned field_width = 20;
     for(NUMStatMap::iterator it = generalNumMap.begin(), eit = generalNumMap.end(); it!=eit; ++it)
     {
         // format out put with width 20 space
         std::cout << std::setw(field_width) << it->first << it->second << "\n";
     }
-    std::cout << "-------------------------------------------------------\n";
+    SVFUtil::outs() << "-------------------------------------------------------\n";
     for(TIMEStatMap::iterator it = timeStatMap.begin(), eit = timeStatMap.end(); it!=eit; ++it)
     {
         // format out put with width 20 space
-        std::cout << std::setw(field_width) << it->first << it->second << "\n";
+        SVFUtil::outs() << std::setw(field_width) << it->first << it->second << "\n";
     }
     for(NUMStatMap::iterator it = PTNumStatMap.begin(), eit = PTNumStatMap.end(); it!=eit; ++it)
     {
         // format out put with width 20 space
-        std::cout << std::setw(field_width) << it->first << it->second << "\n";
+        SVFUtil::outs() << std::setw(field_width) << it->first << it->second << "\n";
     }
 
-    std::cout << "#######################################################" << std::endl;
-    std::cout.flush();
+    SVFUtil::outs() << "#######################################################" << std::endl;
+    SVFUtil::outs().flush();
     generalNumMap.clear();
     PTNumStatMap.clear();
     timeStatMap.clear();

--- a/lib/Util/SVFUtil.cpp
+++ b/lib/Util/SVFUtil.cpp
@@ -146,7 +146,7 @@ void SVFUtil::dumpAliasSet(unsigned node, NodeBS bs)
 /*!
  * Dump bit vector set
  */
-void SVFUtil::dumpSet(NodeBS bs, raw_ostream & O)
+void SVFUtil::dumpSet(NodeBS bs, OutStream & O)
 {
     for (NodeBS::iterator ii = bs.begin(), ie = bs.end();
             ii != ie; ii++)
@@ -155,7 +155,7 @@ void SVFUtil::dumpSet(NodeBS bs, raw_ostream & O)
     }
 }
 
-void SVFUtil::dumpSet(PointsTo pt, raw_ostream &o)
+void SVFUtil::dumpSet(PointsTo pt, OutStream &o)
 {
     for (NodeID n : pt)
     {
@@ -166,7 +166,7 @@ void SVFUtil::dumpSet(PointsTo pt, raw_ostream &o)
 /*!
  * Print memory usage
  */
-void SVFUtil::reportMemoryUsageKB(const std::string& infor, raw_ostream & O)
+void SVFUtil::reportMemoryUsageKB(const std::string& infor, OutStream & O)
 {
     u32_t vmrss, vmsize;
     if (getMemoryUsageKB(&vmrss, &vmsize))
@@ -414,7 +414,6 @@ void SVFFunction::viewCFGOnly() {
 
 void SVFUtil::timeLimitReached(int)
 {
-    std::cout.flush();
     SVFUtil::outs().flush();
     // TODO: output does not indicate which time limit is reached.
     //       This can be better in the future.

--- a/lib/Util/ThreadAPI.cpp
+++ b/lib/Util/ThreadAPI.cpp
@@ -318,19 +318,19 @@ void ThreadAPI::performAPIStat(SVFModule* module)
     StringRef n(module->getModuleIdentifier());
     StringRef name = n.split('/').second;
     name = name.split('.').first;
-    std::cout << "################ (program : " << name.str()
+    SVFUtil::outs() << "################ (program : " << name.str()
               << ")###############\n";
-    std::cout.flags(std::ios::left);
+    SVFUtil::outs().flags(std::ios::left);
     unsigned field_width = 20;
     for (llvm::StringMap<u32_t>::iterator it = tdAPIStatMap.begin(), eit =
                 tdAPIStatMap.end(); it != eit; ++it)
     {
         std::string apiName = it->first().str();
         // format out put with width 20 space
-        std::cout << std::setw(field_width) << apiName << " : " << it->second
+        SVFUtil::outs() << std::setw(field_width) << apiName << " : " << it->second
                   << "\n";
     }
-    std::cout << "#######################################################"
+    SVFUtil::outs() << "#######################################################"
               << std::endl;
 
 }

--- a/lib/Util/TypeBasedHeapCloning.cpp
+++ b/lib/Util/TypeBasedHeapCloning.cpp
@@ -656,42 +656,42 @@ void TypeBasedHeapCloning::validateTBHCTests(SVFModule*)
             if (fn->getName() == PointerAnalysis::aliasTestMayAlias
                     || fn->getName() == PointerAnalysis::aliasTestMayAliasMangled)
             {
-                passed = res == llvm::AliasResult::MayAlias || res == llvm::AliasResult::MustAlias;
+                passed = res == AliasResult::MayAlias || res == AliasResult::MustAlias;
                 testName = PointerAnalysis::aliasTestMayAlias;
             }
             else if (fn->getName() == PointerAnalysis::aliasTestNoAlias
                      || fn->getName() == PointerAnalysis::aliasTestNoAliasMangled)
             {
-                passed = res == llvm::AliasResult::NoAlias;
+                passed = res == AliasResult::NoAlias;
                 testName = PointerAnalysis::aliasTestNoAlias;
             }
             else if (fn->getName() == PointerAnalysis::aliasTestMustAlias
                      || fn->getName() == PointerAnalysis::aliasTestMustAliasMangled)
             {
-                passed = res == llvm::AliasResult::MustAlias || res == llvm::AliasResult::MayAlias;
+                passed = res == AliasResult::MustAlias || res == AliasResult::MayAlias;
                 testName = PointerAnalysis::aliasTestMustAlias;
             }
             else if (fn->getName() == PointerAnalysis::aliasTestPartialAlias
                      || fn->getName() == PointerAnalysis::aliasTestPartialAliasMangled)
             {
-                passed = res == llvm::AliasResult::MayAlias || res == llvm::AliasResult::PartialAlias;
+                passed = res == AliasResult::MayAlias || res == AliasResult::PartialAlias;
                 testName = PointerAnalysis::aliasTestPartialAlias;
             }
             else if (fn->getName() == PointerAnalysis::aliasTestFailMayAlias
                      || fn->getName() == PointerAnalysis::aliasTestFailMayAliasMangled)
             {
-                passed = res != llvm::AliasResult::MayAlias && res != llvm::AliasResult::MustAlias && res != llvm::AliasResult::PartialAlias;
+                passed = res != AliasResult::MayAlias && res != AliasResult::MustAlias && res != AliasResult::PartialAlias;
                 testName = PointerAnalysis::aliasTestFailMayAlias;
             }
             else if (fn->getName() == PointerAnalysis::aliasTestFailNoAlias
                      || fn->getName() == PointerAnalysis::aliasTestFailNoAliasMangled)
             {
-                passed = res != llvm::AliasResult::NoAlias;
+                passed = res != AliasResult::NoAlias;
                 testName = PointerAnalysis::aliasTestFailNoAlias;
             }
 
             SVFUtil::outs() << "[" << pta->PTAName() << "] Checking " << testName << "\n";
-            raw_ostream &msgStream = passed ? SVFUtil::outs() : SVFUtil::errs();
+            OutStream &msgStream = passed ? SVFUtil::outs() : SVFUtil::errs();
             msgStream << (passed ? SVFUtil::sucMsg("\t SUCCESS") : SVFUtil::errMsg("\t FAILURE"))
                       << " : " << testName
                       << " check <id:" << p << ", id:" << q << "> "

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -685,7 +685,7 @@ void Andersen::connectCaller2CalleeParams(CallSite cs, const SVFFunction* F, Nod
 {
     assert(F);
 
-    DBOUT(DAndersen, outs() << "connect parameters from indirect callsite " << *cs.getInstruction() << " to callee " << *F << "\n");
+    // TODO-os DBOUT(DAndersen, outs() << "connect parameters from indirect callsite " << *cs.getInstruction() << " to callee " << *F << "\n");
 
     CallICFGNode* callBlockNode = pag->getICFG()->getCallICFGNode(cs.getInstruction());
     RetICFGNode* retBlockNode = pag->getICFG()->getRetICFGNode(cs.getInstruction());

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -685,7 +685,7 @@ void Andersen::connectCaller2CalleeParams(CallSite cs, const SVFFunction* F, Nod
 {
     assert(F);
 
-    // TODO-os DBOUT(DAndersen, outs() << "connect parameters from indirect callsite " << *cs.getInstruction() << " to callee " << *F << "\n");
+    DBOUT(DAndersen, outs() << "connect parameters from indirect callsite " << SVFUtil::value2String(cs.getInstruction()) << " to callee " << *F << "\n");
 
     CallICFGNode* callBlockNode = pag->getICFG()->getCallICFGNode(cs.getInstruction());
     RetICFGNode* retBlockNode = pag->getICFG()->getRetICFGNode(cs.getInstruction());

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -868,16 +868,16 @@ void FlowSensitive::printCTirAliasStats(void)
     countAliases(cmpLocs, &mayAliases, &noAliases);
 
     unsigned total = mayAliases + noAliases;
-    llvm::outs() << "eval-ctir-aliases "
-                 << total << " "
-                 << mayAliases << " "
-                 << noAliases << " "
-                 << "\n";
-    llvm::outs() << "  " << "TOTAL : " << total << "\n"
-                 << "  " << "MAY   : " << mayAliases << "\n"
-                 << "  " << "MAY % : " << 100 * ((double)mayAliases/(double)(total)) << "\n"
-                 << "  " << "NO    : " << noAliases << "\n"
-                 << "  " << "NO  % : " << 100 * ((double)noAliases/(double)(total)) << "\n";
+    SVFUtil::outs() << "eval-ctir-aliases "
+                    << total << " "
+                    << mayAliases << " "
+                    << noAliases << " "
+                    << "\n";
+    SVFUtil::outs() << "  " << "TOTAL : " << total << "\n"
+                    << "  " << "MAY   : " << mayAliases << "\n"
+                    << "  " << "MAY % : " << 100 * ((double)mayAliases/(double)(total)) << "\n"
+                    << "  " << "NO    : " << noAliases << "\n"
+                    << "  " << "NO  % : " << 100 * ((double)noAliases/(double)(total)) << "\n";
 }
 
 void FlowSensitive::countAliases(Set<std::pair<NodeID, NodeID>> cmp, unsigned *mayAliases, unsigned *noAliases)
@@ -894,10 +894,10 @@ void FlowSensitive::countAliases(Set<std::pair<NodeID, NodeID>> cmp, unsigned *m
 
             switch (alias(p, q))
             {
-            case llvm::AliasResult::NoAlias:
+            case AliasResult::NoAlias:
                 ++(*noAliases);
                 break;
-            case llvm::AliasResult::MayAlias:
+            case AliasResult::MayAlias:
                 ++(*mayAliases);
                 break;
             default:

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -264,7 +264,7 @@ void FlowSensitiveStat::performStat()
     timeStatMap["AverageSCCSize"] = (fspta->numOfSCC == 0) ? 0 :
                                     ((double)fspta->numOfNodesInSCC / fspta->numOfSCC);
 
-    std::cout << "\n****Flow-Sensitive Pointer Analysis Statistics****\n";
+    SVFUtil::outs() << "\n****Flow-Sensitive Pointer Analysis Statistics****\n";
     PTAStat::printStat();
 }
 

--- a/lib/WPA/FlowSensitiveTBHC.cpp
+++ b/lib/WPA/FlowSensitiveTBHC.cpp
@@ -679,10 +679,10 @@ void FlowSensitiveTBHC::countAliases(Set<std::pair<NodeID, NodeID>> cmp, unsigne
 
             switch (alias(aPts, bPts))
             {
-            case llvm::AliasResult::NoAlias:
+            case AliasResult::NoAlias:
                 ++(*noAliases);
                 break;
-            case llvm::AliasResult::MayAlias:
+            case AliasResult::MayAlias:
                 ++(*mayAliases);
                 break;
             default:

--- a/lib/WPA/VersionedFlowSensitiveStat.cpp
+++ b/lib/WPA/VersionedFlowSensitiveStat.cpp
@@ -145,7 +145,7 @@ void VersionedFlowSensitiveStat::performStat()
     timeStatMap["AverageSCCSize"]   = (vfspta->numOfSCC == 0) ? 0 :
                                       ((double)vfspta->numOfNodesInSCC / vfspta->numOfSCC);
 
-    std::cout << "\n****Versioned Flow-Sensitive Pointer Analysis Statistics****\n";
+    SVFUtil::outs() << "\n****Versioned Flow-Sensitive Pointer Analysis Statistics****\n";
     PTAStat::printStat();
 }
 

--- a/lib/WPA/WPAPass.cpp
+++ b/lib/WPA/WPAPass.cpp
@@ -50,10 +50,6 @@ using namespace SVF;
 
 char WPAPass::ID = 0;
 
-static llvm::RegisterPass<WPAPass> WHOLEPROGRAMPA("wpa",
-        "Whole Program Pointer AnalysWPAis Pass");
-
-
 /*!
  * Destructor
  */
@@ -177,9 +173,9 @@ void WPAPass::PrintAliasPairs(PointerAnalysis* pta)
             AliasResult result = pta->alias(node1->getId(), node2->getId());
             SVFUtil::outs()	<< (result == AliasResult::NoAlias ? "NoAlias" : "MayAlias")
                             << " var" << node1->getId() << "[" << node1->getValueName()
-                            << "@" << (fun1==nullptr?"":fun1->getName()) << "] --"
+                            << "@" << (fun1==nullptr?"":fun1->getName().str()) << "] --"
                             << " var" << node2->getId() << "[" << node2->getValueName()
-                            << "@" << (fun2==nullptr?"":fun2->getName()) << "]\n";
+                            << "@" << (fun2==nullptr?"":fun2->getName().str()) << "]\n";
         }
     }
 }
@@ -191,7 +187,7 @@ void WPAPass::PrintAliasPairs(PointerAnalysis* pta)
 AliasResult WPAPass::alias(const Value* V1, const Value* V2)
 {
 
-    AliasResult result = llvm::AliasResult::MayAlias;
+    AliasResult result = AliasResult::MayAlias;
 
     SVFIR* pag = _pta->getPAG();
 
@@ -206,25 +202,25 @@ AliasResult WPAPass::alias(const Value* V1, const Value* V2)
         if (Options::AliasRule.getBits() == 0 || Options::AliasRule.isSet(Veto))
         {
             /// Return NoAlias if any PTA gives NoAlias result
-            result = llvm::AliasResult::MayAlias;
+            result = AliasResult::MayAlias;
 
             for (PTAVector::const_iterator it = ptaVector.begin(), eit = ptaVector.end();
                     it != eit; ++it)
             {
-                if ((*it)->alias(V1, V2) == llvm::AliasResult::NoAlias)
-                    result = llvm::AliasResult::NoAlias;
+                if ((*it)->alias(V1, V2) == AliasResult::NoAlias)
+                    result = AliasResult::NoAlias;
             }
         }
         else if (Options::AliasRule.isSet(Conservative))
         {
             /// Return MayAlias if any PTA gives MayAlias result
-            result = llvm::AliasResult::NoAlias;
+            result = AliasResult::NoAlias;
 
             for (PTAVector::const_iterator it = ptaVector.begin(), eit = ptaVector.end();
                     it != eit; ++it)
             {
-                if ((*it)->alias(V1, V2) == llvm::AliasResult::MayAlias)
-                    result = llvm::AliasResult::MayAlias;
+                if ((*it)->alias(V1, V2) == AliasResult::MayAlias)
+                    result = AliasResult::MayAlias;
             }
         }
     }

--- a/tools/Example/svf-ex.cpp
+++ b/tools/Example/svf-ex.cpp
@@ -42,7 +42,7 @@ static llvm::cl::opt<std::string> InputFilename(cl::Positional,
 /*!
  * An example to query alias results of two LLVM values
  */
-AliasResult aliasQuery(PointerAnalysis* pta, Value* v1, Value* v2)
+SVF::AliasResult aliasQuery(PointerAnalysis* pta, Value* v1, Value* v2)
 {
     return pta->alias(v1,v2);
 }


### PR DESCRIPTION
This looks big but it's mostly removing namespaces, changing types to our types, etc.

The only problem is `TODO-os`. These are instances where we cannot print to `std::cout` because we are trying to print things like LLVM instructions and callsites. We need a solution like a to string function or preferably to just not print instructions (print SVF instructions/edges instead).