### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/tools/DDA/CMakeLists.txt
+++ b/tools/DDA/CMakeLists.txt
@@ -5,7 +5,7 @@ if(DEFINED IN_SOURCE_BUILD)
 else()
     add_executable( dvf dda.cpp )
 
-    target_link_libraries( dvf Svf Cudd ${llvm_libs} )
+    target_link_libraries( dvf Svf Cudd ${llvm_libs} pthread)
 
     set_target_properties( dvf PROPERTIES
                            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )

--- a/tools/SABER/CMakeLists.txt
+++ b/tools/SABER/CMakeLists.txt
@@ -5,7 +5,7 @@ if(DEFINED IN_SOURCE_BUILD)
 else()
     add_executable( saber saber.cpp )
 
-    target_link_libraries( saber Svf Cudd ${llvm_libs})
+    target_link_libraries( saber Svf Cudd ${llvm_libs} pthread)
 
     set_target_properties( saber PROPERTIES
                            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )


### PR DESCRIPTION
[Compile Error] undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'

```shell
/usr/local/bin/ld: ../../../z3.obj/bin/libz3.a(scoped_timer.o): undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/local/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [tools/SABER/CMakeFiles/saber.dir/build.make:91: bin/saber] Error 1
```
```shell
/usr/local/bin/ld: ../../../z3.obj/bin/libz3.a(scoped_timer.o): undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/local/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [tools/DDA/CMakeFiles/dvf.dir/build.make:91: bin/dvf] Error 1
```

Thus, I add `pthread` to `target_link_libraries` in `tools/DDA/CMakeLists.txt` and `tools/SABER/CMakeLists.txt`, then it works fine. But I don't understand why SVF2.3 with LLVM-12 doesn't have such problem
