### PR TITLE
do not connect callICFGNode to funcEntry for external API

### DIFF
--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -438,33 +438,36 @@ void ICFG::updateCallGraph(PTACallGraph* callgraph)
             const SVFFunction*  callee = *func_iter;
             CallICFGNode* callBlockNode = getCallICFGNode(cs);
             RetICFGNode* retBlockNode = getRetICFGNode(cs);
-            FunEntryICFGNode* calleeEntryNode = getFunEntryBlock(callee);
-            FunExitICFGNode* calleeExitNode = getFunExitBlock(callee);
-            if(ICFGEdge* callEdge = addCallEdge(callBlockNode, calleeEntryNode, cs)){
-                for (const SVFStmt *stmt : callBlockNode->getSVFStmts())
-                {
-                    if(const CallPE *callPE = SVFUtil::dyn_cast<CallPE>(stmt)){
-                        if(callPE->getFunEntryICFGNode() == calleeEntryNode)
-                            SVFUtil::cast<CallCFGEdge>(callEdge)->addCallPE(callPE);
-                    }
-                }
-            }
-            if(ICFGEdge* retEdge = addRetEdge(calleeExitNode, retBlockNode, cs)){
-                for (const SVFStmt *stmt : retBlockNode->getSVFStmts())
-                {
-                    if(const RetPE *retPE = SVFUtil::dyn_cast<RetPE>(stmt)){
-                        if(retPE->getFunExitICFGNode() == calleeExitNode)
-                            SVFUtil::cast<RetCFGEdge>(retEdge)->addRetPE(retPE);
-                    }
-                }
-            }
             /// if this is an external function (no function body), connect calleeEntryNode to calleeExitNode
             if (isExtCall(callee))
-                addIntraEdge(calleeEntryNode, calleeExitNode); 
+                addIntraEdge(callBlockNode, retBlockNode);
+            else {
+                FunEntryICFGNode* calleeEntryNode = getFunEntryBlock(callee);
+                FunExitICFGNode* calleeExitNode = getFunExitBlock(callee);
+                if(ICFGEdge* callEdge = addCallEdge(callBlockNode, calleeEntryNode, cs)){
+                    for (const SVFStmt *stmt : callBlockNode->getSVFStmts())
+                    {
+                        if(const CallPE *callPE = SVFUtil::dyn_cast<CallPE>(stmt)){
+                            if(callPE->getFunEntryICFGNode() == calleeEntryNode)
+                                SVFUtil::cast<CallCFGEdge>(callEdge)->addCallPE(callPE);
+                        }
+                    }
+                }
+                if(ICFGEdge* retEdge = addRetEdge(calleeExitNode, retBlockNode, cs)){
+                    for (const SVFStmt *stmt : retBlockNode->getSVFStmts())
+                    {
+                        if(const RetPE *retPE = SVFUtil::dyn_cast<RetPE>(stmt)){
+                            if(retPE->getFunExitICFGNode() == calleeExitNode)
+                                SVFUtil::cast<RetCFGEdge>(retEdge)->addRetPE(retPE);
+                        }
+                    }
+                }
 
-            /// Remove callBlockNode to retBlockNode intraICFGEdge since we found at least one inter procedural edge
-            if(ICFGEdge* edge = hasIntraICFGEdge(callBlockNode,retBlockNode, ICFGEdge::IntraCF))
-                removeICFGEdge(edge);
+                /// Remove callBlockNode to retBlockNode intraICFGEdge since we found at least one inter procedural edge
+                if(ICFGEdge* edge = hasIntraICFGEdge(callBlockNode,retBlockNode, ICFGEdge::IntraCF))
+                    removeICFGEdge(edge);
+            }
+
         }
     }
     // dump ICFG


### PR DESCRIPTION
As discussed, we should not connect callCFGNode to funEntryNode for external API because external API does not contain a function body.