### PR TITLE
Fixed print stats error

### DIFF
--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -73,7 +73,7 @@ void BVDataPTAImpl::finalize()
 {
     normalizePointsTo();
     PointerAnalysis::finalize();
-    if (Options::ptDataBacking == PTBackingType::Persistent && Options::PStat) ptCache.printStats("bv-finalize");
+    if (Options::ptDataBacking == PTBackingType::Persistent && print_stat) ptCache.printStats("bv-finalize");
 }
 
 /*!


### PR DESCRIPTION
Changed to use internal flag rather than command line option to decide whether to print stats. This is important to provide control on whether stats get printed when using as library.