### PR TITLE
Bump LLVM from 13.0.0 to 15.0.0

### DIFF
--- a/include/Graphs/ConsGNode.h
+++ b/include/Graphs/ConsGNode.h
@@ -259,56 +259,68 @@ public:
         storeInEdges.insert(inEdge);
         addIncomingEdge(inEdge);
     }
-    inline void addIncomingDirectEdge(ConstraintEdge* inEdge)
+    inline bool addIncomingDirectEdge(ConstraintEdge* inEdge)
     {
         assert(inEdge->getDstID() == this->getId());
         bool added1 = directInEdges.insert(inEdge).second;
         bool added2 = addIncomingEdge(inEdge);
-        assert(added1 && added2 && "edge not added, duplicated adding!!");
+        bool both_added = added1 & added2;
+        assert(both_added && "edge not added, duplicated adding!!");
+        return both_added;
     }
     inline void addOutgoingAddrEdge(AddrCGEdge* outEdge)
     {
         addressOutEdges.insert(outEdge);
         addOutgoingEdge(outEdge);
     }
-    inline void addOutgoingLoadEdge(LoadCGEdge* outEdge)
+    inline bool addOutgoingLoadEdge(LoadCGEdge* outEdge)
     {
         bool added1 = loadOutEdges.insert(outEdge).second;
         bool added2 = addOutgoingEdge(outEdge);
-        assert(added1 && added2 && "edge not added, duplicated adding!!");
+        bool both_added = added1 & added2;
+        assert(both_added && "edge not added, duplicated adding!!");
+        return both_added;
     }
-    inline void addOutgoingStoreEdge(StoreCGEdge* outEdge)
+    inline bool addOutgoingStoreEdge(StoreCGEdge* outEdge)
     {
         bool added1 = storeOutEdges.insert(outEdge).second;
         bool added2 = addOutgoingEdge(outEdge);
-        assert(added1 && added2 && "edge not added, duplicated adding!!");
+        bool both_added = added1 & added2;
+        assert(both_added && "edge not added, duplicated adding!!");
+        return both_added;
     }
-    inline void addOutgoingDirectEdge(ConstraintEdge* outEdge)
+    inline bool addOutgoingDirectEdge(ConstraintEdge* outEdge)
     {
         assert(outEdge->getSrcID() == this->getId());
         bool added1 = directOutEdges.insert(outEdge).second;
         bool added2 = addOutgoingEdge(outEdge);
-        assert(added1 && added2 && "edge not added, duplicated adding!!");
+        bool both_added = added1 & added2;
+        assert(both_added && "edge not added, duplicated adding!!");
+        return both_added;
     }
     //@}
 
     /// Remove constraint graph edges
     //{@
-    inline void removeOutgoingAddrEdge(AddrCGEdge* outEdge)
+    inline bool removeOutgoingAddrEdge(AddrCGEdge* outEdge)
     {
         u32_t num1 = addressOutEdges.erase(outEdge);
         u32_t num2 = removeOutgoingEdge(outEdge);
-        assert((num1 && num2) && "edge not in the set, can not remove!!!");
+        bool removed = (num1 > 0) & (num2 > 0);
+        assert(removed && "edge not in the set, can not remove!!!");
+        return removed;
     }
 
-    inline void removeIncomingAddrEdge(AddrCGEdge* inEdge)
+    inline bool removeIncomingAddrEdge(AddrCGEdge* inEdge)
     {
         u32_t num1 = addressInEdges.erase(inEdge);
         u32_t num2 = removeIncomingEdge(inEdge);
-        assert((num1 && num2) && "edge not in the set, can not remove!!!");
+        bool removed = (num1 > 0) & (num2 > 0);
+        assert(removed && "edge not in the set, can not remove!!!");
+        return removed;
     }
 
-    inline void removeOutgoingDirectEdge(ConstraintEdge* outEdge)
+    inline bool removeOutgoingDirectEdge(ConstraintEdge* outEdge)
     {
         if (SVFUtil::isa<GepCGEdge>(outEdge))
             gepOutEdges.erase(outEdge);
@@ -316,10 +328,12 @@ public:
             copyOutEdges.erase(outEdge);
         u32_t num1 = directOutEdges.erase(outEdge);
         u32_t num2 = removeOutgoingEdge(outEdge);
-        assert((num1 && num2) && "edge not in the set, can not remove!!!");
+        bool removed = (num1 > 0) & (num2 > 0);
+        assert(removed && "edge not in the set, can not remove!!!");
+        return removed;
     }
 
