### PR TITLE
Refactor building symbol method into own function and call it from `buildSVFModule(Module &mod)` as well

### DIFF
--- a/include/SVF-LLVM/LLVMModule.h
+++ b/include/SVF-LLVM/LLVMModule.h
@@ -351,6 +351,7 @@ private:
     /// Invoke llvm passes to modify module
     void prePassSchedule();
     bool preProcessed;
+    void build_symbol_table() const;
 };
 
 } // End namespace SVF

--- a/lib/SVF-LLVM/LLVMModule.cpp
+++ b/lib/SVF-LLVM/LLVMModule.cpp
@@ -83,10 +83,15 @@ LLVMModuleSet::~LLVMModuleSet()
 
 SVFModule* LLVMModuleSet::buildSVFModule(Module &mod)
 {
+    double startSVFModuleTime = SVFStat::getClk(true);
     svfModule = std::make_unique<SVFModule>(mod.getModuleIdentifier());
     modules.emplace_back(mod);
 
     build();
+    double endSVFModuleTime = SVFStat::getClk(true);
+    SVFStat::timeOfBuildingLLVMModule = (endSVFModuleTime - startSVFModuleTime)/TIMEINTERVAL;
+
+    build_symbol_table();
 
     return svfModule.get();
 }
@@ -109,18 +114,21 @@ SVFModule* LLVMModuleSet::buildSVFModule(const std::vector<std::string> &moduleN
     double endSVFModuleTime = SVFStat::getClk(true);
     SVFStat::timeOfBuildingLLVMModule = (endSVFModuleTime - startSVFModuleTime)/TIMEINTERVAL;
 
-    double startSymInfoTime = SVFStat::getClk(true);
-    if (!SVFModule::pagReadFromTXT())
-    {
-        /// building symbol table
-        DBOUT(DGENERAL, SVFUtil::outs() << SVFUtil::pasMsg("Building Symbol table ...\n"));
-        SymbolTableBuilder builder(symInfo);
-        builder.buildMemModel(svfModule.get());
-    }
-    double endSymInfoTime = SVFStat::getClk(true);
-    SVFStat::timeOfBuildingSymbolTable = (endSymInfoTime - startSymInfoTime)/TIMEINTERVAL;
+    build_symbol_table();
 
     return svfModule.get();
+}
+void LLVMModuleSet::build_symbol_table() const {
+  double startSymInfoTime = SVFStat::getClk(true);
+  if (!SVFModule::pagReadFromTXT())
+  {
+      /// building symbol table
+      DBOUT(DGENERAL, SVFUtil::outs() << SVFUtil::pasMsg("Building Symbol table ...\n"));
+      SymbolTableBuilder builder(symInfo);
+      builder.buildMemModel(svfModule.get());
+  }
+  double endSymInfoTime = SVFStat::getClk(true);
+  SVFStat::timeOfBuildingSymbolTable = (endSymInfoTime - startSymInfoTime)/TIMEINTERVAL;
 }
 
 void LLVMModuleSet::build()


### PR DESCRIPTION
If SVF is used as a library using existing modules, the symbol table would not have been build in the first place.

This fixes the issue.