### PR TITLE
Allow libz3 shared objects again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 if (DEFINED Z3_DIR)
     set(ENV{Z3_DIR} "${Z3_DIR}")
 endif()
-find_library(Z3_LIBRARIES NAMES libz3.a
+find_library(Z3_LIBRARIES NAMES libz3.a libz3.so
                           HINTS $ENV{Z3_DIR}
                           PATH_SUFFIXES lib bin)
 find_path(Z3_INCLUDES NAMES z3++.h


### PR DESCRIPTION
In a [recent commit](https://github.com/SVF-tools/SVF/commit/c64457c0bdd57eaba537d44665d8471f9f0ebe52), the ability for shared libz3 objects was (possibly accidentally?) removed from CMakelists.txt. Any problem with re-adding them here?

AFAIK, in the default Ubuntu 20.04 libz3 package, only the shared objects are present.