### PR TITLE
fix compilation warnings

### DIFF
--- a/include/Graphs/ICFGEdge.h
+++ b/include/Graphs/ICFGEdge.h
@@ -138,7 +138,7 @@ public:
         return conditionVar;
     }
 
-    const s32_t getSuccessorCondValue() const{
+    s32_t getSuccessorCondValue() const{
         assert(getCondition() && "this is not a conditional branch edge");
         return branchCondVal;
     }

--- a/include/MemoryModel/PointsTo.h
+++ b/include/MemoryModel/PointsTo.h
@@ -199,7 +199,7 @@ public:
         const PointsToIterator operator++(int);
 
         /// Dereference: *it.
-        const u32_t operator*(void) const;
+        u32_t operator*(void) const;
 
         /// Equality: *this == rhs.
         bool operator==(const PointsToIterator &rhs) const;

--- a/include/Util/CoreBitVector.h
+++ b/include/Util/CoreBitVector.h
@@ -172,7 +172,7 @@ public:
         const CoreBitVectorIterator operator++(int);
 
         /// Dereference: *it.
-        const u32_t operator*(void) const;
+        u32_t operator*(void) const;
 
         /// Equality: *this == rhs.
         bool operator==(const CoreBitVectorIterator &rhs) const;

--- a/lib/MemoryModel/PointsTo.cpp
+++ b/lib/MemoryModel/PointsTo.cpp
@@ -385,7 +385,7 @@ PointsTo::PointsToIterator::PointsToIterator(const PointsTo *pt, bool end)
     {
         new (&bvIt) BitVector::iterator(end ? pt->bv.end() : pt->bv.begin());
     }
-    else 
+    else
     {
         assert(false && "PointsToIterator::PointsToIterator: unknown type");
         abort();
@@ -495,7 +495,7 @@ const PointsTo::PointsToIterator PointsTo::PointsToIterator::operator++(int)
     return old;
 }
 
-const NodeID PointsTo::PointsToIterator::operator*(void) const
+NodeID PointsTo::PointsToIterator::operator*(void) const
 {
     assert(!atEnd() && "PointsToIterator: dereferencing end!");
     if (pt->type == Type::CBV) return pt->getExternalNode(*cbvIt);

--- a/lib/Util/CoreBitVector.cpp
+++ b/lib/Util/CoreBitVector.cpp
@@ -422,7 +422,7 @@ const CoreBitVector::CoreBitVectorIterator CoreBitVector::CoreBitVectorIterator:
     return old;
 }
 
-const u32_t CoreBitVector::CoreBitVectorIterator::operator*(void) const
+u32_t CoreBitVector::CoreBitVectorIterator::operator*(void) const
 {
     assert(!atEnd() && "CoreBitVectorIterator::*: dereferencing end!");
     size_t wordsIndex = wordIt - cbv->words.begin();


### PR DESCRIPTION
Removes 3 warnings during compilation: `type qualifiers ignored on function return type`.