-    inline void removeIncomingDirectEdge(ConstraintEdge* inEdge)
+    inline bool removeIncomingDirectEdge(ConstraintEdge* inEdge)
     {
         if (SVFUtil::isa<GepCGEdge>(inEdge))
             gepInEdges.erase(inEdge);
@@ -327,35 +341,45 @@ public:
             copyInEdges.erase(inEdge);
         u32_t num1 = directInEdges.erase(inEdge);
         u32_t num2 = removeIncomingEdge(inEdge);
-        assert((num1 && num2) && "edge not in the set, can not remove!!!");
+        bool removed = (num1 > 0) & (num2 > 0);
+        assert(removed && "edge not in the set, can not remove!!!");
+        return removed;
     }
 
-    inline void removeOutgoingLoadEdge(LoadCGEdge* outEdge)
+    inline bool removeOutgoingLoadEdge(LoadCGEdge* outEdge)
     {
         u32_t num1 = loadOutEdges.erase(outEdge);
         u32_t num2 = removeOutgoingEdge(outEdge);
-        assert((num1 && num2) && "edge not in the set, can not remove!!!");
+        bool removed = (num1 > 0) & (num2 > 0);
+        assert(removed && "edge not in the set, can not remove!!!");
+        return removed;
     }
 
-    inline void removeIncomingLoadEdge(LoadCGEdge* inEdge)
+    inline bool removeIncomingLoadEdge(LoadCGEdge* inEdge)
     {
         u32_t num1 = loadInEdges.erase(inEdge);
         u32_t num2 = removeIncomingEdge(inEdge);
-        assert((num1 && num2) && "edge not in the set, can not remove!!!");
+        bool removed = (num1 > 0) & (num2 > 0);
+        assert(removed && "edge not in the set, can not remove!!!");
+        return removed;
     }
 
-    inline void removeOutgoingStoreEdge(StoreCGEdge* outEdge)
+    inline bool removeOutgoingStoreEdge(StoreCGEdge* outEdge)
     {
         u32_t num1 = storeOutEdges.erase(outEdge);
         u32_t num2 = removeOutgoingEdge(outEdge);
-        assert((num1 && num2) && "edge not in the set, can not remove!!!");
+        bool removed = (num1 > 0) & (num2 > 0);
+        assert(removed && "edge not in the set, can not remove!!!");
+        return removed;
     }
 
-    inline void removeIncomingStoreEdge(StoreCGEdge* inEdge)
+    inline bool removeIncomingStoreEdge(StoreCGEdge* inEdge)
     {
         u32_t num1 = storeInEdges.erase(inEdge);
         u32_t num2 = removeIncomingEdge(inEdge);
-        assert((num1 && num2) && "edge not in the set, can not remove!!!");
+        bool removed = (num1 > 0) & (num2 > 0);
+        assert(removed && "edge not in the set, can not remove!!!");
+        return removed;
     }
     //@}
 

--- a/include/Graphs/GenericGraph.h
+++ b/include/Graphs/GenericGraph.h
@@ -292,13 +292,15 @@ public:
     {
         iterator it = InEdges.find(edge);
         assert(it != InEdges.end() && "can not find in edge in SVFG node");
-        return InEdges.erase(edge);
+        InEdges.erase(it);
+        return 1;
     }
     inline u32_t removeOutgoingEdge(EdgeType* edge)
     {
         iterator it = OutEdges.find(edge);
         assert(it != OutEdges.end() && "can not find out edge in SVFG node");
-        return OutEdges.erase(edge);
+        OutEdges.erase(it);
+        return 1;
     }
     ///@}
 

--- a/include/Graphs/ICFG.h
+++ b/include/Graphs/ICFG.h
@@ -179,8 +179,9 @@ protected:
     {
         bool added1 = edge->getDstNode()->addIncomingEdge(edge);
         bool added2 = edge->getSrcNode()->addOutgoingEdge(edge);
-        assert(added1 && added2 && "edge not added??");
-        return true;
+        bool all_added = added1 && added2;
+        assert(all_added && "ICFGEdge not added?");
+        return all_added;
     }
 
     /// Add a ICFG node

--- a/include/Graphs/SVFGOPT.h
+++ b/include/Graphs/SVFGOPT.h
@@ -261,23 +261,23 @@ private:
     {
         PAGNodeToDefMapTy::iterator it = PAGNodeToDefMap.find(pagNode);
         assert(it != PAGNodeToDefMap.end() && "a SVFIR node doesn't have definition before");
-        PAGNodeToDefMap[pagNode] = node->getId();
+        it->second = node->getId();
     }
 
     /// Set def-site of actual-in/formal-out.
     ///@{
     inline void setActualINDef(NodeID ai, NodeID def)
     {
-        NodeIDToNodeIDMap::const_iterator it = actualInToDefMap.find(ai);
-        assert(it == actualInToDefMap.end() && "can not set actual-in's def twice");
-        actualInToDefMap[ai] = def;
+        bool inserted = actualInToDefMap.emplace(ai, def).second;
+        (void) inserted; // Make compiler happy
+        assert(inserted && "can not set actual-in's def twice");
         defNodes.set(def);
     }
     inline void setFormalOUTDef(NodeID fo, NodeID def)
     {
-        NodeIDToNodeIDMap::const_iterator it = formalOutToDefMap.find(fo);
-        assert(it == formalOutToDefMap.end() && "can not set formal-out's def twice");
-        formalOutToDefMap[fo] = def;
+        bool inserted = formalOutToDefMap.emplace(fo, def).second;
+        (void) inserted;
+        assert(inserted && "can not set formal-out's def twice");
         defNodes.set(def);
     }
     ///@}

