### PR TITLE
Build script simplification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,10 @@ if(NOT COMMAND add_llvm_library)
         # add -std=gnu++14
         set(CMAKE_CXX_EXTENSIONS ON)
 
-        if(CMAKE_BUILD_TYPE MATCHES "Debug")
-	    add_compile_options("-fPIC" "-Werror" "-Wall" "-O0" "-fno-rtti")
-        else()
-	    add_compile_options("-fPIC" "-Werror" "-Wall" "-O3" "-fno-rtti")
-        endif()
+        # Treat compiler warnings as errors
+        add_compile_options("-Werror" "-Wall")
 
-        find_package(LLVM REQUIRED CONFIG
-          HINTS "${LLVM_DIR}")
+        find_package(LLVM REQUIRED CONFIG HINTS "${LLVM_DIR}")
 
         message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
         message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")

--- a/build.sh
+++ b/build.sh
@@ -229,7 +229,7 @@ else
     rm -rf ./'Release-build'
     mkdir ./'Release-build'
     cd ./'Release-build'
-    cmake ../
+    cmake -D CMAKE_BUILD_TYPE:STRING=Release ../
     fi
 make -j ${jobs}
 


### PR DESCRIPTION
I had another look. The issue was that the `Release` build was not explicitly selected to build SVF. Without it, no optimisation were run and the release files became much larger.

Undoing the changes from https://github.com/SVF-tools/SVF/commit/9b5c56c922ab150eec924ece1e3fff21ac3af2d0 and enabling `Release` build in `build.sh`.