### PR TITLE
Add clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: Microsoft
+PointerAlignment: Left
+IndentPPDirectives: AfterHash
+AllowShortFunctionsOnASingleLine: Empty
+ColumnLimit: 120


### PR DESCRIPTION
Currently the coding style gets checked manually and is not consistent within our project.

The added `.clang-format` file specifies a style that allow clang-format to automatically reformat code. The VSCode automatically reads the style file and applies the style when doing automatic code reformatting. Such a file is also used by well-known projects like LLVM, Webkit, Linux.

The declared style is consistent with most of the SVF code.

We don't have to reformat the whole project, because that would be a very big change.
Instead, do an auto code formatting every time when we change a file. Eventually the coding style will get consistent.