--- a/include/Graphs/VFG.h
+++ b/include/Graphs/VFG.h
@@ -340,8 +340,9 @@ public:
     {
         bool added1 = edge->getDstNode()->addIncomingEdge(edge);
         bool added2 = edge->getSrcNode()->addOutgoingEdge(edge);
-        assert(added1 && added2 && "edge not added??");
-        return true;
+        bool both_added = added1 & added2;
+        assert(both_added && "VFGEdge not added??");
+        return both_added;
     }
 
 protected:

--- a/include/MSSA/MemSSA.h
+++ b/include/MSSA/MemSSA.h
@@ -324,9 +324,9 @@ public:
     {
         if (const LoadStmt* load = SVFUtil::dyn_cast<LoadStmt>(inst))
         {
-            assert(0 != load2MuSetMap.count(load)
-                   && "not associated with mem region!");
-            return true;
+            bool has_mu = load2MuSetMap.count(load) != 0;
+            assert(has_mu && "not associated with mem region!");
+            return has_mu;
         }
         else
             return false;
@@ -336,9 +336,9 @@ public:
         if (const StoreStmt* store = SVFUtil::dyn_cast<StoreStmt>(
                                          inst))
         {
-            assert(0 != store2ChiSetMap.count(store)
-                   && "not associated with mem region!");
-            return true;
+            bool has_store = store2ChiSetMap.count(store) != 0;
+            assert(has_store && "not associated with mem region!");
+            return has_store;
         }
         else
             return false;

--- a/include/MemoryModel/SVFIR.h
+++ b/include/MemoryModel/SVFIR.h
@@ -456,6 +456,7 @@ private:
     inline void addToStmt2TypeMap(SVFStmt* edge)
     {
         bool added = KindToSVFStmtSetMap[edge->getEdgeKind()].insert(edge).second;
+        (void) added; // Make compiler happy :)
         assert(added && "duplicated edge, not added!!!");
         if (edge->isPTAEdge())
         {
@@ -494,7 +495,8 @@ private:
     /// Add indirect callsites
     inline void addIndirectCallsites(const CallICFGNode* cs,NodeID funPtr)
     {
-        bool added = indCallSiteToFunPtrMap.insert(std::make_pair(cs,funPtr)).second;
+        bool added = indCallSiteToFunPtrMap.emplace(cs, funPtr).second;
+        (void) added;
         funPtrToCallSitesMap[funPtr].insert(cs);
         assert(added && "adding the same indirect callsite twice?");
     }

--- a/include/SABER/SaberCondAllocator.h
+++ b/include/SABER/SaberCondAllocator.h
@@ -148,6 +148,7 @@ public:
     {
         const SVFFunction*  keyFunc = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(bbKey->getParent());
         const SVFFunction*  valueFunc = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(bbValue->getParent());
+        (void)(keyFunc == valueFunc);  // make compiler happy
         assert((keyFunc == valueFunc) && "two basicblocks should be in the same function!");
 
         return keyFunc->postDominate(bbKey,bbValue);
@@ -157,6 +158,7 @@ public:
     {
         const SVFFunction*  keyFunc = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(bbKey->getParent());
         const SVFFunction*  valueFunc = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(bbValue->getParent());
+        (void)(keyFunc == valueFunc); // Make compiler happy
         assert((keyFunc == valueFunc) && "two basicblocks should be in the same function!");
 
         return keyFunc->dominate(bbKey,bbValue);

--- a/include/SVF-FE/IRAnnotator.h
+++ b/include/SVF-FE/IRAnnotator.h
@@ -101,6 +101,7 @@ private:
             LocationSet locationSet = LocationSet(locationSetOffset);
             SVF::NodeID gepnodeId = pag->getGepObjVar(baseNodeId, locationSet);
 
+            (void)(nodeId, gepnodeId); // Make compiler happy
             assert(nodeId == gepnodeId && "nodeId != gepnodeId");
         }
     }

--- a/include/SVF-FE/IRAnnotator.h
+++ b/include/SVF-FE/IRAnnotator.h
@@ -101,8 +101,9 @@ private:
             LocationSet locationSet = LocationSet(locationSetOffset);
             SVF::NodeID gepnodeId = pag->getGepObjVar(baseNodeId, locationSet);
 
-            (void)(nodeId, gepnodeId); // Make compiler happy
-            assert(nodeId == gepnodeId && "nodeId != gepnodeId");
+            bool idEq = nodeId == gepnodeId;
+            (void)idEq; // Make compiler happy
+            assert(idEq && "nodeId is not equal to gepnodeId?");
         }
     }
 

--- a/include/Util/SparseBitVector.h
+++ b/include/Util/SparseBitVector.h
@@ -321,6 +321,7 @@ public:
             if (Bits[i] != 0)
                 return i * BITWORD_SIZE + countTrailingZeros(Bits[i]);
         assert(false && "SBV: find_first: SBV cannot be empty");
+        return -1; // Unreachable. Make the compiler happy
     }
 
     /// find_last - Returns the index of the last set bit.
