### PR TITLE
fix the command of popen()

### DIFF
--- a/lib/Util/ExtAPI.cpp
+++ b/lib/Util/ExtAPI.cpp
@@ -149,7 +149,7 @@ ExtAPI *ExtAPI::getExtAPI(const std::string &path)
             return extOp;
         }
 
-        jsonFilePath = getJsonFile("$SVF_DIR");
+        jsonFilePath = getJsonFile("echo $SVF_DIR");
         if (!stat(jsonFilePath.c_str(), &statbuf))
         {
             root = parseJson(jsonFilePath, statbuf.st_size);


### PR DESCRIPTION
error message - sh: 1: /path_to_SVF_DIR: Permission denied
cause - popen("$SVF_DIR", "r")
path - jsonFilePath = getJsonFile("$SVF_DIR"); -> GetStdoutFromCommand() -> popen()


