### PR TITLE
get correct types for values used in memcpy

### DIFF
--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -1008,6 +1008,21 @@ const Value* SVFIRBuilder::getBaseValueForExtArg(const Value* V)
         if(totalidx == 0 && !SVFUtil::isa<StructType>(value->getType()))
             value = gep->getPointerOperand();
     }
+
+    LLVMContext &cxt = LLVMModuleSet::getLLVMModuleSet()->getContext();
+    if (value->getType() == PointerType::getInt8PtrTy(cxt)) {
+        if (const CallBase* cb = SVFUtil::dyn_cast<CallBase>(value)) {
+            for (const User* user: cb->users()) {
+                if (const BitCastInst* bitCast = SVFUtil::dyn_cast<BitCastInst>(user))
+                    return bitCast;
+            }
+        }
+        else if (const LoadInst* load = SVFUtil::dyn_cast<LoadInst>(value)) {
+            if (const BitCastInst* bitCast = SVFUtil::dyn_cast<BitCastInst>(load->getPointerOperand()))
+                return bitCast->getOperand(0);
+        }
+    }
+
     return value;
 }
 

--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -1027,8 +1027,8 @@ const Value* SVFIRBuilder::getBaseValueForExtArg(const Value* V)
     if (value->getType() == PointerType::getInt8PtrTy(cxt)) {
         // (1)
         if (const CallBase* cb = SVFUtil::dyn_cast<CallBase>(value)) {
-            for (const User* user: cb->users()) {
-                if (const BitCastInst* bitCast = SVFUtil::dyn_cast<BitCastInst>(user))
+            if (SVFUtil::isHeapAllocExtCallViaRet(cb)) {
+                if (const Value* bitCast = getUniqueUseViaCastInst(cb))
                     return bitCast;
             }
         }

--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -1009,14 +1009,30 @@ const Value* SVFIRBuilder::getBaseValueForExtArg(const Value* V)
             value = gep->getPointerOperand();
     }
 
+    // if the argument of memcpy is the result of an allocation (1) or a casted load instruction (2),
+    // further steps are necessary to find the correct base value
+    //
+    // (1)
+    // %call   = malloc 80
+    // %0      = bitcast i8* %call to %struct.A*
+    // %1      = bitcast %struct.B* %param to i8*
+    // call void memcpy(%call, %1, 80)
+    // 
+    // (2)
+    // %0 = bitcast %struct.A* %param to i8*
+    // %2 = bitcast %struct.B** %arrayidx to i8**
+    // %3 = load i8*, i8** %2
+    // call void @memcpy(%0, %3, 80)
     LLVMContext &cxt = LLVMModuleSet::getLLVMModuleSet()->getContext();
     if (value->getType() == PointerType::getInt8PtrTy(cxt)) {
+        // (1)
         if (const CallBase* cb = SVFUtil::dyn_cast<CallBase>(value)) {
             for (const User* user: cb->users()) {
                 if (const BitCastInst* bitCast = SVFUtil::dyn_cast<BitCastInst>(user))
                     return bitCast;
             }
         }
+        // (2)
         else if (const LoadInst* load = SVFUtil::dyn_cast<LoadInst>(value)) {
             if (const BitCastInst* bitCast = SVFUtil::dyn_cast<BitCastInst>(load->getPointerOperand()))
                 return bitCast->getOperand(0);


### PR DESCRIPTION
In the following two cases, SVF fails to determine the correct type of a value used in a memcpy:

1. 
```llvm
%call   = malloc 80
%0      = bitcast i8* %call to %struct.x264_t*
%1      = bitcast %struct.x264_param_t* %param to i8*
call void memcpy(%call, %1, 80)
```

2.
```llvm
%0 = bitcast %struct.x264_param_t* %param to i8*, !dbg !3505
%2 = bitcast %struct.x264_t** %arrayidx to i8**
%3 = load i8*, i8** %2
call void @memcpy(%0, %3, 704)
```

This leads to underapproximations in the pointer analysis.