### PR TITLE
Various fixes regarding the SVF namespace

### DIFF
--- a/include/MemoryModel/PointsTo.h
+++ b/include/MemoryModel/PointsTo.h
@@ -240,7 +240,7 @@ PointsTo operator&(const PointsTo &lhs, const PointsTo &rhs);
 /// Returns a new lhs - rhs.
 PointsTo operator-(const PointsTo &lhs, const PointsTo &rhs);
 
-};
+} // End namespace SVF
 
 template <>
 struct std::hash<SVF::PointsTo>

--- a/include/MemoryModel/SVFLoop.h
+++ b/include/MemoryModel/SVFLoop.h
@@ -34,6 +34,7 @@
 
 namespace SVF
 {
+
 class SVFLoop
 {
     typedef Set<const ICFGEdge *> ICFGEdgeSet;
@@ -158,6 +159,6 @@ public:
     }
 };
 
-}
+} // End namespace SVF
 
 #endif //SVF_SVFLOOP_H

--- a/include/SVF-FE/BasicTypes.h
+++ b/include/SVF-FE/BasicTypes.h
@@ -24,6 +24,8 @@
 
 #include <llvm/Support/SourceMgr.h>
 
+namespace SVF {
+
 typedef llvm::LLVMContext LLVMContext;
 typedef llvm::GlobalObject GlobalObject;
 typedef llvm::Use Use;
@@ -126,5 +128,7 @@ typedef llvm::VectorType VectorType;
 #if (LLVM_VERSION_MAJOR >= 9)
 typedef llvm::FunctionCallee FunctionCallee;
 #endif
+
+} // End namespace SVF
 
 #endif  // SVF_FE_BASIC_TYPES_H

--- a/include/SVF-FE/CHGBuilder.h
+++ b/include/SVF-FE/CHGBuilder.h
@@ -68,4 +68,5 @@ public:
     void addFuncToFuncVector(CHNode::FuncVector &v, const SVFFunction *f);
 };
 
-}
+} // End namespace SVF
+

--- a/include/SVF-FE/LLVMLoopAnalysis.h
+++ b/include/SVF-FE/LLVMLoopAnalysis.h
@@ -54,6 +54,6 @@ public:
     /// Build SVF loops based on llvm loops
     virtual void buildSVFLoops(ICFG *icfg, std::vector<const Loop *> &llvmLoops);
 };
-} // end fo SVF
+} // End namespace SVF
 
 #endif //SVF_LLVMLOOPANALYSIS_H

--- a/include/SVF-FE/SymbolTableBuilder.h
+++ b/include/SVF-FE/SymbolTableBuilder.h
@@ -92,6 +92,6 @@ public:
     u32_t getObjSize(const Type* type);
 };
 
-}
+} // End namespace SVF
 
 #endif /* SymbolTableBuilder_H_ */

--- a/include/Util/CoreBitVector.h
+++ b/include/Util/CoreBitVector.h
@@ -209,6 +209,6 @@ struct Hash<CoreBitVector>
     }
 };
 
-};
+} // End namespace SVF
 
 #endif  // COREBITVECTOR_H_

--- a/include/Util/DPItem.h
+++ b/include/Util/DPItem.h
@@ -559,7 +559,7 @@ public:
     }
 
 };
-}
+} // End namespace SVF
 
 /// Specialise hash for CxtDPItem.
 template <>

--- a/include/Util/ExeState.h
+++ b/include/Util/ExeState.h
@@ -166,7 +166,7 @@ protected:
         return locToVal[objId];
     }
 };
-}
+} // End namespace SVF
 
 template<>
 struct std::hash<SVF::ExeState>

--- a/include/Util/SparseBitVector.h
+++ b/include/Util/SparseBitVector.h
@@ -1203,6 +1203,6 @@ void dump(const SparseBitVector<ElementSize> &LHS, std::ostream &out)
     out << "]\n";
 }
 
-}
+} // End namespace SVF
 
 #endif // SPARSEBITVECTOR_H

--- a/include/Util/SymState.h
+++ b/include/Util/SymState.h
@@ -101,7 +101,7 @@ private:
     ExeState exeState;
     AbstractState absState;
 };
-}
+} // End namespace SVF
 
 template<>
 struct std::hash<SVF::SymState>

--- a/include/Util/Z3Expr.h
+++ b/include/Util/Z3Expr.h
@@ -302,7 +302,7 @@ public:
     /// compute OR, used for branch condition
     static Z3Expr OR(const Z3Expr &lhs, const Z3Expr &rhs);
 };
-}
+} // End namespace SVF
 
 /// Specialise hash for AbsCxtDPItem.
 template<>
@@ -315,3 +315,4 @@ struct std::hash<SVF::Z3Expr>
 };
 
 #endif //Z3_EXAMPLE_Z3EXPR_H
+


### PR DESCRIPTION
- Adds missing namespace to [include/SVF-FE/BasicTypes.h](https://github.com/SVF-tools/SVF/blob/master/include/Util/BasicTypes.h)
- Removes semicolon from a few namespace parenthesis
- Adds `End namespace SVF` where missing