### PR TITLE
Refactor boilerplate code of disjunctive predicates of "isa()"

### DIFF
--- a/include/DDA/DDAVFSolver.h
+++ b/include/DDA/DDAVFSolver.h
@@ -177,10 +177,9 @@ protected:
         {
             handleAddr(pts,dpm,SVFUtil::cast<AddrSVFGNode>(node));
         }
-        else if(SVFUtil::isa<CopySVFGNode>(node) || SVFUtil::isa<PHISVFGNode>(node)
-                || SVFUtil::isa<ActualParmSVFGNode>(node) || SVFUtil::isa<FormalParmSVFGNode>(node)
-                || SVFUtil::isa<ActualRetSVFGNode>(node) || SVFUtil::isa<FormalRetSVFGNode>(node)
-                || SVFUtil::isa<NullPtrSVFGNode>(node))
+        else if (SVFUtil::isa<CopySVFGNode, PHISVFGNode, ActualParmSVFGNode,
+                              FormalParmSVFGNode, ActualRetSVFGNode,
+                              FormalRetSVFGNode, NullPtrSVFGNode>(node))
         {
             backtraceAlongDirectVF(pts,dpm);
         }
@@ -579,10 +578,7 @@ protected:
     /// Whether this is a top-level pointer statement
     inline bool isTopLevelPtrStmt(const SVFGNode* stmt)
     {
-        if (SVFUtil::isa<StoreSVFGNode>(stmt) || SVFUtil::isa<MRSVFGNode>(stmt))
-            return false;
-        else
-            return true;
+        return SVFUtil::isa<StoreSVFGNode, MRSVFGNode>(stmt);
     }
     /// Return dpm with old context and path conditions
     virtual inline DPIm getDPImWithOldCond(const DPIm& oldDpm,const CVar& var, const SVFGNode* loc)

--- a/include/Graphs/SVFGOPT.h
+++ b/include/Graphs/SVFGOPT.h
@@ -230,8 +230,8 @@ private:
     /// Return TRUE if both edges are indirect call/ret edges.
     inline bool bothInterEdges(const SVFGEdge* edge1, const SVFGEdge* edge2) const
     {
-        bool inter1 = (SVFUtil::isa<CallIndSVFGEdge>(edge1) || SVFUtil::isa<RetIndSVFGEdge>(edge1));
-        bool inter2 = (SVFUtil::isa<CallIndSVFGEdge>(edge2) || SVFUtil::isa<RetIndSVFGEdge>(edge2));
+        bool inter1 = SVFUtil::isa<CallIndSVFGEdge, RetIndSVFGEdge>(edge1);
+        bool inter2 = SVFUtil::isa<CallIndSVFGEdge, RetIndSVFGEdge>(edge2);
         return (inter1 && inter2);
     }
 

