### PR TITLE
Make ExtAPI extensible at run time, after parsing

### DIFF
--- a/include/Util/ExtAPI.h
+++ b/include/Util/ExtAPI.h
@@ -231,8 +231,12 @@ public:
 
     static void destory();
 
+    void add_entry(const char* funName, extType type, bool overwrite_app_function);
+
     // Get the corresponding name in ext_t, e.g. "EXT_ADDR" in {"addr", EXT_ADDR},
-    extf_t get_opName(std::string s);
+    extf_t get_opName(const std::string& s);
+    // opposite for extType
+    const std::string& extType_toString(extType type);
 
     // Return the extf_t of (F).
     // Get external function name, e.g "memcpy"
@@ -246,6 +250,7 @@ public:
 
     // Get property of the operation, e.g. "EFT_A1R_A0R"
     extType get_type(const SVF::SVFFunction *callee);
+    extType get_type(const std::string& funName);
 
     // Get priority of he function, return value
     // 0: Apply user-defined functions

--- a/include/Util/ExtAPI.h
+++ b/include/Util/ExtAPI.h
@@ -231,6 +231,7 @@ public:
 
     static void destory();
 
+    // Add an entry with the specified fields to the ExtAPI, which will be reflected immediately by further ExtAPI queries
     void add_entry(const char* funName, extType type, bool overwrite_app_function);
 
     // Get the corresponding name in ext_t, e.g. "EXT_ADDR" in {"addr", EXT_ADDR},
@@ -238,7 +239,6 @@ public:
     // opposite for extType
     const std::string& extType_toString(extType type);
 
-    // Return the extf_t of (F).
     // Get external function name, e.g "memcpy"
     std::string get_name(const SVFFunction *F);
 

--- a/lib/Util/ExtAPI.cpp
+++ b/lib/Util/ExtAPI.cpp
@@ -167,10 +167,16 @@ void ExtAPI::add_entry(const char* funName, extType type, bool overwrite_app_fun
     assert(root);
     assert(get_type(funName) == EFT_NULL);
     auto entry = cJSON_CreateObject();
-    auto typeString = cJSON_CreateString(extType_toString(type).data());
-    cJSON_AddItemToObject(entry, "type", typeString);
+
+    // add the type field
+    auto typeString = cJSON_CreateString(extType_toString(type).c_str());
+    cJSON_AddItemToObject(entry, JSON_OPT_FUNCTIONTYPE, typeString);
+
+    // add the 'overwrite_app_function' field
     auto overwriteBool = cJSON_CreateNumber(overwrite_app_function ? 1 : 0);
-    cJSON_AddItemToObject(entry, "overwrite_app_function", overwriteBool);
+    cJSON_AddItemToObject(entry, JSON_OPT_OVERWRITE, overwriteBool);
+
+    // we don't know where the `funName` comes from, so copy it just in case
     cJSON_AddItemToObject(root, strdup(funName), entry);
 }
 

--- a/lib/Util/ExtAPI.cpp
+++ b/lib/Util/ExtAPI.cpp
@@ -9,6 +9,7 @@
 
 #include "Util/ExtAPI.h"
 #include "Util/SVFUtil.h"
+#include "Util/cJSON.h"
 #include <string.h>
 #include <sys/stat.h>
 #include <stdlib.h>
@@ -161,8 +162,20 @@ void ExtAPI::destory()
     }
 }
 
+void ExtAPI::add_entry(const char* funName, extType type, bool overwrite_app_function) 
+{
+    assert(root);
+    assert(get_type(funName) == EFT_NULL);
+    auto entry = cJSON_CreateObject();
+    auto typeString = cJSON_CreateString(extType_toString(type).data());
+    cJSON_AddItemToObject(entry, "type", typeString);
+    auto overwriteBool = cJSON_CreateNumber(overwrite_app_function ? 1 : 0);
+    cJSON_AddItemToObject(entry, "overwrite_app_function", overwriteBool);
+    cJSON_AddItemToObject(root, strdup(funName), entry);
+}
+
 // Get the corresponding name in ext_t, e.g. "EXT_ADDR" in {"addr", EXT_ADDR},
-ExtAPI::extf_t ExtAPI::get_opName(std::string s)
+ExtAPI::extf_t ExtAPI::get_opName(const std::string& s)
 {
     std::map<std::string, extf_t>::iterator pos = op_pair.find(s);
     if (pos != op_pair.end())
@@ -173,6 +186,14 @@ ExtAPI::extf_t ExtAPI::get_opName(std::string s)
     {
         return EXT_OTHER;
     }
+}
+
+const std::string& ExtAPI::extType_toString(extType type) {
+    auto it = llvm::find_if(type_pair, [&](const auto& pair) {
+        return pair.second == type;
+    });
+    assert(it != type_pair.end());
+    return it->first;
 }
 
 // Get external function name, e.g "memcpy"
@@ -209,10 +230,8 @@ std::vector<std::string> ExtAPI::get_opArgs(const cJSON *value)
     return args;
 }
 
-// Get property of the operation, e.g. "EFT_A1R_A0R"
-ExtAPI::extType ExtAPI::get_type(const SVF::SVFFunction *F)
+ExtAPI::extType ExtAPI::get_type(const std::string& funName) 
 {
-    std::string funName = get_name(F);
     cJSON *item = get_FunJson(funName);
     std::string type = "";
     if (item != nullptr)
@@ -229,6 +248,12 @@ ExtAPI::extType ExtAPI::get_type(const SVF::SVFFunction *F)
         return EFT_NULL;
     else
         return it->second;
+}
+
+// Get property of the operation, e.g. "EFT_A1R_A0R"
+ExtAPI::extType ExtAPI::get_type(const SVF::SVFFunction *F)
+{
+    return get_type(get_name(F));
 }
 
 // Get priority of he function, return value


### PR DESCRIPTION
In our own analyses, we discover that some user-defined functions implement memory allocation functionality. To make the points-to results more precise in this case, we inform SVF about this.

We used to have a much more invasive patch to SVF for this, but since the introduction of the JSON ExtAPI format, this small patch now suffices.

There's many other ways to go about this change. In fact, SVF already supports this in a way by just parsing & generating a new ExtAPI up front. However, that requires duplicating quite a bit of parsing/JSON format code that SVF already contains anyway. This patch adds a small `add_entry` function to ExtAPI that modifies the in-memory cJSON object directly. 

Let me know if this is not a direction you would like to go with ExtAPI, or if you have any comments. Happy to do this in a different way if need be.

PS: there's some stylistic/compiler warning changes I made too in various other parts. Let me know if you'd prefer this in another patch, or not at all.