### PR TITLE
Build system enhancements

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           echo $(pwd)
-          if [ "$RUNNER_OS" == "Linux" ]; then sed -i "s/-fno-rtti/-fno-rtti -fprofile-arcs -ftest-coverage/g" CMakeLists.txt; fi
+          if [ "$RUNNER_OS" == "Linux" ]; then export SVF_COVERAGE=1; fi
           git clone "https://github.com/SVF-tools/Test-Suite.git";
           source ${{github.workspace}}/build.sh
       # run ctest

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 Release*/
 Debug*/
 build/
-include/Util/config.h
 html/
 Test-Suite/
 Release+Asserts/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,20 @@ if(NOT COMMAND add_llvm_library)
 
         add_compile_options("-Werror" "-Wall")
 
-        if(CMAKE_BUILD_TYPE MATCHES "Debug")
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAGS} -O0 -fno-rtti")
-            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_FLAGS} -O0")
-        else()
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAGS} -O3 -fno-rtti")
-            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_FLAGS} -O3")
         find_package(LLVM REQUIRED CONFIG
           HINTS "${LLVM_DIR}")
 
         message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
         message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
+        if (NOT LLVM_ENABLE_RTTI)
+          add_compile_options("-fno-rtti")
+          message(STATUS "Disable RTTI")
+        endif()
+
+        if (NOT LLVM_ENABLE_EH)
+          add_compile_options("-fno-exceptions")
+          message(STATUS "Disable exceptions")
         endif()
 
         list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,6 @@ configure_file(${CMAKE_SOURCE_DIR}/.config.in ${CMAKE_BINARY_DIR}/include/Util/c
 # we check for the presence of the add_llvm_loadable_module command.
 # - if this command is not present, we are building out-of-source
 if(NOT COMMAND add_llvm_library)
-    if (DEFINED LLVM_DIR)
-        set(ENV{LLVM_DIR} "${LLVM_DIR}")
-    endif()
-    if (DEFINED ENV{LLVM_DIR})
         # We need to match the build environment for LLVM:
         # In particular, we need C++14 and the -fno-rtti flag
         set(CMAKE_CXX_STANDARD 14)
@@ -27,10 +23,14 @@ if(NOT COMMAND add_llvm_library)
         else()
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAGS} -O3 -fno-rtti")
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_FLAGS} -O3")
+        find_package(LLVM REQUIRED CONFIG
+          HINTS "${LLVM_DIR}")
+
+        message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+        message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
         endif()
 
-        find_package(LLVM REQUIRED CONFIG)
-        
         list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
         include(AddLLVM)
 
@@ -42,13 +42,6 @@ if(NOT COMMAND add_llvm_library)
         else()
             llvm_map_components_to_libnames(llvm_libs bitwriter core ipo irreader instcombine instrumentation target linker analysis scalaropts support transformutils)
         endif()
-
-    else()
-        message(FATAL_ERROR "\
-WARNING: The LLVM_DIR var was not set (required for an out-of-source build)!\n\
-Please set this to environment variable to point to the LLVM build directory\
-(e.g. on linux: export LLVM_DIR=/path/to/llvm/build/dir)")
-    endif()
 else()
         set(IN_SOURCE_BUILD 1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ if(NOT COMMAND add_llvm_library)
           message(STATUS "Disable exceptions")
         endif()
 
+        if (SVF_COVERAGE OR DEFINED ENV{SVF_COVERAGE})
+          add_compile_options("-fprofile-arcs" "-ftest-coverage")
+          add_link_options("-fprofile-arcs" "-ftest-coverage")
+          message(STATUS "Enable coverage")
+        endif()
+
         list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
         include(AddLLVM)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,14 +54,11 @@ else()
         set(IN_SOURCE_BUILD 1)
 endif()
 
-if (DEFINED Z3_DIR)
-    set(ENV{Z3_DIR} "${Z3_DIR}")
-endif()
-find_library(Z3_LIBRARIES NAMES libz3.a libz3.so
-                          HINTS $ENV{Z3_DIR}
-                          PATH_SUFFIXES lib bin)
+find_library(Z3_LIBRARIES NAMES z3
+                          HINTS ${Z3_DIR} ENV Z3_DIR
+                          PATH_SUFFIXES bin lib)
 find_path(Z3_INCLUDES NAMES z3++.h
-                      HINTS $ENV{Z3_DIR}
+                      HINTS ${Z3_DIR} ENV Z3_DIR
                       PATH_SUFFIXES include z3)
 if(NOT Z3_LIBRARIES OR NOT Z3_INCLUDES)
     message(FATAL_ERROR "Z3 not found!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.13.4)
 
 project("SVF")
 
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/.config.in ${CMAKE_CURRENT_SOURCE_DIR}/include/Util/config.h @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/.config.in ${CMAKE_BINARY_DIR}/include/Util/config.h)
 
 # To support both in- and out-of-source builds,
 # we check for the presence of the add_llvm_loadable_module command.
@@ -67,6 +66,7 @@ message(STATUS "Found Z3: ${Z3_LIBRARIES}")
 message(STATUS "Z3 include dir: ${Z3_INCLUDES}")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
+                    ${CMAKE_BINARY_DIR}/include
                     ${Z3_INCLUDES})
 
 # checks if the test-suite is present, if it is then build bc files and add testing to cmake build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT COMMAND add_llvm_library)
         # add -std=gnu++14
         set(CMAKE_CXX_EXTENSIONS ON)
 
-        set(COMMON_FLAGS "-fPIC -Werror -Wall")
+        add_compile_options("-Werror" "-Wall")
 
         if(CMAKE_BUILD_TYPE MATCHES "Debug")
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAGS} -O0 -fno-rtti")

--- a/build.sh
+++ b/build.sh
@@ -201,6 +201,11 @@ then
             echo "Unzipping z3 package..."
             unzip -q "z3.zip" && mv ./z3-* ./$Z3Home
             rm z3.zip
+            if [ "$sysOS" = "Darwin" ]
+            then
+              # Fix missing rpath information in libz3
+              install_name_tool -id @rpath/libz3.dylib "$Z3Home/bin/libz3.dylib"
+            fi
         fi
     fi
 


### PR DESCRIPTION
Those are a couple of smaller fixes that simplify the build system:
* It allows to automatically detect and use systems' LLVM/Z3 libraries if available.
* Support MacOS Z3 dylib
* be more verbose of detected and used libraries

This also allows to use `cmake` directly avoiding the `build.sh` script if not needed, i.e. for alternative configurations.