--- a/include/MTA/MTAResultValidator.h
+++ b/include/MTA/MTAResultValidator.h
@@ -417,7 +417,7 @@ private:
         I = I->getPrevNode();
         while (I)
         {
-            if (SVFUtil::isa<LoadInst>(I) || SVFUtil::isa<StoreInst>(I))
+            if (SVFUtil::isa<LoadInst, StoreInst>(I))
                 return I;
 
             const SVFInstruction* inst = LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(I);

--- a/include/Util/Casting.h
+++ b/include/Util/Casting.h
@@ -236,11 +236,18 @@ struct isa_impl_wrap<To, FromTy, FromTy>
 // template type argument.  Used like this:
 //
 //  if (SVFUtil::isa<Type>(myVal)) { ... }
+//  if (SVFUtil::isa<Type0, Type1, Type2>(myVal)) { ... }
 //
 template <class X, class Y> LLVM_NODISCARD inline bool isa(const Y &Val)
 {
     return isa_impl_wrap<X, const Y,
            typename simplify_type<const Y>::SimpleType>::doit(Val);
+}
+
+template <typename First, typename Second, typename... Rest, typename Y>
+LLVM_NODISCARD inline bool isa(const Y &Val) 
+{
+    return SVFUtil::isa<First>(Val) || SVFUtil::isa<Second, Rest...>(Val);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/CFL/CFLStat.cpp
+++ b/lib/CFL/CFLStat.cpp
@@ -79,7 +79,7 @@ void CFLStat::CFLSolverStat()
  */
 void CFLStat::performStat()
 {
-    assert((SVFUtil::isa<CFLAlias>(pta)||SVFUtil::isa<CFLVF>(pta)) && "not an CFLAlias pass!! what else??");
+    assert((SVFUtil::isa<CFLAlias, CFLVF>(pta)) && "not an CFLAlias pass!! what else??");
     endClk();
 
     // Grammar stat

--- a/lib/DDA/ContextDDA.cpp
+++ b/lib/DDA/ContextDDA.cpp
@@ -348,7 +348,7 @@ bool ContextDDA::isHeapCondMemObj(const CxtVar& var, const StoreSVFGNode*)
             }
             else
             {
-                assert((SVFUtil::isa<DummyObjVar>(pnode) || SVFUtil::isa<DummyValVar>(pnode))
+                assert((SVFUtil::isa<DummyObjVar, DummyValVar>(pnode))
                        && "empty refVal in non-dummy object");
             }
             return true;

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -480,7 +480,7 @@ bool ConstraintGraph::moveInEdgesToRepNode(ConstraintNode* node, ConstraintNode*
             }
             removeDirectEdge(edge);
         }
-        else if(SVFUtil::isa<LoadCGEdge>(edge) || SVFUtil::isa<StoreCGEdge>(edge))
+        else if(SVFUtil::isa<LoadCGEdge, StoreCGEdge>(edge))
             reTargetDstOfEdge(edge,rep);
         else if(AddrCGEdge* addr = SVFUtil::dyn_cast<AddrCGEdge>(edge))
         {
@@ -539,7 +539,7 @@ bool ConstraintGraph::moveOutEdgesToRepNode(ConstraintNode*node, ConstraintNode*
             }
             removeDirectEdge(edge);
         }
-        else if(SVFUtil::isa<LoadCGEdge>(edge) || SVFUtil::isa<StoreCGEdge>(edge))
+        else if(SVFUtil::isa<LoadCGEdge, StoreCGEdge>(edge))
             reTargetSrcOfEdge(edge,rep);
         else if(AddrCGEdge* addr = SVFUtil::dyn_cast<AddrCGEdge>(edge))
         {

--- a/lib/MTA/FSMPTA.cpp
+++ b/lib/MTA/FSMPTA.cpp
@@ -270,7 +270,8 @@ bool MTASVFGBuilder::isTailofSpan(const StmtSVFGNode* n, InstSet mergespan)
 
     for (SVFGNodeIDSet::iterator it = succ.begin(), eit = succ.end(); it != eit; ++it)
     {
-        assert ((SVFUtil::isa<StoreSVFGNode>(svfg->getSVFGNode(*it)) || SVFUtil::isa<LoadSVFGNode>(svfg->getSVFGNode(*it))) && "succ is not a store/load node");
+        assert((SVFUtil::isa<StoreSVFGNode, LoadSVFGNode>(svfg->getSVFGNode(*it))) &&
+               "succ is not a store/load node");
         const StmtSVFGNode* succNode = SVFUtil::dyn_cast<StmtSVFGNode>(svfg->getSVFGNode(*it));
         const SVFInstruction* succIns = succNode->getInst();
 
@@ -292,7 +293,8 @@ bool MTASVFGBuilder::isTailofSpan(const StmtSVFGNode* n, LockAnalysis::LockSpan 
     SVFGNodeIDSet succ = getSuccNodes(n);
     for (SVFGNodeIDSet::iterator it = succ.begin(), eit = succ.end(); it != eit; ++it)
     {
-        assert ((SVFUtil::isa<StoreSVFGNode>(svfg->getSVFGNode(*it)) || SVFUtil::isa<LoadSVFGNode>(svfg->getSVFGNode(*it))) && "succ is not a store/load node");
+        assert((SVFUtil::isa<StoreSVFGNode, LoadSVFGNode>(svfg->getSVFGNode(*it))) &&
+               "succ is not a store/load node");
         if (SVFUtil::isa<LoadSVFGNode>(svfg->getSVFGNode(*it)))
             continue;
         const StmtSVFGNode* succNode = SVFUtil::dyn_cast<StmtSVFGNode>(svfg->getSVFGNode(*it));
@@ -322,8 +324,7 @@ bool MTASVFGBuilder::isTailofSpan(const StmtSVFGNode* n)
 
     for (SVFGNodeIDSet::iterator it = succ.begin(), eit = succ.end(); it != eit; ++it)
     {
-        assert((SVFUtil::isa<StoreSVFGNode>(svfg->getSVFGNode(*it)) || SVFUtil::isa<LoadSVFGNode>(svfg->getSVFGNode(*it)))
-               && "succ is not a store/load node");
+        assert((SVFUtil::isa<StoreSVFGNode, LoadSVFGNode>(svfg->getSVFGNode(*it))) && "succ is not a store/load node");
         if (SVFUtil::isa<LoadSVFGNode>(svfg->getSVFGNode(*it)))
             continue;
 
@@ -401,7 +402,7 @@ MTASVFGBuilder::SVFGNodeIDSet MTASVFGBuilder::getSuccNodes(const StmtSVFGNode* n
         const SVFGNode* node = *worklist.begin();
         worklist.erase(worklist.begin());
         visited.insert(node);
-        if (SVFUtil::isa<StoreSVFGNode>(node) || SVFUtil::isa<LoadSVFGNode>(node))
+        if (SVFUtil::isa<StoreSVFGNode, LoadSVFGNode>(node))
             succ.set(node->getId());
         else
         {
@@ -440,7 +441,7 @@ MTASVFGBuilder::SVFGNodeIDSet MTASVFGBuilder::getSuccNodes(const StmtSVFGNode* n
         const SVFGNode* node = *worklist.begin();
         worklist.erase(worklist.begin());
         visited.insert(node);
-        if (SVFUtil::isa<StoreSVFGNode>(node) || SVFUtil::isa<LoadSVFGNode>(node))
+        if (SVFUtil::isa<StoreSVFGNode, LoadSVFGNode>(node))
             succ.set(node->getId());
         else
         {

--- a/lib/MTA/LockAnalysis.cpp
+++ b/lib/MTA/LockAnalysis.cpp
@@ -456,7 +456,7 @@ void LockAnalysis::handleRet(const CxtStmt& cts)
     for (PTACallGraphNode::const_iterator it = curFunNode->getInEdges().begin(), eit = curFunNode->getInEdges().end(); it != eit; ++it)
     {
         PTACallGraphEdge* edge = *it;
-        if (SVFUtil::isa<ThreadForkEdge>(edge) || SVFUtil::isa<ThreadJoinEdge>(edge))
+        if (SVFUtil::isa<ThreadForkEdge, ThreadJoinEdge>(edge))
             continue;
         for (PTACallGraphEdge::CallInstSet::const_iterator cit = (edge)->directCallsBegin(), ecit = (edge)->directCallsEnd(); cit != ecit;
                 ++cit)

--- a/lib/MTA/MHP.cpp
+++ b/lib/MTA/MHP.cpp
@@ -41,8 +41,8 @@ using namespace SVFUtil;
 /*!
  * Constructor
  */
-MHP::MHP(TCT* t) :tcg(t->getThreadCallGraph()),tct(t),numOfTotalQueries(0),numOfMHPQueries(0),
-    interleavingTime(0),interleavingQueriesTime(0)
+MHP::MHP(TCT* t) : tcg(t->getThreadCallGraph()), tct(t), numOfTotalQueries(0), numOfMHPQueries(0),
+                   interleavingTime(0), interleavingQueriesTime(0)
 {
     fja = new ForkJoinAnalysis(tct);
     fja->analyzeForkJoinPair();
@@ -61,14 +61,12 @@ MHP::~MHP()
  */
 void MHP::analyze()
 {
-
     DBOUT(DGENERAL, outs() << pasMsg("MHP interleaving analysis\n"));
     DBOUT(DMTA, outs() << pasMsg("MHP interleaving analysis\n"));
     DOTIMESTAT(double interleavingStart = PTAStat::getClk(true));
     analyzeInterleaving();
     DOTIMESTAT(double interleavingEnd = PTAStat::getClk(true));
     DOTIMESTAT(interleavingTime += (interleavingEnd - interleavingStart) / TIMEINTERVAL);
-
 }
 
 /*!
@@ -76,27 +74,27 @@ void MHP::analyze()
  */
 void MHP::analyzeInterleaving()
 {
-    for(TCT::const_iterator it = tct->begin(), eit = tct->end(); it!=eit; ++it)
+    for (TCT::const_iterator it = tct->begin(), eit = tct->end(); it != eit; ++it)
     {
         const CxtThread& ct = it->second->getCxtThread();
         NodeID rootTid = it->first;
         const SVFFunction* routine = tct->getStartRoutineOfCxtThread(ct);
         const SVFInstruction* svfInst = routine->getEntryBlock()->front();
-        CxtThreadStmt rootcts(rootTid,ct.getContext(),svfInst);
+        CxtThreadStmt rootcts(rootTid, ct.getContext(), svfInst);
 
-        addInterleavingThread(rootcts,rootTid);
+        addInterleavingThread(rootcts, rootTid);
         updateAncestorThreads(rootTid);
         updateSiblingThreads(rootTid);
 
-        while(!cxtStmtList.empty())
+        while (!cxtStmtList.empty())
         {
             CxtThreadStmt cts = popFromCTSWorkList();
             const SVFInstruction* curInst = cts.getStmt();
-            DBOUT(DMTA,outs() << "-----\nMHP analysis root thread: " << rootTid << " ");
-            DBOUT(DMTA,cts.dump());
-            DBOUT(DMTA,outs() << "current thread interleaving: < ");
-            DBOUT(DMTA,dumpSet(getInterleavingThreads(cts)));
-            DBOUT(DMTA,outs() << " >\n-----\n");
+            DBOUT(DMTA, outs() << "-----\nMHP analysis root thread: " << rootTid << " ");
+            DBOUT(DMTA, cts.dump());
+            DBOUT(DMTA, outs() << "current thread interleaving: < ");
+            DBOUT(DMTA, dumpSet(getInterleavingThreads(cts)));
+            DBOUT(DMTA, outs() << " >\n-----\n");
 
             /// handle non-candidate function
             if (!tct->isCandidateFun(curInst->getParent()->getParent()))
@@ -106,22 +104,22 @@ void MHP::analyzeInterleaving()
             /// handle candidate function
             else
             {
-                if(isTDFork(curInst))
+                if (isTDFork(curInst))
                 {
-                    handleFork(cts,rootTid);
+                    handleFork(cts, rootTid);
                 }
-                else if(isTDJoin(curInst))
+                else if (isTDJoin(curInst))
                 {
-                    handleJoin(cts,rootTid);
+                    handleJoin(cts, rootTid);
                 }
-                else if(SVFUtil::isCallSite(curInst) && !isExtCall(curInst))
+                else if (SVFUtil::isCallSite(curInst) && !isExtCall(curInst))
                 {
-                    handleCall(cts,rootTid);
+                    handleCall(cts, rootTid);
                     PTACallGraph::FunctionSet callees;
-                    if(!tct->isCandidateFun(getCallee(curInst, callees)))
+                    if (!tct->isCandidateFun(getCallee(curInst, callees)))
                         handleIntra(cts);
                 }
-                else if(curInst->isRetInst())
+                else if (curInst->isRetInst())
                 {
                     handleRet(cts);
                 }
@@ -136,8 +134,7 @@ void MHP::analyzeInterleaving()
     /// update non-candidate functions' interleaving
     updateNonCandidateFunInterleaving();
 
-
-    if(Options::PrintInterLev)
+    if (Options::PrintInterLev)
         printInterleaving();
 }
 
@@ -212,19 +209,20 @@ void MHP::handleFork(const CxtThreadStmt& cts, NodeID rootTid)
 
     assert(isTDFork(call));
     CallICFGNode* cbn = getCBN(call);
-    if(tct->getThreadCallGraph()->hasCallGraphEdge(cbn))
+    if (tct->getThreadCallGraph()->hasCallGraphEdge(cbn))
     {
 
         for (ThreadCallGraph::ForkEdgeSet::const_iterator cgIt = tcg->getForkEdgeBegin(cbn),
-                ecgIt = tcg->getForkEdgeEnd(cbn); cgIt != ecgIt; ++cgIt)
+                                                          ecgIt = tcg->getForkEdgeEnd(cbn);
+             cgIt != ecgIt; ++cgIt)
         {
             const SVFFunction* svfroutine = (*cgIt)->getDstNode()->getFunction();
             CallStrCxt newCxt = curCxt;
-            pushCxt(newCxt,call,svfroutine);
+            pushCxt(newCxt, call, svfroutine);
             const SVFInstruction* stmt = svfroutine->getEntryBlock()->front();
-            CxtThread ct(newCxt,call);
-            CxtThreadStmt newcts(tct->getTCTNode(ct)->getId(),ct.getContext(),stmt);
-            addInterleavingThread(newcts,cts);
+            CxtThread ct(newCxt, call);
+            CxtThreadStmt newcts(tct->getTCTNode(ct)->getId(), ct.getContext(), stmt);
+            addInterleavingThread(newcts, cts);
         }
     }
     handleIntra(cts);
@@ -241,45 +239,45 @@ void MHP::handleJoin(const CxtThreadStmt& cts, NodeID rootTid)
 
     assert(isTDJoin(call));
 
-    NodeBS joinedTids = getDirAndIndJoinedTid(curCxt,call);
-    if(!joinedTids.empty())
+    NodeBS joinedTids = getDirAndIndJoinedTid(curCxt, call);
+    if (!joinedTids.empty())
     {
-        if(fja->hasJoinLoop(call))
+        if (fja->hasJoinLoop(call))
         {
-            std::vector<const SVFBasicBlock*>  exitbbs;
-            call->getFunction()->getExitBlocksOfLoop(call->getParent(),exitbbs);
-            while(!exitbbs.empty())
+            std::vector<const SVFBasicBlock*> exitbbs;
+            call->getFunction()->getExitBlocksOfLoop(call->getParent(), exitbbs);
+            while (!exitbbs.empty())
             {
                 const SVFBasicBlock* eb = exitbbs.back();
                 exitbbs.pop_back();
                 const SVFInstruction* svfEntryInst = eb->front();
-                CxtThreadStmt newCts(cts.getTid(),curCxt,svfEntryInst);
-                addInterleavingThread(newCts,cts);
-                if(hasJoinInSymmetricLoop(curCxt,call))
-                    rmInterleavingThread(newCts,joinedTids,call);
+                CxtThreadStmt newCts(cts.getTid(), curCxt, svfEntryInst);
+                addInterleavingThread(newCts, cts);
+                if (hasJoinInSymmetricLoop(curCxt, call))
+                    rmInterleavingThread(newCts, joinedTids, call);
             }
         }
         else
         {
-            rmInterleavingThread(cts,joinedTids,call);
-            DBOUT(DMTA,outs() << "\n\t match join site " << call->toString() <<  " for thread " << rootTid << "\n");
+            rmInterleavingThread(cts, joinedTids, call);
+            DBOUT(DMTA, outs() << "\n\t match join site " << call->toString() << " for thread " << rootTid << "\n");
         }
     }
     /// for the join site in a loop loop which does not join the current thread
     /// we process the loop exit
     else
     {
-        if(fja->hasJoinLoop(call))
+        if (fja->hasJoinLoop(call))
         {
-            std::vector<const SVFBasicBlock*>  exitbbs;
-            call->getFunction()->getExitBlocksOfLoop(call->getParent(),exitbbs);
-            while(!exitbbs.empty())
+            std::vector<const SVFBasicBlock*> exitbbs;
+            call->getFunction()->getExitBlocksOfLoop(call->getParent(), exitbbs);
+            while (!exitbbs.empty())
             {
                 const SVFBasicBlock* eb = exitbbs.back();
                 exitbbs.pop_back();
                 const SVFInstruction* svfEntryInst = eb->front();
-                CxtThreadStmt newCts(cts.getTid(),cts.getContext(),svfEntryInst);
-                addInterleavingThread(newCts,cts);
+                CxtThreadStmt newCts(cts.getTid(), cts.getContext(), svfEntryInst);
+                addInterleavingThread(newCts, cts);
             }
         }
     }
@@ -295,20 +293,21 @@ void MHP::handleCall(const CxtThreadStmt& cts, NodeID rootTid)
     const SVFInstruction* call = cts.getStmt();
     const CallStrCxt& curCxt = cts.getContext();
     CallICFGNode* cbn = getCBN(call);
-    if(tct->getThreadCallGraph()->hasCallGraphEdge(cbn))
+    if (tct->getThreadCallGraph()->hasCallGraphEdge(cbn))
     {
         for (PTACallGraph::CallGraphEdgeSet::const_iterator cgIt = tcg->getCallEdgeBegin(cbn),
-                ecgIt = tcg->getCallEdgeEnd(cbn); cgIt != ecgIt; ++cgIt)
+                                                            ecgIt = tcg->getCallEdgeEnd(cbn);
+             cgIt != ecgIt; ++cgIt)
         {
 
             const SVFFunction* svfcallee = (*cgIt)->getDstNode()->getFunction();
             if (isExtCall(svfcallee))
                 continue;
             CallStrCxt newCxt = curCxt;
-            pushCxt(newCxt,call,svfcallee);
+            pushCxt(newCxt, call, svfcallee);
             const SVFInstruction* svfEntryInst = svfcallee->getEntryBlock()->front();
-            CxtThreadStmt newCts(cts.getTid(),newCxt,svfEntryInst);
-            addInterleavingThread(newCts,cts);
+            CxtThreadStmt newCts(cts.getTid(), newCxt, svfEntryInst);
+            addInterleavingThread(newCts, cts);
         }
     }
 }
@@ -318,38 +317,38 @@ void MHP::handleCall(const CxtThreadStmt& cts, NodeID rootTid)
  */
 void MHP::handleRet(const CxtThreadStmt& cts)
 {
-
     PTACallGraphNode* curFunNode = tcg->getCallGraphNode(cts.getStmt()->getParent()->getParent());
-    for(PTACallGraphNode::const_iterator it = curFunNode->getInEdges().begin(), eit = curFunNode->getInEdges().end(); it!=eit; ++it)
+    for (PTACallGraphEdge* edge : curFunNode->getInEdges())
     {
-        PTACallGraphEdge* edge = *it;
-        if(SVFUtil::isa<ThreadForkEdge>(edge) || SVFUtil::isa<ThreadJoinEdge>(edge))
+        if (SVFUtil::isa<ThreadForkEdge, ThreadJoinEdge>(edge))
             continue;
-        for(PTACallGraphEdge::CallInstSet::const_iterator cit = (edge)->directCallsBegin(),
-                ecit = (edge)->directCallsEnd(); cit!=ecit; ++cit)
+        for (PTACallGraphEdge::CallInstSet::const_iterator cit = (edge)->directCallsBegin(),
+                                                           ecit = (edge)->directCallsEnd();
+             cit != ecit; ++cit)
         {
             CallStrCxt newCxt = cts.getContext();
-            if(matchCxt(newCxt,(*cit)->getCallSite(),curFunNode->getFunction()))
+            if (matchCxt(newCxt, (*cit)->getCallSite(), curFunNode->getFunction()))
             {
                 const InstVec& nextInsts = (*cit)->getCallSite()->getSuccInstructions();
-                for(InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit!=enit; ++nit)
+                for (const auto& ni : nextInsts)
                 {
-                    CxtThreadStmt newCts(cts.getTid(),newCxt,*nit);
-                    addInterleavingThread(newCts,cts);
+                    CxtThreadStmt newCts(cts.getTid(), newCxt, ni);
+                    addInterleavingThread(newCts, cts);
                 }
             }
         }
-        for(PTACallGraphEdge::CallInstSet::const_iterator cit = (edge)->indirectCallsBegin(),
-                ecit = (edge)->indirectCallsEnd(); cit!=ecit; ++cit)
+        for (PTACallGraphEdge::CallInstSet::const_iterator cit = (edge)->indirectCallsBegin(),
+                                                           ecit = (edge)->indirectCallsEnd();
+             cit != ecit; ++cit)
         {
             CallStrCxt newCxt = cts.getContext();
-            if(matchCxt(newCxt,(*cit)->getCallSite(),curFunNode->getFunction()))
+            if (matchCxt(newCxt, (*cit)->getCallSite(), curFunNode->getFunction()))
             {
                 const InstVec& nextInsts = (*cit)->getCallSite()->getSuccInstructions();
-                for(InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit!=enit; ++nit)
+                for (const auto& ni: nextInsts)
                 {
-                    CxtThreadStmt newCts(cts.getTid(),newCxt,*nit);
-                    addInterleavingThread(newCts,cts);
+                    CxtThreadStmt newCts(cts.getTid(), newCxt, ni);
+                    addInterleavingThread(newCts, cts);
                 }
             }
         }
@@ -363,13 +362,12 @@ void MHP::handleIntra(const CxtThreadStmt& cts)
 {
 
     const InstVec& nextInsts = cts.getStmt()->getSuccInstructions();
-    for(InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit!=enit; ++nit)
+    for (const auto& ni: nextInsts)
     {
-        CxtThreadStmt newCts(cts.getTid(),cts.getContext(),*nit);
-        addInterleavingThread(newCts,cts);
+        CxtThreadStmt newCts(cts.getTid(), cts.getContext(), ni);
+        addInterleavingThread(newCts, cts);
     }
 }
-
 
 /*!
  * Update interleavings of ancestor threads according to TCT
@@ -377,22 +375,22 @@ void MHP::handleIntra(const CxtThreadStmt& cts)
 void MHP::updateAncestorThreads(NodeID curTid)
 {
     NodeBS tds = tct->getAncestorThread(curTid);
-    DBOUT(DMTA,outs() << "##Ancestor thread of " << curTid << " is : ");
-    DBOUT(DMTA,dumpSet(tds));
-    DBOUT(DMTA,outs() << "\n");
+    DBOUT(DMTA, outs() << "##Ancestor thread of " << curTid << " is : ");
+    DBOUT(DMTA, dumpSet(tds));
+    DBOUT(DMTA, outs() << "\n");
     tds.set(curTid);
 
-    for(NodeBS::iterator it = tds.begin(), eit = tds.end(); it!=eit; ++it)
+    for (NodeBS::iterator it = tds.begin(), eit = tds.end(); it != eit; ++it)
     {
         const CxtThread& ct = tct->getTCTNode(*it)->getCxtThread();
-        if(const SVFInstruction* forkInst = ct.getThread())
+        if (const SVFInstruction* forkInst = ct.getThread())
         {
             CallStrCxt forkSiteCxt = tct->getCxtOfCxtThread(ct);
             const InstVec& nextInsts = forkInst->getSuccInstructions();
-            for(InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit!=enit; ++nit)
+            for (const auto& ni: nextInsts)
             {
-                CxtThreadStmt cts(tct->getParentThread(*it),forkSiteCxt,*nit);
-                addInterleavingThread(cts,curTid);
+                CxtThreadStmt cts(tct->getParentThread(*it), forkSiteCxt, ni);
+                addInterleavingThread(cts, curTid);
             }
         }
     }
@@ -412,25 +410,25 @@ void MHP::updateSiblingThreads(NodeID curTid)
 {
     NodeBS tds = tct->getAncestorThread(curTid);
     tds.set(curTid);
-    for(NodeBS::iterator cit = tds.begin(), ecit = tds.end(); cit!=ecit; ++cit)
+    for (NodeBS::iterator cit = tds.begin(), ecit = tds.end(); cit != ecit; ++cit)
     {
-        NodeBS  siblingTds = tct->getSiblingThread(*cit);
-        for(NodeBS::iterator it = siblingTds.begin(), eit = siblingTds.end(); it!=eit; ++it)
+        NodeBS siblingTds = tct->getSiblingThread(*cit);
+        for (NodeBS::iterator it = siblingTds.begin(), eit = siblingTds.end(); it != eit; ++it)
         {
 
-            if((isHBPair(*cit,*it) && isRecurFullJoin(*cit,curTid)) || isHBPair(*it,*cit) )
+            if ((isHBPair(*cit, *it) && isRecurFullJoin(*cit, curTid)) || isHBPair(*it, *cit))
                 continue;
 
             const CxtThread& ct = tct->getTCTNode(*it)->getCxtThread();
             const SVFFunction* routine = tct->getStartRoutineOfCxtThread(ct);
             const SVFInstruction* stmt = routine->getEntryBlock()->front();
-            CxtThreadStmt cts(*it,ct.getContext(),stmt);
-            addInterleavingThread(cts,curTid);
+            CxtThreadStmt cts(*it, ct.getContext(), stmt);
+            addInterleavingThread(cts, curTid);
         }
 
-        DBOUT(DMTA,outs() << "##Sibling thread of " << curTid << " is : ");
-        DBOUT(DMTA,dumpSet(siblingTds));
-        DBOUT(DMTA,outs() << "\n");
+        DBOUT(DMTA, outs() << "##Sibling thread of " << curTid << " is : ");
+        DBOUT(DMTA, dumpSet(siblingTds));
+        DBOUT(DMTA, outs() << "\n");
     }
 }
 
@@ -439,24 +437,24 @@ void MHP::updateSiblingThreads(NodeID curTid)
  */
 bool MHP::isRecurFullJoin(NodeID parentTid, NodeID curTid)
 {
-    if(parentTid==curTid)
+    if (parentTid == curTid)
         return true;
 
     const TCTNode* curNode = tct->getTCTNode(curTid);
     FIFOWorkList<const TCTNode*> worklist;
     worklist.push(curNode);
-    while(!worklist.empty())
+    while (!worklist.empty())
     {
         const TCTNode* node = worklist.pop();
-        for(TCT::ThreadCreateEdgeSet::const_iterator it = node->getInEdges().begin(), eit = node->getInEdges().end(); it!=eit; ++it)
+        for (TCTEdge* edge : node->getInEdges())
         {
-            NodeID srcID = (*it)->getSrcID();
-            if(fja->isFullJoin(srcID,node->getId()))
+            NodeID srcID = edge->getSrcID();
+            if (fja->isFullJoin(srcID, node->getId()))
             {
-                if(srcID == parentTid)
+                if (srcID == parentTid)
                     return true;
                 else
-                    worklist.push((*it)->getSrcNode());
+                    worklist.push(edge->getSrcNode());
             }
             else
             {
@@ -466,7 +464,6 @@ bool MHP::isRecurFullJoin(NodeID parentTid, NodeID curTid)
     }
     return false;
 }
-
 
 /*!
  * A join site must join t if
@@ -484,7 +481,7 @@ bool MHP::isMustJoin(NodeID curTid, const SVFInstruction* joinsite)
  */
 NodeBS MHP::getDirAndIndJoinedTid(const CallStrCxt& cxt, const SVFInstruction* call)
 {
-    CxtStmt cs(cxt,call);
+    CxtStmt cs(cxt, call);
     return fja->getDirAndIndJoinedTid(cs);
 }
 
@@ -493,28 +490,24 @@ NodeBS MHP::getDirAndIndJoinedTid(const CallStrCxt& cxt, const SVFInstruction* c
  */
 bool MHP::hasJoinInSymmetricLoop(const CallStrCxt& cxt, const SVFInstruction* call) const
 {
-    CxtStmt cs(cxt,call);
+    CxtStmt cs(cxt, call);
     return fja->hasJoinInSymmetricLoop(cs);
 }
-
 
 /// Whether a context-sensitive join satisfies symmetric loop pattern
 const MHP::LoopBBs& MHP::getJoinInSymmetricLoop(const CallStrCxt& cxt, const SVFInstruction* call) const
 {
-    CxtStmt cs(cxt,call);
+    CxtStmt cs(cxt, call);
     return fja->getJoinInSymmetricLoop(cs);
 }
-
 
 /*!
  * Whether two thread t1 happens-fore t2
  */
 bool MHP::isHBPair(NodeID tid1, NodeID tid2)
 {
-    return fja->isHBPair(tid1,tid2);
+    return fja->isHBPair(tid1, tid2);
 }
-
-
 
 bool MHP::isConnectedfromMain(const SVFFunction* fun)
 {
@@ -526,7 +519,7 @@ bool MHP::isConnectedfromMain(const SVFFunction* fun)
     while (!worklist.empty())
     {
         const PTACallGraphNode* node = worklist.pop();
-        if("main" == node->getFunction()->getName())
+        if ("main" == node->getFunction()->getName())
             return true;
         for (PTACallGraphNode::const_iterator nit = node->InEdgeBegin(), neit = node->InEdgeEnd(); nit != neit; nit++)
         {
@@ -555,22 +548,20 @@ bool MHP::mayHappenInParallelInst(const SVFInstruction* i1, const SVFInstruction
 {
 
     /// TODO: Any instruction in dead function is assumed no MHP with others
-    if(!hasThreadStmtSet(i1) || !hasThreadStmtSet(i2))
+    if (!hasThreadStmtSet(i1) || !hasThreadStmtSet(i2))
         return false;
 
     const CxtThreadStmtSet& tsSet1 = getThreadStmtSet(i1);
     const CxtThreadStmtSet& tsSet2 = getThreadStmtSet(i2);
-    for(CxtThreadStmtSet::const_iterator it1 = tsSet1.begin(), eit1 = tsSet1.end(); it1!=eit1; ++it1)
+    for (const CxtThreadStmt& ts1 : tsSet1)
     {
-        const CxtThreadStmt& ts1 = *it1;
         NodeBS l1 = getInterleavingThreads(ts1);
-        for(CxtThreadStmtSet::const_iterator it2 = tsSet2.begin(), eit2 = tsSet2.end(); it2!=eit2; ++it2)
+        for (const CxtThreadStmt& ts2 : tsSet2)
         {
-            const CxtThreadStmt& ts2 = *it2;
             NodeBS l2 = getInterleavingThreads(ts2);
-            if(ts1.getTid()!=ts2.getTid())
+            if (ts1.getTid() != ts2.getTid())
             {
-                if(l1.test(ts2.getTid()) && l2.test(ts1.getTid()))
+                if (l1.test(ts2.getTid()) && l2.test(ts1.getTid()))
                 {
                     numOfMHPQueries++;
                     return true;
@@ -591,11 +582,11 @@ bool MHP::mayHappenInParallelInst(const SVFInstruction* i1, const SVFInstruction
 
 bool MHP::mayHappenInParallelCache(const SVFInstruction* i1, const SVFInstruction* i2)
 {
-    if(!tct->isCandidateFun(i1->getParent()->getParent()) &&!tct->isCandidateFun(i2->getParent()->getParent()))
+    if (!tct->isCandidateFun(i1->getParent()->getParent()) && !tct->isCandidateFun(i2->getParent()->getParent()))
     {
         FuncPair funpair = std::make_pair(i1->getFunction(), i2->getFunction());
         FuncPairToBool::const_iterator it = nonCandidateFuncMHPRelMap.find(funpair);
-        if (it==nonCandidateFuncMHPRelMap.end())
+        if (it == nonCandidateFuncMHPRelMap.end())
         {
             bool mhp = mayHappenInParallelInst(i1, i2);
             nonCandidateFuncMHPRelMap[funpair] = mhp;
@@ -603,12 +594,12 @@ bool MHP::mayHappenInParallelCache(const SVFInstruction* i1, const SVFInstructio
         }
         else
         {
-            if(it->second)
+            if (it->second)
                 numOfMHPQueries++;
             return it->second;
         }
     }
-    return mayHappenInParallelInst(i1,i2);
+    return mayHappenInParallelInst(i1, i2);
 }
 
 bool MHP::mayHappenInParallel(const SVFInstruction* i1, const SVFInstruction* i2)
@@ -616,7 +607,7 @@ bool MHP::mayHappenInParallel(const SVFInstruction* i1, const SVFInstruction* i2
     numOfTotalQueries++;
 
     DOTIMESTAT(double queryStart = PTAStat::getClk(true));
-    bool mhp=mayHappenInParallelCache(i1,i2);
+    bool mhp = mayHappenInParallelCache(i1, i2);
     DOTIMESTAT(double queryEnd = PTAStat::getClk(true));
     DOTIMESTAT(interleavingQueriesTime += (queryEnd - queryStart) / TIMEINTERVAL);
 
@@ -625,44 +616,40 @@ bool MHP::mayHappenInParallel(const SVFInstruction* i1, const SVFInstruction* i2
 
 bool MHP::executedByTheSameThread(const SVFInstruction* i1, const SVFInstruction* i2)
 {
-    if(!hasThreadStmtSet(i1) || !hasThreadStmtSet(i2))
+    if (!hasThreadStmtSet(i1) || !hasThreadStmtSet(i2))
         return true;
 
     const CxtThreadStmtSet& tsSet1 = getThreadStmtSet(i1);
     const CxtThreadStmtSet& tsSet2 = getThreadStmtSet(i2);
-    for(CxtThreadStmtSet::const_iterator it1 = tsSet1.begin(), eit1 = tsSet1.end(); it1!=eit1; ++it1)
+    for (const CxtThreadStmt&ts1 : tsSet1)
     {
-        const CxtThreadStmt& ts1 = *it1;
-        for(CxtThreadStmtSet::const_iterator it2 = tsSet2.begin(), eit2 = tsSet2.end(); it2!=eit2; ++it2)
+        for (const CxtThreadStmt& ts2 : tsSet2)
         {
-            const CxtThreadStmt& ts2 = *it2;
-            if(ts1.getTid()!=ts2.getTid())
-                return false;
-            else if (isMultiForkedThread(ts1.getTid()))
+            if (ts1.getTid() != ts2.getTid() || isMultiForkedThread(ts1.getTid()))
                 return false;
         }
     }
     return true;
 }
 
-
 /*!
  * Print interleaving results
  */
 void MHP::printInterleaving()
 {
-    for(ThreadStmtToThreadInterleav::const_iterator it = threadStmtToTheadInterLeav.begin(), eit = threadStmtToTheadInterLeav.end(); it!=eit; ++it)
+    for (const auto& pair : threadStmtToTheadInterLeav)
     {
-        outs() << "( t" << it->first.getTid() << " , $" << it->first.getStmt()->getSourceLoc() << "$" << it->first.getStmt()->toString() << " ) ==> [";
+        outs() << "( t" << pair.first.getTid()
+               << " , $" << pair.first.getStmt()->getSourceLoc()
+               << "$" << it->first.getStmt()->toString() << " ) ==> [";
         for (NodeBS::iterator ii = it->second.begin(), ie = it->second.end();
-                ii != ie; ii++)
+             ii != ie; ii++)
         {
             outs() << " " << *ii << " ";
         }
         outs() << "]\n";
     }
 }
-
 
 /*!
  * Collect SCEV pass information for pointers at fork/join sites
@@ -673,18 +660,20 @@ void MHP::printInterleaving()
 void ForkJoinAnalysis::collectSCEVInfo()
 {
     typedef Set<const SVFInstruction*> CallInstSet;
-    typedef Map<const SVFFunction*, CallInstSet > FunToFJSites;
+    typedef Map<const SVFFunction*, CallInstSet> FunToFJSites;
     FunToFJSites funToFJSites;
 
-    for(ThreadCallGraph::CallSiteSet::const_iterator it = tct->getThreadCallGraph()->forksitesBegin(),
-            eit = tct->getThreadCallGraph()->forksitesEnd(); it!=eit; ++it)
+    for (ThreadCallGraph::CallSiteSet::const_iterator it = tct->getThreadCallGraph()->forksitesBegin(),
+                                                      eit = tct->getThreadCallGraph()->forksitesEnd();
+         it != eit; ++it)
     {
         const SVFInstruction* fork = (*it)->getCallSite();
         funToFJSites[fork->getFunction()].insert(fork);
     }
 
-    for(ThreadCallGraph::CallSiteSet::const_iterator it = tct->getThreadCallGraph()->joinsitesBegin(),
-            eit = tct->getThreadCallGraph()->joinsitesEnd(); it!=eit; ++it)
+    for (ThreadCallGraph::CallSiteSet::const_iterator it = tct->getThreadCallGraph()->joinsitesBegin(),
+                                                      eit = tct->getThreadCallGraph()->joinsitesEnd();
+         it != eit; ++it)
     {
         const SVFInstruction* join = (*it)->getCallSite();
         funToFJSites[join->getFunction()].insert(join);
@@ -724,45 +713,45 @@ void ForkJoinAnalysis::collectSCEVInfo()
  */
 void ForkJoinAnalysis::analyzeForkJoinPair()
 {
-    for(TCT::const_iterator it = tct->begin(), eit = tct->end(); it!=eit; ++it)
+    for (TCT::const_iterator it = tct->begin(), eit = tct->end(); it != eit; ++it)
     {
         const CxtThread& ct = it->second->getCxtThread();
         const NodeID rootTid = it->first;
         clearFlagMap();
-        if(const SVFInstruction* forkInst = ct.getThread())
+        if (const SVFInstruction* forkInst = ct.getThread())
         {
             CallStrCxt forkSiteCxt = tct->getCxtOfCxtThread(ct);
             const SVFInstruction* exitInst = getExitInstOfParentRoutineFun(rootTid);
 
             const InstVec& nextInsts = forkInst->getSuccInstructions();
-            for(InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit!=enit; ++nit)
+            for (InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit != enit; ++nit)
             {
-                CxtStmt cs(forkSiteCxt,*nit);
-                markCxtStmtFlag(cs,TDAlive);
+                CxtStmt cs(forkSiteCxt, *nit);
+                markCxtStmtFlag(cs, TDAlive);
             }
 
-            while(!cxtStmtList.empty())
+            while (!cxtStmtList.empty())
             {
                 CxtStmt cts = popFromCTSWorkList();
                 const SVFInstruction* curInst = cts.getStmt();
-                DBOUT(DMTA,outs() << "-----\nForkJoinAnalysis root thread: " << it->first << " ");
-                DBOUT(DMTA,cts.dump());
-                DBOUT(DMTA,outs() << "-----\n");
+                DBOUT(DMTA, outs() << "-----\nForkJoinAnalysis root thread: " << it->first << " ");
+                DBOUT(DMTA, cts.dump());
+                DBOUT(DMTA, outs() << "-----\n");
                 PTACallGraph::FunctionSet callees;
-                if(isTDFork(curInst))
+                if (isTDFork(curInst))
                 {
-                    handleFork(cts,rootTid);
+                    handleFork(cts, rootTid);
                 }
-                else if(isTDJoin(curInst))
+                else if (isTDJoin(curInst))
                 {
-                    handleJoin(cts,rootTid);
+                    handleJoin(cts, rootTid);
                 }
-                else if(SVFUtil::isCallSite(curInst) && tct->isCandidateFun(getCallee(curInst, callees)))
+                else if (SVFUtil::isCallSite(curInst) && tct->isCandidateFun(getCallee(curInst, callees)))
                 {
 
-                    handleCall(cts,rootTid);
+                    handleCall(cts, rootTid);
                 }
-                else if(curInst->isRetInst())
+                else if (curInst->isRetInst())
                 {
                     handleRet(cts);
                 }
@@ -771,15 +760,14 @@ void ForkJoinAnalysis::analyzeForkJoinPair()
                     handleIntra(cts);
                 }
 
-                if(curInst==exitInst)
+                if (curInst == exitInst)
                 {
-                    if(getMarkedFlag(cts)!=TDAlive)
-                        addToFullJoin(tct->getParentThread(rootTid),rootTid);
+                    if (getMarkedFlag(cts) != TDAlive)
+                        addToFullJoin(tct->getParentThread(rootTid), rootTid);
                     else
-                        addToPartial(tct->getParentThread(rootTid),rootTid);
+                        addToPartial(tct->getParentThread(rootTid), rootTid);
                 }
             }
-
         }
     }
 }
@@ -792,19 +780,20 @@ void ForkJoinAnalysis::handleFork(const CxtStmt& cts, NodeID rootTid)
 
     assert(isTDFork(call));
     CallICFGNode* cbn = getCBN(call);
-    if(getTCG()->hasThreadForkEdge(cbn))
+    if (getTCG()->hasThreadForkEdge(cbn))
     {
         for (ThreadCallGraph::ForkEdgeSet::const_iterator cgIt = getTCG()->getForkEdgeBegin(cbn),
-                ecgIt = getTCG()->getForkEdgeEnd(cbn); cgIt != ecgIt; ++cgIt)
+                                                          ecgIt = getTCG()->getForkEdgeEnd(cbn);
+             cgIt != ecgIt; ++cgIt)
         {
             const SVFFunction* callee = (*cgIt)->getDstNode()->getFunction();
             CallStrCxt newCxt = curCxt;
-            pushCxt(newCxt,call,callee);
-            CxtThread ct(newCxt,call);
-            if(getMarkedFlag(cts)!=TDAlive)
-                addToHBPair(rootTid,tct->getTCTNode(ct)->getId());
+            pushCxt(newCxt, call, callee);
+            CxtThread ct(newCxt, call);
+            if (getMarkedFlag(cts) != TDAlive)
+                addToHBPair(rootTid, tct->getTCTNode(ct)->getId());
             else
-                addToHPPair(rootTid,tct->getTCTNode(ct)->getId());
+                addToHPPair(rootTid, tct->getTCTNode(ct)->getId());
         }
     }
     handleIntra(cts);
@@ -818,56 +807,56 @@ void ForkJoinAnalysis::handleJoin(const CxtStmt& cts, NodeID rootTid)
 
     assert(isTDJoin(call));
     CallICFGNode* cbn = getCBN(call);
-    if(getTCG()->hasCallGraphEdge(cbn))
+    if (getTCG()->hasCallGraphEdge(cbn))
     {
         const SVFInstruction* forkSite = tct->getTCTNode(rootTid)->getCxtThread().getThread();
         const SVFInstruction* joinSite = cts.getStmt();
 
-        if(isAliasedForkJoin(forkSite, joinSite))
+        if (isAliasedForkJoin(forkSite, joinSite))
         {
-            if(hasJoinLoop(joinSite))
+            if (hasJoinLoop(joinSite))
             {
                 LoopBBs& joinLoop = getJoinLoop(joinSite);
-                std::vector<const SVFBasicBlock*>  exitbbs;
-                joinSite->getFunction()->getExitBlocksOfLoop(joinSite->getParent(),exitbbs);
-                while(!exitbbs.empty())
+                std::vector<const SVFBasicBlock *> exitbbs;
+                joinSite->getFunction()->getExitBlocksOfLoop(joinSite->getParent(), exitbbs);
+                while (!exitbbs.empty())
                 {
                     const SVFBasicBlock* eb = exitbbs.back();
                     exitbbs.pop_back();
                     const SVFInstruction* svfEntryInst = eb->front();
-                    CxtStmt newCts(curCxt,svfEntryInst);
-                    addDirectlyJoinTID(cts,rootTid);
-                    if(isSameSCEV(forkSite,joinSite))
+                    CxtStmt newCts(curCxt, svfEntryInst);
+                    addDirectlyJoinTID(cts, rootTid);
+                    if (isSameSCEV(forkSite, joinSite))
                     {
-                        markCxtStmtFlag(newCts,TDDead);
-                        addSymmetricLoopJoin(cts,joinLoop);
+                        markCxtStmtFlag(newCts, TDDead);
+                        addSymmetricLoopJoin(cts, joinLoop);
                     }
                     else
-                        markCxtStmtFlag(cts,TDAlive);
+                        markCxtStmtFlag(cts, TDAlive);
                 }
             }
             else
             {
-                markCxtStmtFlag(cts,TDDead);
-                addDirectlyJoinTID(cts,rootTid);
-                DBOUT(DMTA,outs() << "\n\t match join site " << call->toString() <<  "for thread " << rootTid << "\n");
+                markCxtStmtFlag(cts, TDDead);
+                addDirectlyJoinTID(cts, rootTid);
+                DBOUT(DMTA, outs() << "\n\t match join site " << call->toString() << "for thread " << rootTid << "\n");
             }
         }
         /// for the join site in a loop loop which does not join the current thread
         /// we process the loop exit
         else
         {
-            if(hasJoinLoop(joinSite))
+            if (hasJoinLoop(joinSite))
             {
-                std::vector<const SVFBasicBlock*>  exitbbs;
-                joinSite->getFunction()->getExitBlocksOfLoop(joinSite->getParent(),exitbbs);
-                while(!exitbbs.empty())
+                std::vector<const SVFBasicBlock*> exitbbs;
+                joinSite->getFunction()->getExitBlocksOfLoop(joinSite->getParent(), exitbbs);
+                while (!exitbbs.empty())
                 {
                     const SVFBasicBlock* eb = exitbbs.back();
                     exitbbs.pop_back();
                     const SVFInstruction* svfEntryInst = eb->front();
-                    CxtStmt newCts(curCxt,svfEntryInst);
-                    markCxtStmtFlag(newCts,cts);
+                    CxtStmt newCts(curCxt, svfEntryInst);
+                    markCxtStmtFlag(newCts, cts);
                 }
             }
         }
@@ -882,19 +871,20 @@ void ForkJoinAnalysis::handleCall(const CxtStmt& cts, NodeID rootTid)
     const SVFInstruction* call = cts.getStmt();
     const CallStrCxt& curCxt = cts.getContext();
     CallICFGNode* cbn = getCBN(call);
-    if(getTCG()->hasCallGraphEdge(cbn))
+    if (getTCG()->hasCallGraphEdge(cbn))
     {
         for (PTACallGraph::CallGraphEdgeSet::const_iterator cgIt = getTCG()->getCallEdgeBegin(cbn),
-                ecgIt = getTCG()->getCallEdgeEnd(cbn); cgIt != ecgIt; ++cgIt)
+                                                            ecgIt = getTCG()->getCallEdgeEnd(cbn);
+             cgIt != ecgIt; ++cgIt)
         {
             const SVFFunction* svfcallee = (*cgIt)->getDstNode()->getFunction();
             if (isExtCall(svfcallee))
                 continue;
             CallStrCxt newCxt = curCxt;
-            pushCxt(newCxt,call,svfcallee);
+            pushCxt(newCxt, call, svfcallee);
             const SVFInstruction* svfEntryInst = svfcallee->getEntryBlock()->front();
-            CxtStmt newCts(newCxt,svfEntryInst);
-            markCxtStmtFlag(newCts,cts);
+            CxtStmt newCts(newCxt, svfEntryInst);
+            markCxtStmtFlag(newCts, cts);
         }
     }
 }
@@ -907,36 +897,37 @@ void ForkJoinAnalysis::handleRet(const CxtStmt& cts)
     const CallStrCxt& curCxt = cts.getContext();
 
     PTACallGraphNode* curFunNode = getTCG()->getCallGraphNode(curInst->getFunction());
-    for(PTACallGraphNode::const_iterator it = curFunNode->getInEdges().begin(), eit = curFunNode->getInEdges().end(); it!=eit; ++it)
+    for (PTACallGraphEdge* edge : curFunNode->getInEdges())
     {
-        PTACallGraphEdge* edge = *it;
-        if(SVFUtil::isa<ThreadForkEdge>(edge) || SVFUtil::isa<ThreadJoinEdge>(edge))
+        if (SVFUtil::isa<ThreadForkEdge, ThreadJoinEdge>(edge))
             continue;
-        for(PTACallGraphEdge::CallInstSet::const_iterator cit = (edge)->directCallsBegin(),
-                ecit = (edge)->directCallsEnd(); cit!=ecit; ++cit)
+        for (PTACallGraphEdge::CallInstSet::const_iterator cit = edge->directCallsBegin(),
+                                                           ecit = edge->directCallsEnd();
+             cit != ecit; ++cit)
         {
             CallStrCxt newCxt = curCxt;
-            if(matchCxt(newCxt,(*cit)->getCallSite(),curFunNode->getFunction()))
+            if (matchCxt(newCxt, (*cit)->getCallSite(), curFunNode->getFunction()))
             {
                 const InstVec& nextInsts = (*cit)->getCallSite()->getSuccInstructions();
-                for(InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit!=enit; ++nit)
+                for (const auto& ni : nextInsts)
                 {
-                    CxtStmt newCts(newCxt,*nit);
-                    markCxtStmtFlag(newCts,cts);
+                    CxtStmt newCts(newCxt, ni);
+                    markCxtStmtFlag(newCts, cts);
                 }
             }
         }
-        for(PTACallGraphEdge::CallInstSet::const_iterator cit = (edge)->indirectCallsBegin(),
-                ecit = (edge)->indirectCallsEnd(); cit!=ecit; ++cit)
+        for (PTACallGraphEdge::CallInstSet::const_iterator cit = edge->indirectCallsBegin(),
+                                                           ecit = edge->indirectCallsEnd();
+             cit != ecit; ++cit)
         {
             CallStrCxt newCxt = curCxt;
-            if(matchCxt(newCxt,(*cit)->getCallSite(),curFunNode->getFunction()))
+            if (matchCxt(newCxt, (*cit)->getCallSite(), curFunNode->getFunction()))
             {
                 const InstVec& nextInsts = (*cit)->getCallSite()->getSuccInstructions();
-                for(InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit!=enit; ++nit)
+                for (const auto& ni : nextInsts)
                 {
-                    CxtStmt newCts(newCxt,*nit);
-                    markCxtStmtFlag(newCts,cts);
+                    CxtStmt newCts(newCxt, ni);
+                    markCxtStmtFlag(newCts, cts);
                 }
             }
         }
@@ -951,10 +942,10 @@ void ForkJoinAnalysis::handleIntra(const CxtStmt& cts)
     const CallStrCxt& curCxt = cts.getContext();
 
     const InstVec& nextInsts = curInst->getSuccInstructions();
-    for(InstVec::const_iterator nit = nextInsts.begin(), enit = nextInsts.end(); nit!=enit; ++nit)
+    for (const auto& ni: nextInsts)
     {
-        CxtStmt newCts(curCxt,*nit);
-        markCxtStmtFlag(newCts,cts);
+        CxtStmt newCts(curCxt, ni);
+        markCxtStmtFlag(newCts, cts);
     }
 }
 
@@ -967,26 +958,26 @@ NodeBS ForkJoinAnalysis::getDirAndIndJoinedTid(const CxtStmt& cs)
 {
 
     CxtStmtToTIDMap::const_iterator it = dirAndIndJoinMap.find(cs);
-    if(it!=dirAndIndJoinMap.end())
+    if (it != dirAndIndJoinMap.end())
         return it->second;
 
-    const NodeBS& directJoinTids =  getDirectlyJoinedTid(cs);
+    const NodeBS& directJoinTids = getDirectlyJoinedTid(cs);
     NodeBS allJoinTids = directJoinTids;
 
     FIFOWorkList<NodeID> worklist;
-    for(NodeBS::iterator it = directJoinTids.begin(), eit = directJoinTids.end(); it!=eit; ++it)
+    for (NodeBS::iterator it = directJoinTids.begin(), eit = directJoinTids.end(); it != eit; ++it)
     {
         worklist.push(*it);
     }
 
-    while(!worklist.empty())
+    while (!worklist.empty())
     {
         NodeID tid = worklist.pop();
         TCTNode* node = tct->getTCTNode(tid);
-        for(TCT::ThreadCreateEdgeSet::const_iterator it = tct->getChildrenBegin(node), eit = tct->getChildrenEnd(node); it!=eit; ++it)
+        for (TCT::ThreadCreateEdgeSet::const_iterator it = tct->getChildrenBegin(node), eit = tct->getChildrenEnd(node); it != eit; ++it)
         {
             NodeID childTid = (*it)->getDstID();
-            if(isFullJoin(tid,childTid))
+            if (isFullJoin(tid, childTid))
             {
                 allJoinTids.set(childTid);
                 worklist.push(childTid);
@@ -1051,7 +1042,7 @@ bool ForkJoinAnalysis::isSameSCEV(const SVFInstruction* forkSite, const SVFInstr
     //     return forkse.start==joinse.start && forkse.step == joinse.step && forkse.tripcount <= joinse.tripcount;
     // else if(SVFUtil::isa<GetElementPtrInst>(forkse.ptr) && SVFUtil::isa<GetElementPtrInst>(joinse.ptr))
     //     return accessSameArrayIndex(SVFUtil::cast<GetElementPtrInst>(forkse.ptr),SVFUtil::cast<GetElementPtrInst>(joinse.ptr));
-    // else if(SVFUtil::isa<GetElementPtrInst>(forkse.ptr) || SVFUtil::isa<GetElementPtrInst>(joinse.ptr))
+    // else if(SVFUtil::isa<GetElementPtrInst, GetElementPtrInst>(joinse.ptr))
     //     return false;
     // else
     //     return true;

--- a/lib/MemoryModel/LocationSet.cpp
+++ b/lib/MemoryModel/LocationSet.cpp
@@ -63,7 +63,7 @@ bool LocationSet::isConstantOffset() const
 u32_t LocationSet::getElementNum(const SVFType* type) const
 {
 
-    if(SVFUtil::isa<SVFArrayType>(type) || SVFUtil::isa<SVFStructType>(type))
+    if (SVFUtil::isa<SVFArrayType, SVFStructType>(type))
     {
         return SymbolTableInfo::SymbolInfo()->getNumOfFlattenElements(type);
     }

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -238,7 +238,7 @@ void PointerAnalysis::dumpAllTypes()
             nIter != this->getAllValidPtrs().end(); ++nIter)
     {
         const PAGNode* node = getPAG()->getGNode(*nIter);
-        if (SVFUtil::isa<DummyObjVar>(node) || SVFUtil::isa<DummyValVar>(node))
+        if (SVFUtil::isa<DummyObjVar, DummyValVar>(node))
             continue;
 
         outs() << "##<" << node->getValue()->getName() << "> ";

--- a/lib/SABER/SaberSVFGBuilder.cpp
+++ b/lib/SABER/SaberSVFGBuilder.cpp
@@ -70,7 +70,7 @@ void SaberSVFGBuilder::collectGlobals(BVDataPTAImpl* pta)
     for(SVFIR::iterator it = pag->begin(), eit = pag->end(); it!=eit; it++)
     {
         PAGNode* pagNode = it->second;
-        if(SVFUtil::isa<DummyValVar>(pagNode) || SVFUtil::isa<DummyObjVar>(pagNode))
+        if (SVFUtil::isa<DummyValVar, DummyObjVar>(pagNode))
             continue;
 
         if(GepObjVar* gepobj = SVFUtil::dyn_cast<GepObjVar>(pagNode))

--- a/lib/SABER/SrcSnkDDA.cpp
+++ b/lib/SABER/SrcSnkDDA.cpp
@@ -160,9 +160,9 @@ bool SrcSnkDDA::isInAWrapper(const SVFGNode* src, CallSiteSet& csIdSet)
                 const SVFGNode* succ = edge->getDstNode();
                 if(SVFUtil::isa<IntraDirSVFGEdge>(edge))
                 {
-                    if (SVFUtil::isa<CopySVFGNode>(succ) || SVFUtil::isa<GepSVFGNode>(succ)
-                            || SVFUtil::isa<PHISVFGNode>(succ) || SVFUtil::isa<FormalRetSVFGNode>(succ)
-                            || SVFUtil::isa<ActualRetSVFGNode>(succ) || SVFUtil::isa<StoreSVFGNode>(succ))
+                    if (SVFUtil::isa<CopySVFGNode, GepSVFGNode, PHISVFGNode,
+                                     FormalRetSVFGNode, ActualRetSVFGNode,
+                                     StoreSVFGNode>(succ)) 
                     {
                         worklist.push(succ);
                     }

--- a/lib/SVF-LLVM/LLVMModule.cpp
+++ b/lib/SVF-LLVM/LLVMModule.cpp
@@ -1097,7 +1097,7 @@ StInfo* LLVMModuleSet::collectStructInfo(const StructType *sty)
         /// offset with int_32 (s32_t) is large enough and will not cause overflow
         stinfo->addFldWithType(nf, getSVFType(et), strideOffset);
 
-        if (SVFUtil::isa<StructType>(et) || SVFUtil::isa<ArrayType>(et))
+        if (SVFUtil::isa<StructType, ArrayType>(et))
         {
             StInfo * subStinfo = collectTypeInfo(et);
             u32_t nfE = subStinfo->getNumOfFlattenFields();

--- a/lib/SVF-LLVM/LLVMUtil.cpp
+++ b/lib/SVF-LLVM/LLVMUtil.cpp
@@ -50,7 +50,7 @@ bool LLVMUtil::isObject(const Value*  ref)
         createobj = true;
     if (SVFUtil::isa<GlobalVariable>(ref))
         createobj = true;
-    if (SVFUtil::isa<Function>(ref) || SVFUtil::isa<AllocaInst>(ref) )
+    if (SVFUtil::isa<Function, AllocaInst>(ref))
         createobj = true;
 
     return createobj;

--- a/lib/SVF-LLVM/SVFIRBuilder.cpp
+++ b/lib/SVF-LLVM/SVFIRBuilder.cpp
@@ -482,7 +482,7 @@ void SVFIRBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
         setCurrentLocation(gvar, nullptr);
         NodeID field = getGlobalVarField(gvar, offset, LLVMModuleSet::getLLVMModuleSet()->getSVFType(C->getType()));
 
-        if (SVFUtil::isa<GlobalVariable>(C) || SVFUtil::isa<Function>(C))
+        if (SVFUtil::isa<GlobalVariable, Function>(C))
         {
             setCurrentLocation(C, nullptr);
             addStoreEdge(src, field);
@@ -511,7 +511,7 @@ void SVFIRBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
                 addCopyEdge(pag->getNullPtr(), src);
         }
     }
-    else if (SVFUtil::isa<ConstantArray>(C) || SVFUtil::isa<ConstantStruct>(C))
+    else if (SVFUtil::isa<ConstantArray, ConstantStruct>(C))
     {
         if(cppUtil::isValVtbl(gvar) && !Options::VtableInSVFIR)
             return;
@@ -536,7 +536,7 @@ void SVFIRBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
             }
             else
             {
-                assert((SVFUtil::isa<ConstantAggregateZero>(data) || SVFUtil::isa<UndefValue>(data)) && "Single value type data should have been handled!");
+                assert((SVFUtil::isa<ConstantAggregateZero, UndefValue>(data)) && "Single value type data should have been handled!");
             }
         }
     }
@@ -1588,7 +1588,7 @@ NodeID SVFIRBuilder::getGepValVar(const Value* val, const LocationSet& ls, const
          * 1. Instruction
          * 2. GlobalVariable
          */
-        assert((SVFUtil::isa<SVFInstruction>(curVal) || SVFUtil::isa<SVFGlobalValue>(curVal)) && "curVal not an instruction or a globalvariable?");
+        assert((SVFUtil::isa<SVFInstruction, SVFGlobalValue>(curVal)) && "curVal not an instruction or a globalvariable?");
 
         // We assume every GepValNode and its GepEdge to the baseNode are unique across the whole program
         // We preserve the current BB information to restore it after creating the gepNode

--- a/lib/SVF-LLVM/SymbolTableBuilder.cpp
+++ b/lib/SVF-LLVM/SymbolTableBuilder.cpp
@@ -526,7 +526,8 @@ void SymbolTableBuilder::handleGlobalInitializerCE(const Constant *C)
             }
             else
             {
-                assert((SVFUtil::isa<ConstantAggregateZero>(data) || SVFUtil::isa<UndefValue>(data)) && "Single value type data should have been handled!");
+                assert((SVFUtil::isa<ConstantAggregateZero, UndefValue>(data)) &&
+                       "Single value type data should have been handled!");
             }
         }
     }
@@ -737,7 +738,7 @@ u32_t SymbolTableBuilder::getObjSize(const Type* ety)
 {
     assert(ety && "type is null?");
     u32_t numOfFields = 1;
-    if (SVFUtil::isa<StructType>(ety) || SVFUtil::isa<ArrayType>(ety))
+    if (SVFUtil::isa<StructType, ArrayType>(ety))
     {
         numOfFields = getNumOfFlattenElements(ety);
     }

--- a/lib/SVFIR/SymbolTableInfo.cpp
+++ b/lib/SVFIR/SymbolTableInfo.cpp
@@ -373,7 +373,7 @@ bool ObjTypeInfo::isNonPtrFieldObj(const LocationSet& ls)
 
     const SVFType* ety = getType();
 
-    if (SVFUtil::isa<SVFStructType>(ety) || SVFUtil::isa<SVFArrayType>(ety))
+    if (SVFUtil::isa<SVFStructType, SVFArrayType>(ety))
     {
         u32_t sz = 0;
         if(Options::ModelArrays)

--- a/lib/WPA/AndersenSFR.cpp
+++ b/lib/WPA/AndersenSFR.cpp
@@ -136,7 +136,7 @@ void AndersenSFR::fieldExpand(NodeSet& initials, s32_t offset, NodeBS& strides, 
             s32_t initOffset;
             if (GepObjVar *gepNode = SVFUtil::dyn_cast<GepObjVar>(initPN))
                 initOffset = gepNode->getConstantFieldIdx();
-            else if (SVFUtil::isa<FIObjVar>(initPN) || SVFUtil::isa<DummyObjVar>(initPN))
+            else if (SVFUtil::isa<FIObjVar, DummyObjVar>(initPN))
                 initOffset = 0;
             else
             {

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -192,61 +192,61 @@ bool FlowSensitive::processSVFGNode(SVFGNode* node)
 {
     double start = stat->getClk();
     bool changed = false;
-    if(AddrSVFGNode* addr = SVFUtil::dyn_cast<AddrSVFGNode>(node))
+    if (AddrSVFGNode* addr = SVFUtil::dyn_cast<AddrSVFGNode>(node))
     {
         numOfProcessedAddr++;
-        if(processAddr(addr))
+        if (processAddr(addr))
             changed = true;
     }
-    else if(CopySVFGNode* copy = SVFUtil::dyn_cast<CopySVFGNode>(node))
+    else if (CopySVFGNode* copy = SVFUtil::dyn_cast<CopySVFGNode>(node))
     {
         numOfProcessedCopy++;
-        if(processCopy(copy))
+        if (processCopy(copy))
             changed = true;
     }
-    else if(GepSVFGNode* gep = SVFUtil::dyn_cast<GepSVFGNode>(node))
+    else if (GepSVFGNode* gep = SVFUtil::dyn_cast<GepSVFGNode>(node))
     {
         numOfProcessedGep++;
         if(processGep(gep))
             changed = true;
     }
-    else if(LoadSVFGNode* load = SVFUtil::dyn_cast<LoadSVFGNode>(node))
+    else if (LoadSVFGNode* load = SVFUtil::dyn_cast<LoadSVFGNode>(node))
     {
         numOfProcessedLoad++;
         if(processLoad(load))
             changed = true;
     }
-    else if(StoreSVFGNode* store = SVFUtil::dyn_cast<StoreSVFGNode>(node))
+    else if (StoreSVFGNode* store = SVFUtil::dyn_cast<StoreSVFGNode>(node))
     {
         numOfProcessedStore++;
-        if(processStore(store))
+        if (processStore(store))
             changed = true;
     }
-    else if(PHISVFGNode* phi = SVFUtil::dyn_cast<PHISVFGNode>(node))
+    else if (PHISVFGNode* phi = SVFUtil::dyn_cast<PHISVFGNode>(node))
     {
         numOfProcessedPhi++;
         if (processPhi(phi))
             changed = true;
-    }
-    else if(SVFUtil::isa<MSSAPHISVFGNode>(node) || SVFUtil::isa<FormalINSVFGNode>(node)
-            || SVFUtil::isa<FormalOUTSVFGNode>(node) || SVFUtil::isa<ActualINSVFGNode>(node)
-            || SVFUtil::isa<ActualOUTSVFGNode>(node))
+    } else if (SVFUtil::isa<MSSAPHISVFGNode, FormalINSVFGNode,
+                            FormalOUTSVFGNode, ActualINSVFGNode,
+                            ActualOUTSVFGNode>(node)) 
     {
         numOfProcessedMSSANode++;
         changed = true;
-    }
-    else if(SVFUtil::isa<ActualParmSVFGNode>(node) || SVFUtil::isa<FormalParmSVFGNode>(node)
-            || SVFUtil::isa<ActualRetSVFGNode>(node) || SVFUtil::isa<FormalRetSVFGNode>(node)
-            || SVFUtil::isa<NullPtrSVFGNode>(node))
+    } 
+    else if (SVFUtil::isa<ActualParmSVFGNode, FormalParmSVFGNode,
+                            ActualRetSVFGNode, FormalRetSVFGNode,
+                            NullPtrSVFGNode>(node)) 
     {
         changed = true;
-    }
-    else if(SVFUtil::isa<CmpVFGNode>(node) || SVFUtil::isa<BinaryOPVFGNode>(node) || SVFUtil::dyn_cast<UnaryOPVFGNode>(node))
-    {
-
+    } 
+    else if (SVFUtil::isa<CmpVFGNode, BinaryOPVFGNode>(node) ||
+               SVFUtil::dyn_cast<UnaryOPVFGNode>(node)) {
     }
     else
+    {
         assert(false && "unexpected kind of SVFG nodes");
+    }
 
     double end = stat->getClk();
     processTime += (end - start) / TIMEINTERVAL;
@@ -710,10 +710,8 @@ void FlowSensitive::connectCallerAndCallee(const CallEdgeMap& newEdges, SVFGEdge
  */
 void FlowSensitive::updateConnectedNodes(const SVFGEdgeSetTy& edges)
 {
-    for (SVFGEdgeSetTy::const_iterator it = edges.begin(), eit = edges.end();
-            it != eit; ++it)
+    for (const SVFGEdge* edge : edges)
     {
-        const SVFGEdge* edge = *it;
         SVFGNode* dstNode = edge->getDstNode();
         if (SVFUtil::isa<PHISVFGNode>(dstNode))
         {
@@ -721,7 +719,7 @@ void FlowSensitive::updateConnectedNodes(const SVFGEdgeSetTy& edges)
             /// node in next iteration
             pushIntoWorklist(dstNode->getId());
         }
-        else if (SVFUtil::isa<FormalINSVFGNode>(dstNode) || SVFUtil::isa<ActualOUTSVFGNode>(dstNode))
+        else if (SVFUtil::isa<FormalINSVFGNode, ActualOUTSVFGNode>(dstNode))
         {
             /// If this is a formal-in or actual-out node, we need to propagate points-to
             /// information from its predecessor node.
@@ -778,7 +776,8 @@ bool FlowSensitive::propVarPtsAfterCGUpdated(NodeID var, const SVFGNode* src, co
 void FlowSensitive::cluster(void)
 {
     std::vector<std::pair<unsigned, unsigned>> keys;
-    for (SVFIR::iterator pit = pag->begin(); pit != pag->end(); ++pit) keys.push_back(std::make_pair(pit->first, 1));
+    for (const auto& pair : *pag)
+        keys.emplace_back(pair.first, 1);
 
     PointsTo::MappingPtr nodeMapping =
         std::make_shared<std::vector<NodeID>>(NodeIDAllocator::Clusterer::cluster(ander, keys, candidateMappings, "aux-ander"));


### PR DESCRIPTION
* Refactor boilerplate code of disjunctive predicates of `isa()`
  E.g, Change `isa<X>(v) || isa<Y>(v) || isa<Z>(v)` to `isa<X, Y, Z>(v)`
* Code formatting