### PR TITLE
Fix compiler error under MacOS about unsafe usage of `sprintf`.

### DIFF
--- a/include/MSSA/MemRegion.h
+++ b/include/MSSA/MemRegion.h
@@ -98,7 +98,7 @@ public:
                 ii != ie; ii++)
         {
             char int2str[16];
-            sprintf(int2str, "%d", *ii);
+            snprintf(int2str, sizeof(int2str), "%d", *ii);
             str += int2str;
             str += " ";
         }

--- a/include/MemoryModel/ConditionalPT.h
+++ b/include/MemoryModel/ConditionalPT.h
@@ -732,7 +732,7 @@ public:
                     ii != ie; ii++)
             {
                 char int2str[16];
-                sprintf(int2str, "%d", *ii);
+                snprintf(int2str, sizeof(int2str), "%d", *ii);
                 str += int2str;
                 str += " ";
             }


### PR DESCRIPTION
Use safer `snprintf` instead to avoid buffer overflows.