### PR TITLE
Add some [[maybe_unused]] annotations to help suppress warnings

### DIFF
--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -127,12 +127,10 @@ void FlowSensitiveStat::performStat()
 
     unsigned numOfCopy = 0;
     unsigned numOfStore = 0;
-    [[maybe_unused]] unsigned numOfNode = 0;
     SVFG::iterator svfgNodeIt = fspta->svfg->begin();
     SVFG::iterator svfgNodeEit = fspta->svfg->end();
     for (; svfgNodeIt != svfgNodeEit; ++svfgNodeIt)
     {
-        numOfNode++;
         SVFGNode* svfgNode = svfgNodeIt->second;
         if (SVFUtil::isa<CopySVFGNode>(svfgNode))
             numOfCopy++;

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -101,8 +101,8 @@ void FlowSensitiveStat::performStat()
     // stat address-taken variables' points-to
     statAddrVarPtsSize();
 
-    [[maybe_unused]] u32_t fiObjNumber = 0;
-    [[maybe_unused]] u32_t fsObjNumber = 0;
+    u32_t fiObjNumber = 0;
+    u32_t fsObjNumber = 0;
     Set<SymID> nodeSet;
     for (SVFIR::const_iterator nodeIt = pag->begin(), nodeEit = pag->end(); nodeIt != nodeEit; nodeIt++)
     {
@@ -121,6 +121,9 @@ void FlowSensitiveStat::performStat()
             }
         }
     }
+
+    PTNumStatMap[NumberOfFieldInsensitiveObj] = fiObjNumber;
+    PTNumStatMap[NumberOfFieldSensitiveObj] = fsObjNumber;
 
     unsigned numOfCopy = 0;
     unsigned numOfStore = 0;

--- a/lib/WPA/FlowSensitiveStat.cpp
+++ b/lib/WPA/FlowSensitiveStat.cpp
@@ -101,8 +101,8 @@ void FlowSensitiveStat::performStat()
     // stat address-taken variables' points-to
     statAddrVarPtsSize();
 
-    u32_t fiObjNumber = 0;
-    u32_t fsObjNumber = 0;
+    [[maybe_unused]] u32_t fiObjNumber = 0;
+    [[maybe_unused]] u32_t fsObjNumber = 0;
     Set<SymID> nodeSet;
     for (SVFIR::const_iterator nodeIt = pag->begin(), nodeEit = pag->end(); nodeIt != nodeEit; nodeIt++)
     {
@@ -124,7 +124,7 @@ void FlowSensitiveStat::performStat()
 
     unsigned numOfCopy = 0;
     unsigned numOfStore = 0;
-    unsigned numOfNode = 0;
+    [[maybe_unused]] unsigned numOfNode = 0;
     SVFG::iterator svfgNodeIt = fspta->svfg->begin();
     SVFG::iterator svfgNodeEit = fspta->svfg->end();
     for (; svfgNodeIt != svfgNodeEit; ++svfgNodeIt)

--- a/lib/WPA/TypeAnalysis.cpp
+++ b/lib/WPA/TypeAnalysis.cpp
@@ -127,7 +127,7 @@ void TypeAnalysis::dumpCHAStats()
      * vtbl max vfunction
      * pure abstract class
      */
-    u32_t vtblnum = 0,
+    [[maybe_unused]] u32_t vtblnum = 0,
           vfunc_total = 0,
           vtbl_max = 0,
           pure_abstract = 0;

--- a/lib/WPA/TypeAnalysis.cpp
+++ b/lib/WPA/TypeAnalysis.cpp
@@ -127,7 +127,7 @@ void TypeAnalysis::dumpCHAStats()
      * vtbl max vfunction
      * pure abstract class
      */
-    [[maybe_unused]] u32_t vtblnum = 0,
+    u32_t vtblnum = 0,
           vfunc_total = 0,
           vtbl_max = 0,
           pure_abstract = 0;
@@ -166,6 +166,7 @@ void TypeAnalysis::dumpCHAStats()
     outs() << "vtblnum:\t" << vtblnum << '\n';
     outs() << "vtbl_average:\t" << (double)(vfunc_total)/vtblnum << '\n';
     outs() << "vtbl_max:\t" << vtbl_max << '\n';
+    outs() << "pure_abstract:\t" << pure_abstract << '\n';
 }
 
 

--- a/lib/WPA/VersionedFlowSensitiveStat.cpp
+++ b/lib/WPA/VersionedFlowSensitiveStat.cpp
@@ -46,8 +46,8 @@ void VersionedFlowSensitiveStat::performStat()
     versionStat();
     ptsSizeStat();
 
-    u32_t fiObjNumber = 0;
-    u32_t fsObjNumber = 0;
+    [[maybe_unused]] u32_t fiObjNumber = 0;
+    [[maybe_unused]] u32_t fsObjNumber = 0;
     Set<SymID> nodeSet;
     for (SVFIR::const_iterator it = pag->begin(); it != pag->end(); ++it)
     {
@@ -67,7 +67,7 @@ void VersionedFlowSensitiveStat::performStat()
 
     unsigned numOfCopy = 0;
     unsigned numOfStore = 0;
-    unsigned numOfNode = 0;
+    [[maybe_unused]] unsigned numOfNode = 0;
     for (SVFG::iterator it = vfspta->svfg->begin(); it != vfspta->svfg->end(); ++it)
     {
         numOfNode++;

--- a/lib/WPA/VersionedFlowSensitiveStat.cpp
+++ b/lib/WPA/VersionedFlowSensitiveStat.cpp
@@ -70,10 +70,8 @@ void VersionedFlowSensitiveStat::performStat()
 
     unsigned numOfCopy = 0;
     unsigned numOfStore = 0;
-    [[maybe_unused]] unsigned numOfNode = 0;
     for (SVFG::iterator it = vfspta->svfg->begin(); it != vfspta->svfg->end(); ++it)
     {
-        numOfNode++;
         SVFGNode* svfgNode = it->second;
         if (SVFUtil::isa<CopySVFGNode>(svfgNode)) numOfCopy++;
         else if (SVFUtil::isa<StoreSVFGNode>(svfgNode)) numOfStore++;

--- a/lib/WPA/VersionedFlowSensitiveStat.cpp
+++ b/lib/WPA/VersionedFlowSensitiveStat.cpp
@@ -46,8 +46,8 @@ void VersionedFlowSensitiveStat::performStat()
     versionStat();
     ptsSizeStat();
 
-    [[maybe_unused]] u32_t fiObjNumber = 0;
-    [[maybe_unused]] u32_t fsObjNumber = 0;
+    u32_t fiObjNumber = 0;
+    u32_t fsObjNumber = 0;
     Set<SymID> nodeSet;
     for (SVFIR::const_iterator it = pag->begin(); it != pag->end(); ++it)
     {
@@ -64,6 +64,9 @@ void VersionedFlowSensitiveStat::performStat()
             }
         }
     }
+
+    PTNumStatMap[NumberOfFieldInsensitiveObj] = fiObjNumber;
+    PTNumStatMap[NumberOfFieldSensitiveObj] = fsObjNumber;
 
     unsigned numOfCopy = 0;
     unsigned numOfStore = 0;


### PR DESCRIPTION
As per the discussion in #821, some of the variables here are supposedly not used, causing `-Werror` compilation failures. 

I'm compiling with a recent version of clang, which can probably detect that this variables are initialized, then incremented a few times, but their eventual value is never used. This is basically a more complicated case of a write-only variable, which is also commonly warned on.

We could also remove these counters as a whole, did they used to be logged somewhere perhaps?