### PR TITLE
provide API for user of class ExtAPI to register coustomized functions

### DIFF
--- a/include/Util/ExtAPI.h
+++ b/include/Util/ExtAPI.h
@@ -107,6 +107,7 @@ private:
 
     // Singleton pattern here to enable instance of PAG can only be created once.
     static ExtAPI* extAPI;
+    std::unordered_set<std::string> definedFuncNames;
 
 public:
 
@@ -130,7 +131,7 @@ public:
             funName = "llvm." + F->getName().split('.').second.split('.').first.str();
         }
         llvm::StringMap<extf_t>::const_iterator it= info.find(funName);
-        if(it == info.end() || !F->isDeclaration())
+        if(it == info.end() || !(F->isDeclaration() or definedFuncNames.count(funName)))
             return EFT_OTHER;
         else
             return it->second;
@@ -227,6 +228,10 @@ public:
         isext_cache[F]= res;
         return res;
     }
+    // update 'info' private member variable
+    void registerFunc(std::unordered_set<std::string> &funcNames, extf_t type);
+    // update 'info' private member variable and annotate these function as non-declaration functions
+    void registerDefinedFunc(std::unordered_set<std::string> &funcNames, extf_t type);
 };
 
 } // End namespace SVF

--- a/lib/Util/ExtAPI.cpp
+++ b/lib/Util/ExtAPI.cpp
@@ -876,3 +876,16 @@ void ExtAPI::init()
     }
 }
 
+void ExtAPI::registerFunc(std::unordered_set<std::string> &funcNames, extf_t type)
+{
+    for (std::string funcName : funcNames)
+    {
+        info[funcName] = type;
+    }
+}
+
+void ExtAPI::registerDefinedFunc(std::unordered_set<std::string> &funcNames, extf_t type)
+{
+    registerFunc(funcNames, type);
+    definedFuncNames.insert(funcNames.begin(), funcNames.end());
+}


### PR DESCRIPTION
How about providing API of class `ExtAPI` to register coustomized functions (including functions that only have declaration and functions that have definition) to `ExtAPI::info`?

After having this, I can pass my customized heap allocator (not listed in `static const ei_pair ei_pairs[]={...}`) to SVF's ExtAPI before SVF analysis