@@ -334,6 +335,7 @@ public:
                        countLeadingZeros(Bits[Idx]) - 1;
         }
         assert(false && "SBV: find_last: SBV cannot be empty");
+        return -1; // Unreachable. Make the compiler happy
     }
 
     /// find_next - Returns the index of the next set bit starting from the

--- a/lib/DDA/ContextDDA.cpp
+++ b/lib/DDA/ContextDDA.cpp
@@ -335,22 +335,25 @@ bool ContextDDA::isHeapCondMemObj(const CxtVar& var, const StoreSVFGNode*)
 {
     const MemObj* mem = _pag->getObject(getPtrNodeID(var));
     assert(mem && "memory object is null??");
-    if(mem->isHeap())
+    if (mem->isHeap())
     {
         if (!mem->getValue())
         {
             PAGNode *pnode = _pag->getGNode(getPtrNodeID(var));
-            if(GepObjVar* gepobj = SVFUtil::dyn_cast<GepObjVar>(pnode))
+            GepObjVar* gepobj = SVFUtil::dyn_cast<GepObjVar>(pnode);
+            if (gepobj != nullptr)
             {
-                assert(SVFUtil::isa<DummyObjVar>(_pag->getGNode(gepobj->getBaseNode())) && "emtpy refVal in a gep object whose base is a non-dummy object");
+                assert(SVFUtil::isa<DummyObjVar>(_pag->getGNode(gepobj->getBaseNode())) 
+                    && "emtpy refVal in a gep object whose base is a non-dummy object");
             }
             else
             {
-                assert((SVFUtil::isa<DummyObjVar>(pnode) || SVFUtil::isa<DummyValVar>(pnode)) && "empty refVal in non-dummy object");
+                assert((SVFUtil::isa<DummyObjVar>(pnode) || SVFUtil::isa<DummyValVar>(pnode))
+                    && "empty refVal in non-dummy object");
             }
             return true;
         }
-        else if(const Instruction* mallocSite = SVFUtil::dyn_cast<Instruction>(mem->getValue()))
+        else if (const Instruction* mallocSite = SVFUtil::dyn_cast<Instruction>(mem->getValue()))
         {
             const Function* fun = mallocSite->getFunction();
             const SVFFunction* svfFun = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(fun);

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -157,8 +157,11 @@ AddrCGEdge::AddrCGEdge(ConstraintNode* s, ConstraintNode* d, EdgeID id)
 {
     // Retarget addr edges may lead s to be a dummy node
     PAGNode* node = SVFIR::getPAG()->getGNode(s->getId());
+    (void) node; // Make compiler happy
     if (!SVFModule::pagReadFromTXT())
+    {
         assert(!SVFUtil::isa<DummyValVar>(node) && "a dummy node??");
+    }
 }
 
 /*!
@@ -168,11 +171,13 @@ AddrCGEdge* ConstraintGraph::addAddrCGEdge(NodeID src, NodeID dst)
 {
     ConstraintNode* srcNode = getConstraintNode(src);
     ConstraintNode* dstNode = getConstraintNode(dst);
-    if(hasEdge(srcNode,dstNode,ConstraintEdge::Addr))
+    if (hasEdge(srcNode, dstNode, ConstraintEdge::Addr))
         return nullptr;
     AddrCGEdge* edge = new AddrCGEdge(srcNode, dstNode, edgeIndex++);
-    bool added = AddrCGEdgeSet.insert(edge).second;
-    assert(added && "not added??");
+    if (!AddrCGEdgeSet.insert(edge).second)
+    {
+        assert(!"new AddrCGEdge not added??");
+    }
     srcNode->addOutgoingAddrEdge(edge);
     dstNode->addIncomingAddrEdge(edge);
     return edge;
@@ -186,13 +191,13 @@ CopyCGEdge* ConstraintGraph::addCopyCGEdge(NodeID src, NodeID dst)
 
     ConstraintNode* srcNode = getConstraintNode(src);
     ConstraintNode* dstNode = getConstraintNode(dst);
-    if(hasEdge(srcNode,dstNode,ConstraintEdge::Copy)
-            || srcNode == dstNode)
+    if (hasEdge(srcNode, dstNode, ConstraintEdge::Copy) || srcNode == dstNode)
         return nullptr;
 
     CopyCGEdge* edge = new CopyCGEdge(srcNode, dstNode, edgeIndex++);
-    bool added = directEdgeSet.insert(edge).second;
-    assert(added && "not added??");
+    if (!directEdgeSet.insert(edge).second) {
+        assert(!"new CopyCGEdge not added??");
+    }
     srcNode->addOutgoingCopyEdge(edge);
     dstNode->addIncomingCopyEdge(edge);
     return edge;
@@ -206,12 +211,14 @@ NormalGepCGEdge*  ConstraintGraph::addNormalGepCGEdge(NodeID src, NodeID dst, co
 {
     ConstraintNode* srcNode = getConstraintNode(src);
     ConstraintNode* dstNode = getConstraintNode(dst);
-    if(hasEdge(srcNode,dstNode,ConstraintEdge::NormalGep))
+    if (hasEdge(srcNode, dstNode, ConstraintEdge::NormalGep))
         return nullptr;
 
     NormalGepCGEdge* edge = new NormalGepCGEdge(srcNode, dstNode,ls, edgeIndex++);
-    bool added = directEdgeSet.insert(edge).second;
-    assert(added && "not added??");
+    if (!directEdgeSet.insert(edge).second)
+    {
+        assert(!"new NormalGepCGEdge not added??");
+    }
     srcNode->addOutgoingGepEdge(edge);
     dstNode->addIncomingGepEdge(edge);
     return edge;
@@ -224,12 +231,14 @@ VariantGepCGEdge* ConstraintGraph::addVariantGepCGEdge(NodeID src, NodeID dst)
 {
     ConstraintNode* srcNode = getConstraintNode(src);
     ConstraintNode* dstNode = getConstraintNode(dst);
-    if(hasEdge(srcNode,dstNode,ConstraintEdge::VariantGep))
+    if (hasEdge(srcNode, dstNode, ConstraintEdge::VariantGep))
         return nullptr;
 
     VariantGepCGEdge* edge = new VariantGepCGEdge(srcNode, dstNode, edgeIndex++);
-    bool added = directEdgeSet.insert(edge).second;
-    assert(added && "not added??");
+    if (!directEdgeSet.insert(edge).second)
+    {
+        assert(!"new VariantGepCGEdge not added??");
+    }
     srcNode->addOutgoingGepEdge(edge);
     dstNode->addIncomingGepEdge(edge);
     return edge;
@@ -242,12 +251,14 @@ LoadCGEdge* ConstraintGraph::addLoadCGEdge(NodeID src, NodeID dst)
 {
     ConstraintNode* srcNode = getConstraintNode(src);
     ConstraintNode* dstNode = getConstraintNode(dst);
-    if(hasEdge(srcNode,dstNode,ConstraintEdge::Load))
+    if (hasEdge(srcNode, dstNode, ConstraintEdge::Load))
         return nullptr;
 
     LoadCGEdge* edge = new LoadCGEdge(srcNode, dstNode, edgeIndex++);
-    bool added = LoadCGEdgeSet.insert(edge).second;
-    assert(added && "not added??");
+    if (!LoadCGEdgeSet.insert(edge).second)
+    {
+        assert(!"new LoadCGEdge not added??");
+    }
     srcNode->addOutgoingLoadEdge(edge);
     dstNode->addIncomingLoadEdge(edge);
     return edge;
@@ -260,12 +271,14 @@ StoreCGEdge* ConstraintGraph::addStoreCGEdge(NodeID src, NodeID dst)
 {
     ConstraintNode* srcNode = getConstraintNode(src);
     ConstraintNode* dstNode = getConstraintNode(dst);
-    if(hasEdge(srcNode,dstNode,ConstraintEdge::Store))
+    if (hasEdge(srcNode, dstNode, ConstraintEdge::Store))
         return nullptr;
 
     StoreCGEdge* edge = new StoreCGEdge(srcNode, dstNode, edgeIndex++);
-    bool added = StoreCGEdgeSet.insert(edge).second;
-    assert(added && "not added??");
+    if (!StoreCGEdgeSet.insert(edge).second)
+    {
+        assert(!"new StoreCGEdge not added??");
+    }
     srcNode->addOutgoingStoreEdge(edge);
     dstNode->addIncomingStoreEdge(edge);
     return edge;
@@ -369,8 +382,9 @@ void ConstraintGraph::removeAddrEdge(AddrCGEdge* edge)
     getConstraintNode(edge->getSrcID())->removeOutgoingAddrEdge(edge);
     getConstraintNode(edge->getDstID())->removeIncomingAddrEdge(edge);
     u32_t num = AddrCGEdgeSet.erase(edge);
-    delete edge;
+    (void) num; // make compiler happy
     assert(num && "edge not in the set, can not remove!!!");
+    delete edge;
 }
 
 /*!
@@ -381,8 +395,9 @@ void ConstraintGraph::removeLoadEdge(LoadCGEdge* edge)
     getConstraintNode(edge->getSrcID())->removeOutgoingLoadEdge(edge);
     getConstraintNode(edge->getDstID())->removeIncomingLoadEdge(edge);
     u32_t num = LoadCGEdgeSet.erase(edge);
-    delete edge;
+    (void) num; // make compiler happy
     assert(num && "edge not in the set, can not remove!!!");
+    delete edge;
 }
 
 /*!
@@ -393,8 +408,9 @@ void ConstraintGraph::removeStoreEdge(StoreCGEdge* edge)
     getConstraintNode(edge->getSrcID())->removeOutgoingStoreEdge(edge);
     getConstraintNode(edge->getDstID())->removeIncomingStoreEdge(edge);
     u32_t num = StoreCGEdgeSet.erase(edge);
-    delete edge;
+    (void) num; // make compiler happy
     assert(num && "edge not in the set, can not remove!!!");
+    delete edge;
 }
 
 /*!
@@ -406,7 +422,7 @@ void ConstraintGraph::removeDirectEdge(ConstraintEdge* edge)
     getConstraintNode(edge->getSrcID())->removeOutgoingDirectEdge(edge);
     getConstraintNode(edge->getDstID())->removeIncomingDirectEdge(edge);
     u32_t num = directEdgeSet.erase(edge);
-
+    (void) num; // make compiler happy
     assert(num && "edge not in the set, can not remove!!!");
     delete edge;
 }

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -364,7 +364,8 @@ ICFGEdge* ICFG::getICFGEdge(const ICFGNode* src, const ICFGNode* dst, ICFGEdge::
 ICFGEdge* ICFG::addIntraEdge(ICFGNode* srcNode, ICFGNode* dstNode)
 {
     checkIntraEdgeParents(srcNode, dstNode);
-    if(ICFGEdge* edge = hasIntraICFGEdge(srcNode,dstNode, ICFGEdge::IntraCF))
+    ICFGEdge* edge = hasIntraICFGEdge(srcNode, dstNode, ICFGEdge::IntraCF);
+    if (edge != nullptr)
     {
         assert(edge->isIntraCFGEdge() && "this should be an intra CFG edge!");
         return nullptr;
@@ -383,7 +384,8 @@ ICFGEdge* ICFG::addConditionalIntraEdge(ICFGNode* srcNode, ICFGNode* dstNode, co
 {
 
     checkIntraEdgeParents(srcNode, dstNode);
-    if(ICFGEdge* edge = hasIntraICFGEdge(srcNode,dstNode, ICFGEdge::IntraCF))
+    ICFGEdge* edge = hasIntraICFGEdge(srcNode, dstNode, ICFGEdge::IntraCF);
+    if (edge != nullptr)
     {
         assert(edge->isIntraCFGEdge() && "this should be an intra CFG edge!");
         return nullptr;
@@ -402,7 +404,8 @@ ICFGEdge* ICFG::addConditionalIntraEdge(ICFGNode* srcNode, ICFGNode* dstNode, co
  */
 ICFGEdge* ICFG::addCallEdge(ICFGNode* srcNode, ICFGNode* dstNode, const Instruction*  cs)
 {
-    if(ICFGEdge* edge = hasInterICFGEdge(srcNode,dstNode, ICFGEdge::CallCF))
+    ICFGEdge* edge = hasInterICFGEdge(srcNode,dstNode, ICFGEdge::CallCF);
+    if (edge != nullptr)
     {
         assert(edge->isCallCFGEdge() && "this should be a call CFG edge!");
         return nullptr;
@@ -419,7 +422,8 @@ ICFGEdge* ICFG::addCallEdge(ICFGNode* srcNode, ICFGNode* dstNode, const Instruct
  */
 ICFGEdge* ICFG::addRetEdge(ICFGNode* srcNode, ICFGNode* dstNode, const Instruction*  cs)
 {
-    if(ICFGEdge* edge = hasInterICFGEdge(srcNode,dstNode, ICFGEdge::RetCF))
+    ICFGEdge* edge = hasInterICFGEdge(srcNode, dstNode, ICFGEdge::RetCF);
+    if (edge != nullptr)
     {
         assert(edge->isRetCFGEdge() && "this should be a return CFG edge!");
         return nullptr;

--- a/lib/Graphs/VFG.cpp
+++ b/lib/Graphs/VFG.cpp
@@ -677,7 +677,8 @@ VFGEdge* VFG::addIntraDirectVFEdge(NodeID srcId, NodeID dstId)
     VFGNode* srcNode = getVFGNode(srcId);
     VFGNode* dstNode = getVFGNode(dstId);
     checkIntraEdgeParents(srcNode, dstNode);
-    if(VFGEdge* edge = hasIntraVFGEdge(srcNode,dstNode, VFGEdge::IntraDirectVF))
+    VFGEdge* edge = hasIntraVFGEdge(srcNode, dstNode, VFGEdge::IntraDirectVF);
+    if (edge != nullptr)
     {
         assert(edge->isDirectVFGEdge() && "this should be a direct value flow edge!");
         return nullptr;
@@ -701,7 +702,8 @@ VFGEdge* VFG::addCallEdge(NodeID srcId, NodeID dstId, CallSiteID csId)
 {
     VFGNode* srcNode = getVFGNode(srcId);
     VFGNode* dstNode = getVFGNode(dstId);
-    if(VFGEdge* edge = hasInterVFGEdge(srcNode,dstNode, VFGEdge::CallDirVF,csId))
+    VFGEdge* edge = hasInterVFGEdge(srcNode, dstNode, VFGEdge::CallDirVF, csId);
+    if (edge != nullptr)
     {
         assert(edge->isCallDirectVFGEdge() && "this should be a direct value flow edge!");
         return nullptr;
@@ -720,7 +722,8 @@ VFGEdge* VFG::addRetEdge(NodeID srcId, NodeID dstId, CallSiteID csId)
 {
     VFGNode* srcNode = getVFGNode(srcId);
     VFGNode* dstNode = getVFGNode(dstId);
-    if(VFGEdge* edge = hasInterVFGEdge(srcNode,dstNode, VFGEdge::RetDirVF,csId))
+    VFGEdge* edge = hasInterVFGEdge(srcNode, dstNode, VFGEdge::RetDirVF, csId);
+    if (edge != nullptr)
     {
         assert(edge->isRetDirectVFGEdge() && "this should be a direct value flow edge!");
         return nullptr;

--- a/lib/MSSA/MemRegion.cpp
+++ b/lib/MSSA/MemRegion.cpp
@@ -562,6 +562,7 @@ void MRGenerator::getEscapObjviaGlobals(NodeBS& globs, const NodeBS& calleeModRe
     for(NodeBS::iterator it = calleeModRef.begin(), eit = calleeModRef.end(); it!=eit; ++it)
     {
         const MemObj* obj = pta->getPAG()->getObject(*it);
+        (void) obj; // Make compiler happy
         assert(obj && "object not found!!");
         if(allGlobals.test(*it))
             globs.set(*it);

--- a/lib/MTA/TCT.cpp
+++ b/lib/MTA/TCT.cpp
@@ -661,6 +661,7 @@ struct DOTGraphTraits<TCT*> : public DefaultDOTGraphTraits
     {
 
         TCTEdge* edge = csThreadTree->getGraphEdge(node, *EI, TCTEdge::ThreadCreateEdge);
+        (void) edge; // Make compiler happy
         assert(edge && "No edge found!!");
         /// black edge for direct call while two functions contain indirect calls will be label with red color
         return "color=black";

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -322,7 +322,9 @@ bool BVDataPTAImpl::readFromFile(const string& filename)
         ss >> id >> base >> offset;
 
         NodeID n = pag->getGepObjVar(base, LocationSet(offset));
-        assert(id == n && "Error adding GepObjNode into SVFIR!");
+        bool matched = id == n;
+        (void) matched;
+        assert(matched && "Error adding GepObjNode into SVFIR!");
 
         getline(F, line);
     }

--- a/lib/SABER/SaberCondAllocator.cpp
+++ b/lib/SABER/SaberCondAllocator.cpp
@@ -309,7 +309,9 @@ SaberCondAllocator::Condition SaberCondAllocator::evaluateBranchCond(const Basic
                 {
                     const BasicBlock *succ1 = branchStmt->getSuccessor(0)->getBB();
                     const BasicBlock *succ2 = branchStmt->getSuccessor(1)->getBB();
-                    assert((succ1 == succ || succ2 == succ) && "not a successor??");
+                    bool is_succ = succ1 == succ || succ2 == succ;
+                    (void) is_succ; // Make compiler happy
+                    assert(is_succ && "not a successor??");
 
                     Condition evalLoopExit = evaluateLoopExitBranch(bb, succ);
                     if (!eq(evalLoopExit, Condition::nullExpr()))

--- a/lib/SVF-FE/CHGBuilder.cpp
+++ b/lib/SVF-FE/CHGBuilder.cpp
@@ -491,8 +491,8 @@ void CHGBuilder::analyzeVTables(const Module &M)
                                     else if (const ConstantExpr *aliasconst =
                                                  SVFUtil::dyn_cast<ConstantExpr>(aliasValue))
                                     {
-                                        u32_t aliasopcode = aliasconst->getOpcode();
-                                        assert(aliasopcode == Instruction::BitCast &&
+                                        (void) aliasconst; // Make compiler happy
+                                        assert(aliasconst->getOpcode() == Instruction::BitCast &&
                                                "aliased constantexpr in vtable not a bitcast");
                                         const Function* aliasbitcastfunc =
                                             SVFUtil::dyn_cast<Function>(aliasconst->getOperand(0));

--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -621,7 +621,10 @@ void SVFIRBuilder::visitPHINode(PHINode &inst)
     {
         const Value* val = inst.getIncomingValue(i);
         const Instruction* incomingInst = SVFUtil::dyn_cast<Instruction>(val);
-        assert((incomingInst==nullptr) || (incomingInst->getFunction() == inst.getFunction()));
+        bool f_correct = incomingInst == nullptr ||
+                         incomingInst->getFunction() == inst.getFunction();
+        (void) f_correct; // Make compiler happy
+        assert(f_correct && "incomingInst's Function incorrect");
         const Instruction* predInst = &inst.getIncomingBlock(i)->back();
         const ICFGNode* icfgNode = pag->getICFG()->getICFGNode(predInst);
         NodeID src = getValueNode(val);

--- a/lib/SVF-FE/SVFIRBuilder.cpp
+++ b/lib/SVF-FE/SVFIRBuilder.cpp
@@ -621,10 +621,10 @@ void SVFIRBuilder::visitPHINode(PHINode &inst)
     {
         const Value* val = inst.getIncomingValue(i);
         const Instruction* incomingInst = SVFUtil::dyn_cast<Instruction>(val);
-        bool f_correct = incomingInst == nullptr ||
+        bool matched = incomingInst == nullptr ||
                          incomingInst->getFunction() == inst.getFunction();
-        (void) f_correct; // Make compiler happy
-        assert(f_correct && "incomingInst's Function incorrect");
+        (void)matched; // Make compiler happy
+        assert(matched && "incomingInst's Function incorrect");
         const Instruction* predInst = &inst.getIncomingBlock(i)->back();
         const ICFGNode* icfgNode = pag->getICFG()->getICFGNode(predInst);
         NodeID src = getValueNode(val);

--- a/lib/WPA/AndersenSFR.cpp
+++ b/lib/WPA/AndersenSFR.cpp
@@ -139,7 +139,10 @@ void AndersenSFR::fieldExpand(NodeSet& initials, s32_t offset, NodeBS& strides, 
             else if (SVFUtil::isa<FIObjVar>(initPN) || SVFUtil::isa<DummyObjVar>(initPN))
                 initOffset = 0;
             else
+            {
                 assert(false && "Not an object node!!");
+                initOffset = 0;
+            }
 
             Set<s32_t> offsets;
             offsets.insert(offset);

--- a/lib/WPA/TypeAnalysis.cpp
+++ b/lib/WPA/TypeAnalysis.cpp
@@ -85,6 +85,7 @@ void TypeAnalysis::callGraphSolveBasedOnCHA(const CallSiteToFunPtrMap& callsites
         {
             virtualCallSites.insert(cs);
             const Value *vtbl = getVCallVtblPtr(cs);
+            (void) vtbl; // Make compiler happy
             assert(pag->hasValueNode(vtbl));
             VFunSet vfns;
             getVFnsFromCHA(cbn, vfns);

--- a/setup.sh
+++ b/setup.sh
@@ -18,7 +18,7 @@ function set_llvm {
     [ -n "$LLVM_DIR" ] && return 0
 
     # use local download directory
-    LLVM_DIR="$SVF_DIR/llvm-13.0.0.obj"
+    LLVM_DIR="$SVF_DIR/llvm-15.0.0.obj"
     [ -d "$LLVM_DIR" ] && return 0
 
     # ... otherwise don't set LLVM_DIR
@@ -57,12 +57,12 @@ fi
 #########
 #export PATH FOR SVF and LLVM executables
 #########
-if [[ $1 == 'debug' ]]
-then
-PTAOBJTY='Debug'
+if [[ $1 =~ ^[Dd]ebug ]]; then
+    PTAOBJTY='Debug'
 else
-PTAOBJTY='Release'
+    PTAOBJTY='Release'
 fi
+
 Build=$PTAOBJTY'-build'
 
 export PATH=$LLVM_DIR/bin:$PATH


### PR DESCRIPTION
Changes:
- Let ARM Apple use the prebuilt LLVM libraries
- Let AMD64 Linux build LLVM libraries from source (as it is not available on LLVM GitHub release page)
- Update how variables specifically defined for assertions are used.