### PR TITLE
[Bug] Choosing the right label when creating the inverse edge

### DIFF
--- a/lib/CFL/CFLGraphBuilder.cpp
+++ b/lib/CFL/CFLGraphBuilder.cpp
@@ -458,7 +458,7 @@ CFLGraph* VFCFLGraphBuilder::buildBigraph(SVFG *graph, Kind startKind, GrammarBa
                 addAttribute(edgeLabel, attr);
                 edgeLabel = CFLGrammar::getAttributedKind(attr, edgeLabel);
                 cflGraph->addCFLEdge(cflGraph->getGNode(edge->getSrcID()), cflGraph->getGNode(edge->getDstID()), edgeLabel);
-                std::string key = kind2LabelMap[edge->getEdgeKind()];
+                std::string key = kind2LabelMap[edgeLabel];
                 key.append("bar");   // for example Gep_i should be Gepbar_i, not Gep_ibar
                 cflGraph->addCFLEdge(cflGraph->getGNode(edge->getDstID()), cflGraph->getGNode(edge->getSrcID()), CFLGrammar::getAttributedKind(attr, label2KindMap[key]));
                 addAttribute(label2KindMap[key], attr);
@@ -472,7 +472,7 @@ CFLGraph* VFCFLGraphBuilder::buildBigraph(SVFG *graph, Kind startKind, GrammarBa
                 addAttribute(edgeLabel, attr);
                 edgeLabel = CFLGrammar::getAttributedKind(attr, edgeLabel);
                 cflGraph->addCFLEdge(cflGraph->getGNode(edge->getSrcID()), cflGraph->getGNode(edge->getDstID()), edgeLabel);
-                std::string key = kind2LabelMap[edge->getEdgeKind()];
+                std::string key = kind2LabelMap[edgeLabel];
                 key.append("bar");   // for example Gep_i should be Gepbar_i, not Gep_ibar
                 cflGraph->addCFLEdge(cflGraph->getGNode(edge->getDstID()), cflGraph->getGNode(edge->getSrcID()), CFLGrammar::getAttributedKind(attr, label2KindMap[key]));
                 addAttribute(label2KindMap[key], attr);
@@ -486,7 +486,7 @@ CFLGraph* VFCFLGraphBuilder::buildBigraph(SVFG *graph, Kind startKind, GrammarBa
                 addAttribute(edgeLabel, attr);
                 edgeLabel = CFLGrammar::getAttributedKind(attr, edgeLabel);
                 cflGraph->addCFLEdge(cflGraph->getGNode(edge->getSrcID()), cflGraph->getGNode(edge->getDstID()), edgeLabel);
-                std::string key = kind2LabelMap[edge->getEdgeKind()];
+                std::string key = kind2LabelMap[edgeLabel];
                 key.append("bar");   // for example Gep_i should be Gepbar_i, not Gep_ibar
                 cflGraph->addCFLEdge(cflGraph->getGNode(edge->getDstID()), cflGraph->getGNode(edge->getSrcID()), CFLGrammar::getAttributedKind(attr, label2KindMap[key]));
                 addAttribute(label2KindMap[key], attr);
@@ -500,7 +500,7 @@ CFLGraph* VFCFLGraphBuilder::buildBigraph(SVFG *graph, Kind startKind, GrammarBa
                 addAttribute(edgeLabel, attr);
                 edgeLabel = CFLGrammar::getAttributedKind(attr, edgeLabel);
                 cflGraph->addCFLEdge(cflGraph->getGNode(edge->getSrcID()), cflGraph->getGNode(edge->getDstID()), edgeLabel);
-                std::string key = kind2LabelMap[edge->getEdgeKind()];
+                std::string key = kind2LabelMap[edgeLabel];
                 key.append("bar");   // for example Gep_i should be Gepbar_i, not Gep_ibar
                 cflGraph->addCFLEdge(cflGraph->getGNode(edge->getDstID()), cflGraph->getGNode(edge->getSrcID()), CFLGrammar::getAttributedKind(attr, label2KindMap[key]));
                 addAttribute(label2KindMap[key], attr);


### PR DESCRIPTION
When inserting the inverse label into the `VF` CFL graph, it seems the wrong label is chosen. Here is an example, the original edge added to graph is a `ret`, so the expected inverse edge should be `retbar`, but not `Abar`, as the picture shows. This picture is runtime snapshot.

The reason is that **the wrong kind is chosen**, we should use `edgeLabel`(number 2) rather than `edge->getEdgeKind()`(`VFGEdge::RetDirVF` is number 3) in line 489. Variable `edge` is a `VFGEdge`, the edge kind is not the same as CFL edge kind. The other 3 cases are similar.

![1669215765163](https://user-images.githubusercontent.com/33364190/203579509-eb047d18-fe5e-4c93-822c-56832a6e3412.png)
