### PR TITLE
Be more liberal with Z3 location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,9 @@ endif()
 if (DEFINED Z3_DIR)
     set(ENV{Z3_DIR} "${Z3_DIR}")
 endif()
-find_library(Z3_LIBRARIES NAMES libz3.a libz3.so
+find_library(Z3_LIBRARIES NAMES libz3.a
                           HINTS $ENV{Z3_DIR}
-                          PATH_SUFFIXES bin)
+                          PATH_SUFFIXES lib bin)
 find_path(Z3_INCLUDES NAMES z3++.h
                       HINTS $ENV{Z3_DIR}
                       PATH_SUFFIXES include z3)


### PR DESCRIPTION
We were struggling to use a user-built Z3, this fixes it. .so is not needed as far as I can tell, correct? And when you `make install` by hand the library is in `lib` not `bin`.