### PR TITLE
LLVM 15 fixes

### DIFF
--- a/include/SVF-FE/LLVMUtil.h
+++ b/include/SVF-FE/LLVMUtil.h
@@ -68,7 +68,7 @@ static inline Type *getPtrElementType(const PointerType* pty)
 #if (LLVM_VERSION_MAJOR < 14)
     return pty->getElementType();
 #else
-    assert(!pty->isOpaque() && "Opaque Pointer is used, please recompile the source adding '-Xclang -no-opaque-pointer'");
+    assert(!pty->isOpaque() && "Opaque Pointer is used, please recompile the source adding '-Xclang -no-opaque-pointers'");
     return pty->getNonOpaquePointerElementType();
 #endif
 }

--- a/lib/SVF-FE/SymbolTableBuilder.cpp
+++ b/lib/SVF-FE/SymbolTableBuilder.cpp
@@ -434,7 +434,7 @@ void SymbolTableBuilder::handleGlobalCE(const GlobalVariable *G)
     assert(G);
 
     //The type this global points to
-    const Type *T = G->getType()->getContainedType(0);
+    const Type *T = G->getValueType();
     bool is_array = 0;
     //An array is considered a single variable of its type.
     while (const ArrayType *AT = SVFUtil::dyn_cast<ArrayType>(T))


### PR DESCRIPTION
This fixes one typo and replace one deprecated function according to [the LLVM documentation](https://llvm.org/docs/OpaquePointers.html).

BTW, is there any plan how to continue with LLVM 16? As far as I can see, SVF relies heavily on pointer types which will be removed entirely with LLVM 16. We use SVF for [ARA](https://github.com/luhsra/ara) (currently an old version), which in turn also relies on pointer types for other analyses. Migrating to LLVM 16 would make the analyses much more inaccurate. Do you know of any discussion about that topic?