### PR TITLE
Implement independent command line parser

### DIFF
--- a/include/Util/CommandLine.h
+++ b/include/Util/CommandLine.h
@@ -26,7 +26,7 @@ protected:
     template <typename T>
     using OptionPossibility = std::tuple<T, std::string, std::string>;
 
-public:
+protected:
     OptionBase(std::string name, std::string description)
         : OptionBase(name, description, {})
     {
@@ -66,6 +66,7 @@ public:
     /// Can this option be set?
     virtual bool canSet(void) const = 0;
 
+public:
     /// Parse all constructed OptionBase children, returning positional arguments
     /// in the order they appeared.
     static std::vector<std::string> parseOptions(int argc, char *argv[], std::string description, std::string callFormat)

--- a/include/Util/CommandLine.h
+++ b/include/Util/CommandLine.h
@@ -1,0 +1,521 @@
+#ifndef COMMANDLINE_H_
+#define COMMANDLINE_H_
+
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <map>
+#include <vector>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+typedef unsigned u32_t;
+
+class OptionBase
+{
+protected:
+    /// Name/description pairs.
+    typedef std::pair<std::string, std::string> PossibilityDescription;
+    typedef std::vector<std::pair<std::string, std::string>> PossibilityDescriptions;
+
+    /// Value/name/description tuples. If [1] is the value on the commandline for an option, we'd
+    /// set the value for the associated Option to [0].
+    template <typename T>
+    using OptionPossibility = std::tuple<T, std::string, std::string>;
+
+public:
+    OptionBase(std::string name, std::string description)
+        : OptionBase(name, description, {})
+    {
+    }
+
+    OptionBase(std::string name, std::string description, PossibilityDescriptions possibilityDescriptions)
+        : name(name), description(description), possibilityDescriptions(possibilityDescriptions)
+    {
+        assert(name[0] != '-' && "OptionBase: name starts with '-'");
+        assert(!isHelpName(name) && "OptionBase: reserved help name");
+        assert(options.find(name) == options.end() && "OptionBase: duplicate option");
+
+        // Types with empty names (i.e., OptionMultiple) can handle things themselves.
+        if (!name.empty())
+        {
+            // Standard name=value option.
+            options[name] = this;
+        }
+    }
+
+    /// From a given string, set the value of this option.
+    virtual bool parseAndSetValue(const std::string value) = 0;
+
+    /// Whether this option represents a boolean. Important as such
+    /// arguments don't require a value.
+    virtual bool isBool(void) const
+    {
+        return false;
+    }
+
+    /// Whether this option is an OptionMultiple.
+    virtual bool isMultiple(void) const
+    {
+        return false;
+    }
+
+    /// Can this option be set?
+    virtual bool canSet(void) const = 0;
+
+    /// Parse all constructed OptionBase children, returning positional arguments
+    /// in the order they appeared.
+    static std::vector<std::string> parseOptions(int argc, char *argv[], std::string description, std::string callFormat)
+    {
+        const std::string usage = buildUsage(description, std::string(argv[0]), callFormat);
+
+        std::vector<std::string> positionalArguments;
+
+        for (int i = 1; i < argc; ++i)
+        {
+            std::string arg(argv[i]);
+            if (arg.empty()) continue;
+            if (arg[0] != '-')
+            {
+                // Positional argument. NOT a value to another argument because we
+                // "skip" over evaluating those without the corresponding argument.
+                positionalArguments.push_back(arg);
+                continue;
+            }
+
+            // Chop off '-'.
+            arg = arg.substr(1);
+
+            std::string argName;
+            std::string argValue;
+            OptionBase *opt = nullptr;
+
+            size_t equalsSign = arg.find('=');
+            if (equalsSign != std::string::npos)
+            {
+                // Argument has an equal sign, i.e. argName=argValue
+                argName = arg.substr(0, equalsSign);
+                if (isHelpName(argName)) usageAndExit(usage, false);
+
+                opt = getOption(argName);
+                if (opt == nullptr)
+                {
+                    std::cerr << "Unknown option: " << argName << std::endl;
+                    usageAndExit(usage, true);
+                }
+
+                argValue = arg.substr(equalsSign + 1);
+            }
+            else
+            {
+                argName = arg;
+                if (isHelpName(argName)) usageAndExit(usage, false);
+
+                opt = getOption(argName);
+                if (opt == nullptr)
+                {
+                    std::cerr << "Unknown option: " << argName << std::endl;
+                    usageAndExit(usage, true);
+                }
+
+                // No equals sign means we may need next argument.
+                if (opt->isBool())
+                {
+                    // Booleans do not accept -arg true/-arg false.
+                    // They must be -arg=true/-arg=false.
+                    argValue = "true";
+                }
+                else if (opt->isMultiple())
+                {
+                    // Name is the value and will be converted to an enum.
+                    argValue = argName;
+                }
+                else if (i + 1 < argc)
+                {
+                    // On iteration, we'll skip the value.
+                    ++i;
+                    argValue = std::string(argv[i]);
+                }
+                else
+                {
+                    std::cerr << "Expected value for: " << argName << std::endl;
+                    usageAndExit(usage, true);
+                }
+            }
+
+            if (!opt->canSet())
+            {
+                std::cerr << "Unable to set: " << argName << "; check for duplicates" << std::endl;
+                usageAndExit(usage, true);
+            }
+
+            bool valueSet = opt->parseAndSetValue(argValue);
+            if (!valueSet)
+            {
+                std::cerr << "Bad value for: " << argName << std::endl;
+                usageAndExit(usage, true);
+            }
+        }
+
+        return positionalArguments;
+    }
+
+private:
+    /// Sets the usage member to a usage string, built from the static list of options.
+    /// argv0 is argv[0] and callFormat is how the command should be used, minus the command
+    /// name (e.g. "[options] <input-bitcode...>".
+    static std::string buildUsage(
+        const std::string description, const std::string argv0, const std::string callFormat
+    )
+    {
+        // Determine longest option to split into two columns: options and descriptions.
+        unsigned longest = 0;
+        for (const std::pair<std::string, OptionBase *> nopt : options)
+        {
+            const std::string name = std::get<0>(nopt);
+            const OptionBase *option = std::get<1>(nopt);
+            if (option->isMultiple())
+            {
+                // For Multiple, description goes in left column.
+                if (option->description.length() > longest) longest = option->description.length();
+            }
+            else
+            {
+                if (name.length() > longest) longest = name.length();
+            }
+
+            for (const PossibilityDescription &pd : option->possibilityDescriptions)
+            {
+                const std::string possibility = std::get<0>(pd);
+                if (possibility.length() + 3 > longest) longest = possibility.length() + 3;
+            }
+        }
+
+        std::stringstream ss;
+
+        ss << description << std::endl << std::endl;
+
+        ss << "USAGE:" << std::endl;
+        ss << "  " << argv0 << " " << callFormat << std::endl;
+        ss << std::endl;
+
+        ss << "OPTIONS:" << std::endl;
+
+        // Required as we have OptionMultiples doing a many-to-one in options.
+        std::unordered_set<const OptionBase *> handled;
+        for (const std::pair<std::string, OptionBase *> nopt : options)
+        {
+            const std::string name = std::get<0>(nopt);
+            const OptionBase *option = std::get<1>(nopt);
+            if (handled.find(option) != handled.end()) continue;
+            handled.insert(option);
+
+            if (option->isMultiple())
+            {
+                // description
+                //   -name1      - description
+                //   -name2      - description
+                //   ...
+                ss << "  " << option->description << std::endl;
+                for (const PossibilityDescription &pd : option->possibilityDescriptions)
+                {
+                    const std::string possibility = std::get<0>(pd);
+                    const std::string description = std::get<1>(pd);
+                    ss << "    -" << possibility << std::string(longest - possibility.length() + 2, ' ');
+                    ss << "- " << description << std::endl;
+                }
+            }
+            else
+            {
+                // name  - description
+                // or
+                // name     - description
+                //   =opt1    - description
+                //   =opt2    - description
+                //   ...
+                ss << "  -" << name << std::string(longest - name.length() + 2, ' ');
+                ss << "- " << option->description << std::endl;
+                for (const PossibilityDescription &pd : option->possibilityDescriptions)
+                {
+                    const std::string possibility = std::get<0>(pd);
+                    const std::string description = std::get<1>(pd);
+                    ss << "    =" << possibility << std::string(longest - possibility.length() + 2, ' ');
+                    ss << "- " << description << std::endl;
+                }
+            }
+        }
+
+        // Help message.
+        ss << std::endl;
+        ss << "  -help" << std::string(longest - 4 + 2, ' ') << "- show usage and exit" << std::endl;
+        ss << "  -h" << std::string(longest - 1 + 2, ' ') << "- show usage and exit" << std::endl;
+
+        // How to set boolean options.
+        ss << std::endl;
+        ss << "Note: for boolean options, -name true and -name false are invalid." << std::endl;
+        ss << "      Use -name, -name=true, or -name=false." << std::endl;
+
+        return ss.str();
+    }
+
+    /// Find option based on name in options map. Returns nullptr if not found.
+    static OptionBase *getOption(const std::string optName)
+    {
+        auto optIt = options.find(optName);
+        if (optIt == options.end()) return nullptr;
+        else return optIt->second;
+    }
+
+    /// Print usage and exit. If error is set, print to stderr and exits with code 1.
+    static void usageAndExit(const std::string usage, bool error)
+    {
+        if (error) std::cerr << usage;
+        else std::cout << usage;
+        std::exit(error ? 1 : 0);
+    }
+
+    /// Returns whether name is one of the reserved help options.
+    static bool isHelpName(const std::string name)
+    {
+        return std::find(helpNames.begin(), helpNames.end(), name) != helpNames.end();
+    }
+
+protected:
+    // Return the name/description part of OptionsPossibilities (second and third fields).
+    template<typename T>
+    static PossibilityDescriptions extractPossibilityDescriptions(const std::vector<OptionPossibility<T>> possibilities)
+    {
+        PossibilityDescriptions possibilityDescriptions;
+        for (const OptionPossibility<T> &op : possibilities)
+        {
+            possibilityDescriptions.push_back(std::make_pair(std::get<1>(op), std::get<2>(op)));
+        }
+
+        return possibilityDescriptions;
+    }
+
+
+protected:
+    std::string name;
+    std::string description;
+    /// For when we have possibilities like in an OptionMap.
+    PossibilityDescriptions possibilityDescriptions;
+
+    /// Not unordered map so we can have sorted names when building the usage string.
+    /// Map of option names to their object.
+    static std::map<std::string, OptionBase *> options;
+
+private:
+    /// Names of the help options. They are reserved.
+    static std::vector<std::string> helpNames;
+};
+
+/// General -name=value options.
+/// Retrieve value by Opt().
+template <typename T>
+class Option : public OptionBase
+{
+public:
+    Option(std::string name, std::string description, T init)
+        : OptionBase(name, description), isExplicitlySet(false), value(init)
+    {
+        assert(!name.empty() && "Option: empty option name given");
+    }
+
+    virtual bool canSet(void) const override
+    {
+        // Don't allow duplicates.
+        return !isExplicitlySet;
+    }
+
+    virtual bool parseAndSetValue(const std::string s) override
+    {
+        isExplicitlySet = fromString(s, value);
+        return isExplicitlySet;
+    }
+
+    virtual bool isBool(void) const override
+    {
+        return std::is_same<T, bool>::value;
+    }
+
+    void setValue(T v)
+    {
+        value = v;
+    }
+
+    T operator()(void) const
+    {
+        return value;
+    }
+
+private:
+    // Convert string to boolean, returning whether we succeeded.
+    static bool fromString(const std::string s, bool &value)
+    {
+        if (s == "true") value = true;
+        else if (s == "false") value = false;
+        else return false;
+        return true;
+    }
+
+    // Convert string to string, always succeeds.
+    static bool fromString(const std::string s, std::string &value)
+    {
+        value = s;
+        return true;
+    }
+
+    // Convert string to u32_t, returning whether we succeeded.
+    static bool fromString(const std::string s, u32_t &value)
+    {
+        // We won't allow anything except [0-9]+.
+        if (s.empty()) return false;
+        for (char c : s)
+        {
+            if (!(c >= '0' && c <= '9')) return false;
+        }
+
+        // Use strtoul because we're not using exceptions.
+        assert(sizeof(unsigned long) >= sizeof(u32_t));
+        const unsigned long sv = std::strtoul(s.c_str(), nullptr, 10);
+
+        // Out of range according to strtoul, or according to us compared to u32_t.
+        if (errno == ERANGE || sv > std::numeric_limits<u32_t>::max()) return false;
+        value = sv;
+        return true;
+    }
+
+private:
+    bool isExplicitlySet;
+    T value;
+};
+
+/// Option allowing a limited range of values, probably corresponding to an enum.
+/// Opt() gives the value.
+template <typename T>
+class OptionMap : public OptionBase
+{
+public:
+    typedef std::vector<OptionPossibility<T>> OptionPossibilities;
+
+    OptionMap(std::string name, std::string description, T init, OptionPossibilities possibilities)
+        : OptionBase(name, description, extractPossibilityDescriptions(possibilities)),
+          isExplicitlySet(false), value(init), possibilities(possibilities)
+    {
+        assert(!name.empty() && "OptionMap: empty option name given");
+    }
+
+    virtual bool canSet(void) const override
+    {
+        return !isExplicitlySet;
+    }
+
+    virtual bool parseAndSetValue(const std::string s) override
+    {
+        for (const OptionPossibility<T> &op : possibilities)
+        {
+            // Check if the given string is a valid one.
+            if (s == std::get<1>(op))
+            {
+                // What that string maps to.
+                value = std::get<0>(op);
+                isExplicitlySet = true;
+                break;
+            }
+        }
+
+        return isExplicitlySet;
+    }
+
+    T operator()(void) const
+    {
+        return value;
+    }
+
+private:
+    bool isExplicitlySet;
+    T value;
+    OptionPossibilities possibilities;
+};
+
+/// Options which form a kind of bit set. There are multiple names and n of them can be set.
+/// Opt(v) tests whether v had been set, aborting if v is invalid.
+template <typename T>
+class OptionMultiple : public OptionBase
+{
+public:
+    typedef std::vector<OptionPossibility<T>> OptionPossibilities;
+
+    OptionMultiple(std::string description, OptionPossibilities possibilities)
+        : OptionBase("", description, extractPossibilityDescriptions(possibilities)), possibilities(possibilities)
+    {
+        for (const OptionPossibility<T> &op : possibilities)
+        {
+            optionValues[std::get<0>(op)] = false;
+        }
+
+        for (const OptionPossibility<T> &op : possibilities)
+        {
+            std::string possibilityName = std::get<1>(op);
+            options[possibilityName] = this;
+        }
+    }
+
+    virtual bool canSet(void) const override
+    {
+        return true;
+    }
+
+    virtual bool parseAndSetValue(const std::string s) override
+    {
+        // Like in OptionMap basically, except we can have many values.
+        for (const OptionPossibility<T> &op : possibilities)
+        {
+            if (s == std::get<1>(op))
+            {
+                optionValues[std::get<0>(op)] = true;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    virtual bool isMultiple(void) const override
+    {
+        return true;
+    }
+
+    /// If the bitset is empty.
+    bool nothingSet(void) const
+    {
+        for (const std::pair<T, bool> tb : optionValues)
+        {
+            if (tb.second) return false;
+        }
+
+        return true;
+    }
+
+    /// Returns whether the value v had been set as an option.
+    bool operator()(const T v) const
+    {
+        typename std::unordered_map<T, bool>::const_iterator ovIt = optionValues.find(v);
+        // TODO: disabled as we check for "invalid" values in some places.
+        // assert(ovIt != optionValues.end() && "OptionMultiple: bad value checked");
+        if (ovIt == optionValues.end()) return false;
+        return ovIt->second;
+    }
+
+private:
+    /// Is the option set? Use a map rather than a set because it's now easier in one
+    /// DS to determine whether something is 1) valid, and 2) set.
+    std::unordered_map<T, bool> optionValues;
+    OptionPossibilities possibilities;
+};
+
+#endif  /* COMMANDLINE_H_ */

--- a/include/Util/CommandLine.h
+++ b/include/Util/CommandLine.h
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <limits>
 #include <map>
 #include <vector>
 #include <cstdlib>

--- a/include/Util/CommandLine.h
+++ b/include/Util/CommandLine.h
@@ -2,7 +2,7 @@
 #define COMMANDLINE_H_
 
 #include <algorithm>
-#include <assert>
+#include <cassert>
 #include <string>
 #include <tuple>
 #include <type_traits>

--- a/include/Util/CommandLine.h
+++ b/include/Util/CommandLine.h
@@ -1,6 +1,8 @@
 #ifndef COMMANDLINE_H_
 #define COMMANDLINE_H_
 
+#include <algorithm>
+#include <assert>
 #include <string>
 #include <tuple>
 #include <type_traits>

--- a/include/Util/Options.h
+++ b/include/Util/Options.h
@@ -5,12 +5,12 @@
 
 #include <sstream>
 #include "FastCluster/fastcluster.h"
+#include "Util/CommandLine.h"
 #include "Util/PTAStat.h"
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "Util/NodeIDAllocator.h"
 #include "MSSA/MemSSA.h"
 #include "WPA/WPAPass.h"
-#include <llvm/Support/CommandLine.h>	// for command line options
 
 namespace SVF
 {
@@ -21,244 +21,244 @@ class Options
 public:
     Options(void) = delete;
 
-    static const llvm::cl::opt<enum PTAStat::ClockType> ClockType;
+    static const OptionMap<enum PTAStat::ClockType> ClockType;
 
     /// If set, only return the clock when getClk is called as getClk(true).
     /// Retrieving the clock is slow but it should be fine for a few calls.
     /// This is good for benchmarking when we don't need to know how long processLoad
     /// takes, for example (many calls), but want to know things like total solve time.
     /// Should be used only to affect getClk, not CLOCK_IN_MS.
-    static const llvm::cl::opt<bool> MarkedClocksOnly;
+    static const Option<bool> MarkedClocksOnly;
 
     /// Allocation strategy to be used by the node ID allocator.
     /// Currently dense, seq, or debug.
-    static const llvm::cl::opt<SVF::NodeIDAllocator::Strategy> NodeAllocStrat;
+    static const OptionMap<SVF::NodeIDAllocator::Strategy> NodeAllocStrat;
 
     /// Maximum number of field derivations for an object.
-    static const llvm::cl::opt<unsigned> MaxFieldLimit;
+    static const Option<u32_t> MaxFieldLimit;
 
     /// Whether to stage Andersen's with Steensgaard and cluster based on that data.
-    static const llvm::cl::opt<bool> ClusterAnder;
+    static const Option<bool> ClusterAnder;
 
     /// Whether to cluster FS or VFS with the auxiliary Andersen's.
-    static const llvm::cl::opt<bool> ClusterFs;
+    static const Option<bool> ClusterFs;
 
     /// Use an explicitly plain mapping with flow-sensitive (not null).
-    static const llvm::cl::opt<bool> PlainMappingFs;
+    static const Option<bool> PlainMappingFs;
 
     /// Type of points-to set to use for all analyses.
-    static const llvm::cl::opt<PointsTo::Type> PtType;
+    static const OptionMap<PointsTo::Type> PtType;
 
     /// Clustering method for ClusterFs/ClusterAnder.
     /// TODO: we can separate it into two options, and make Clusterer::cluster take in a method
     ///       argument rather than plugging Options::ClusterMethod *inside* Clusterer::cluster
     ///       directly, but it seems we will always want single anyway, and this is for testing.
-    static const llvm::cl::opt<enum hclust_fast_methods> ClusterMethod;
+    static const OptionMap<enum hclust_fast_methods> ClusterMethod;
 
     /// Cluster partitions separately.
-    static const llvm::cl::opt<bool> RegionedClustering;
+    static const Option<bool> RegionedClustering;
 
     /// Align identifiers in each region to a word.
-    static const llvm::cl::opt<bool> RegionAlign;
+    static const Option<bool> RegionAlign;
 
     /// Predict occurences of points-to sets in the staged points-to set to
     /// weigh more common points-to sets as more important.
-    static const llvm::cl::opt<bool> PredictPtOcc;
+    static const Option<bool> PredictPtOcc;
 
     /// PTData type.
-    static const llvm::cl::opt<BVDataPTAImpl::PTBackingType> ptDataBacking;
+    static const OptionMap<BVDataPTAImpl::PTBackingType> ptDataBacking;
 
     /// Time limit for the main phase (i.e., the actual solving) of FS analyses.
-    static const llvm::cl::opt<unsigned> FsTimeLimit;
+    static const Option<u32_t> FsTimeLimit;
 
     /// Time limit for the Andersen's analyses.
-    static const llvm::cl::opt<unsigned> AnderTimeLimit;
+    static const Option<u32_t> AnderTimeLimit;
 
     /// Number of threads for the versioning phase.
-    static const llvm::cl::opt<unsigned> VersioningThreads;
+    static const Option<u32_t> VersioningThreads;
 
     // ContextDDA.cpp
-    static const llvm::cl::opt<unsigned long long> CxtBudget;
+    static const Option<u32_t> CxtBudget;
 
     // DDAClient.cpp
-    static const llvm::cl::opt<bool> SingleLoad;
-    static const llvm::cl::opt<bool> DumpFree;
-    static const llvm::cl::opt<bool> DumpUninitVar;
-    static const llvm::cl::opt<bool> DumpUninitPtr;
-    static const llvm::cl::opt<bool> DumpSUPts;
-    static const llvm::cl::opt<bool> DumpSUStore;
-    static const llvm::cl::opt<bool> MallocOnly;
-    static const llvm::cl::opt<bool> TaintUninitHeap;
-    static const llvm::cl::opt<bool> TaintUninitStack;
+    static const Option<bool> SingleLoad;
+    static const Option<bool> DumpFree;
+    static const Option<bool> DumpUninitVar;
+    static const Option<bool> DumpUninitPtr;
+    static const Option<bool> DumpSUPts;
+    static const Option<bool> DumpSUStore;
+    static const Option<bool> MallocOnly;
+    static const Option<bool> TaintUninitHeap;
+    static const Option<bool> TaintUninitStack;
 
     // DDAPass.cpp
-    static const llvm::cl::opt<unsigned> MaxPathLen;
-    static const llvm::cl::opt<unsigned> MaxContextLen;
-    static const llvm::cl::opt<unsigned> MaxStepInWrapper;
-    static const llvm::cl::opt<std :: string> UserInputQuery;
-    static const llvm::cl::opt<bool> InsenRecur;
-    static const llvm::cl::opt<bool> InsenCycle;
-    static const llvm::cl::opt<bool> PrintCPts;
-    static const llvm::cl::opt<bool> PrintQueryPts;
-    static const llvm::cl::opt<bool> WPANum;
-    static llvm::cl::bits<PointerAnalysis::PTATY> DDASelected;
+    static const Option<u32_t> MaxPathLen;
+    static const Option<u32_t> MaxContextLen;
+    static const Option<u32_t> MaxStepInWrapper;
+    static const Option<std::string> UserInputQuery;
+    static const Option<bool> InsenRecur;
+    static const Option<bool> InsenCycle;
+    static const Option<bool> PrintCPts;
+    static const Option<bool> PrintQueryPts;
+    static const Option<bool> WPANum;
+    static OptionMultiple<PointerAnalysis::PTATY> DDASelected;
 
     // FlowDDA.cpp
-    static const llvm::cl::opt<unsigned long long> FlowBudget;
+    static const Option<u32_t> FlowBudget;
 
     // Offline constraint graph (OfflineConsG.cpp)
-    static const llvm::cl::opt<bool> OCGDotGraph;
+    static const Option<bool> OCGDotGraph;
 
     // Program Assignment Graph for pointer analysis (SVFIR.cpp)
-    static llvm::cl::opt<bool> HandBlackHole;
-    static const llvm::cl::opt<bool> FirstFieldEqBase;
+    static Option<bool> HandBlackHole;
+    static const Option<bool> FirstFieldEqBase;
 
     // SVFG optimizer (SVFGOPT.cpp)
-    static const llvm::cl::opt<bool> ContextInsensitive;
-    static const llvm::cl::opt<bool> KeepAOFI;
-    static const llvm::cl::opt<std::string> SelfCycle;
+    static const Option<bool> ContextInsensitive;
+    static const Option<bool> KeepAOFI;
+    static const Option<std::string> SelfCycle;
 
     // Sparse value-flow graph (VFG.cpp)
-    static const llvm::cl::opt<bool> DumpVFG;
+    static const Option<bool> DumpVFG;
 
     // Location set for modeling abstract memory object (LocationSet.cpp)
-    static const llvm::cl::opt<bool> SingleStride;
+    static const Option<bool> SingleStride;
 
     // Base class of pointer analyses (PointerAnalysis.cpp)
-    static const llvm::cl::opt<bool> TypePrint;
-    static const llvm::cl::opt<bool> FuncPointerPrint;
-    static const llvm::cl::opt<bool> PTSPrint;
-    static const llvm::cl::opt<bool> PTSAllPrint;
-    static const llvm::cl::opt<bool> PStat;
-    static const llvm::cl::opt<unsigned> StatBudget;
-    static const llvm::cl::opt<bool> PAGDotGraph;
-    static const llvm::cl::opt<bool> ShowSVFIRValue;
-    static const llvm::cl::opt<bool> DumpICFG;
-    static const llvm::cl::opt<bool> CallGraphDotGraph;
-    static const llvm::cl::opt<bool> PAGPrint;
-    static const llvm::cl::opt<unsigned> IndirectCallLimit;
-    static const llvm::cl::opt<bool> UsePreCompFieldSensitive;
-    static const llvm::cl::opt<bool> EnableAliasCheck;
-    static const llvm::cl::opt<bool> EnableThreadCallGraph;
-    static const llvm::cl::opt<bool> ConnectVCallOnCHA;
+    static const Option<bool> TypePrint;
+    static const Option<bool> FuncPointerPrint;
+    static const Option<bool> PTSPrint;
+    static const Option<bool> PTSAllPrint;
+    static const Option<bool> PStat;
+    static const Option<u32_t> StatBudget;
+    static const Option<bool> PAGDotGraph;
+    static const Option<bool> ShowSVFIRValue;
+    static const Option<bool> DumpICFG;
+    static const Option<bool> CallGraphDotGraph;
+    static const Option<bool> PAGPrint;
+    static const Option<u32_t> IndirectCallLimit;
+    static const Option<bool> UsePreCompFieldSensitive;
+    static const Option<bool> EnableAliasCheck;
+    static const Option<bool> EnableThreadCallGraph;
+    static const Option<bool> ConnectVCallOnCHA;
 
     // PointerAnalysisImpl.cpp
-    static const llvm::cl::opt<bool> INCDFPTData;
+    static const Option<bool> INCDFPTData;
 
     // Memory region (MemRegion.cpp)
-    static const llvm::cl::opt<bool> IgnoreDeadFun;
+    static const Option<bool> IgnoreDeadFun;
 
     // Base class of pointer analyses (MemSSA.cpp)
-    static const llvm::cl::opt<bool> DumpMSSA;
-    static const llvm::cl::opt<std :: string> MSSAFun;
+    static const Option<bool> DumpMSSA;
+    static const Option<std::string> MSSAFun;
     // static const llvm::cl::opt<string> MSSAFun;
-    static const llvm::cl::opt<MemSSA::MemPartition> MemPar;
+    static const OptionMap<MemSSA::MemPartition> MemPar;
 
     // SVFG builder (SVFGBuilder.cpp)
-    static const llvm::cl::opt<bool> SVFGWithIndirectCall;
-    static llvm::cl::opt<bool> OPTSVFG;
+    static const Option<bool> SVFGWithIndirectCall;
+    static Option<bool> OPTSVFG;
 
-    static const llvm::cl::opt<std :: string> WriteSVFG;
-    static const llvm::cl::opt<std :: string> ReadSVFG;
+    static const Option<std::string> WriteSVFG;
+    static const Option<std::string> ReadSVFG;
 
     // FSMPTA.cpp
-    static const llvm::cl::opt<bool> UsePCG;
-    static const llvm::cl::opt<bool> IntraLock;
-    static const llvm::cl::opt<bool> ReadPrecisionTDEdge;
-    static const llvm::cl::opt<u32_t> AddModelFlag;
+    static const Option<bool> UsePCG;
+    static const Option<bool> IntraLock;
+    static const Option<bool> ReadPrecisionTDEdge;
+    static const Option<u32_t> AddModelFlag;
 
     // LockAnalysis.cpp
-    static const llvm::cl::opt<bool> PrintLockSpan;
+    static const Option<bool> PrintLockSpan;
 
     // MHP.cpp
-    static const llvm::cl::opt<bool> PrintInterLev;
-    static const llvm::cl::opt<bool> DoLockAnalysis;
+    static const Option<bool> PrintInterLev;
+    static const Option<bool> DoLockAnalysis;
 
     // MTA.cpp
-    static const llvm::cl::opt<bool> AndersenAnno;
-    static const llvm::cl::opt<bool> FSAnno;
+    static const Option<bool> AndersenAnno;
+    static const Option<bool> FSAnno;
 
     // MTAAnnotator.cpp
-    static const llvm::cl::opt<u32_t> AnnoFlag;
+    static const Option<u32_t> AnnoFlag;
 
     // MTAResultValidator.cpp
-    static const llvm::cl::opt<bool> PrintValidRes;
+    static const Option<bool> PrintValidRes;
 
-    static const llvm::cl::opt<bool> LockValid;
+    static const Option<bool> LockValid;
     //MTAStat.cpp
-    static const llvm::cl::opt<bool> AllPairMHP;
+    static const Option<bool> AllPairMHP;
 
     // PCG.cpp
-    //const llvm::cl::opt<bool> TDPrint
+    //const Option<bool> TDPrint
 
     // TCT.cpp
-    static const llvm::cl::opt<bool> TCTDotGraph;
+    static const Option<bool> TCTDotGraph;
 
     // LeakChecker.cpp
-    static const llvm::cl::opt<bool> ValidateTests;
+    static const Option<bool> ValidateTests;
 
     // Source-sink analyzer (SrcSnkDDA.cpp)
-    static const llvm::cl::opt<bool> DumpSlice;
-    static const llvm::cl::opt<unsigned> CxtLimit;
+    static const Option<bool> DumpSlice;
+    static const Option<u32_t> CxtLimit;
 
     // CHG.cpp
-    static const llvm::cl::opt<bool> DumpCHA;
+    static const Option<bool> DumpCHA;
 
     // DCHG.cpp
-    static const llvm::cl::opt<bool> PrintDCHG;
+    static const Option<bool> PrintDCHG;
 
     // LLVMModule.cpp
-    static const llvm::cl::opt<std::string> Graphtxt;
-    static const llvm::cl::opt<bool> SVFMain;
+    static const Option<std::string> Graphtxt;
+    static const Option<bool> SVFMain;
 
     // SymbolTableInfo.cpp
-    static const llvm::cl::opt<bool> LocMemModel;
-    static const llvm::cl::opt<bool> ModelConsts;
-    static const llvm::cl::opt<bool> ModelArrays;
-    static const llvm::cl::opt<bool> SymTabPrint;
+    static const Option<bool> LocMemModel;
+    static const Option<bool> ModelConsts;
+    static const Option<bool> ModelArrays;
+    static const Option<bool> SymTabPrint;
 
     // Conditions.cpp
-    static const llvm::cl::opt<unsigned> MaxZ3Size;
+    static const Option<u32_t> MaxZ3Size;
 
     // SaberCondAllocator.cpp
-    static const llvm::cl::opt<bool> PrintPathCond;
+    static const Option<bool> PrintPathCond;
 
     // SVFUtil.cpp
-    static const llvm::cl::opt<bool> DisableWarn;
+    static const Option<bool> DisableWarn;
 
     // Andersen.cpp
-    static const llvm::cl::opt<bool> ConsCGDotGraph;
-    static const llvm::cl::opt<bool> BriefConsCGDotGraph;
-    static const llvm::cl::opt<bool> PrintCGGraph;
-    // static const llvm::cl::opt<string> WriteAnder;
-    static const llvm::cl::opt<std :: string> WriteAnder;
-    // static const llvm::cl::opt<string> ReadAnder;
-    static const llvm::cl::opt<std :: string> ReadAnder;
-    static const llvm::cl::opt<bool> DiffPts;
-    static llvm::cl::opt<bool> DetectPWC;
-    static const llvm::cl::opt<bool> VtableInSVFIR;
+    static const Option<bool> ConsCGDotGraph;
+    static const Option<bool> BriefConsCGDotGraph;
+    static const Option<bool> PrintCGGraph;
+    // static const Option<string> WriteAnder;
+    static const Option<std::string> WriteAnder;
+    // static const Option<string> ReadAnder;
+    static const Option<std::string> ReadAnder;
+    static const Option<bool> DiffPts;
+    static Option<bool> DetectPWC;
+    static const Option<bool> VtableInSVFIR;
 
     // WPAPass.cpp
-    static const llvm::cl::opt<bool> AnderSVFG;
-    static const llvm::cl::opt<bool> SABERFULLSVFG;
-    static const llvm::cl::opt<bool> PrintAliases;
-    static llvm::cl::bits<PointerAnalysis::PTATY> PASelected;
-    static llvm::cl::bits<WPAPass::AliasCheckRule> AliasRule;
+    static const Option<bool> AnderSVFG;
+    static const Option<bool> SABERFULLSVFG;
+    static const Option<bool> PrintAliases;
+    static OptionMultiple<PointerAnalysis::PTATY> PASelected;
+    static OptionMultiple<WPAPass::AliasCheckRule> AliasRule;
 
     // DOTGraphTraits
-    static const llvm::cl::opt<bool> ShowHiddenNode;
+    static const Option<bool> ShowHiddenNode;
 
     // CFL option
-    static const llvm::cl::opt<std::string> GrammarFilename;
-    static const llvm::cl::opt<std::string> CFLGraph;
-    static const llvm::cl::opt<bool> PrintCFL;
-    static const llvm::cl::opt<bool> FlexSymMap;
-    static const llvm::cl::opt<bool>  PEGTransfer;
-    static const llvm::cl::opt<bool>  CFLSVFG;
+    static const Option<std::string> GrammarFilename;
+    static const Option<std::string> CFLGraph;
+    static const Option<bool> PrintCFL;
+    static const Option<bool> FlexSymMap;
+    static const Option<bool>  PEGTransfer;
+    static const Option<bool>  CFLSVFG;
 
     // Loop Analysis
-    static const llvm::cl::opt<bool> LoopAnalysis;
-    static const llvm::cl::opt<unsigned> LoopBound;
+    static const Option<bool> LoopAnalysis;
+    static const Option<u32_t> LoopBound;
 };
 }  // namespace SVF
 

--- a/include/WPA/Andersen.h
+++ b/include/WPA/Andersen.h
@@ -231,7 +231,7 @@ public:
 
     void setDetectPWC(bool flag)
     {
-        Options::DetectPWC = flag;
+        Options::DetectPWC.setValue(flag);
     }
 
 protected:
@@ -242,7 +242,7 @@ protected:
     /// Handle diff points-to set.
     virtual inline void computeDiffPts(NodeID id)
     {
-        if (Options::DiffPts)
+        if (Options::DiffPts())
         {
             NodeID rep = sccRepNode(id);
             getDiffPTDataTy()->computeDiffPts(rep, getDiffPTDataTy()->getPts(rep));
@@ -251,7 +251,7 @@ protected:
     virtual inline const PointsTo& getDiffPts(NodeID id)
     {
         NodeID rep = sccRepNode(id);
-        if (Options::DiffPts)
+        if (Options::DiffPts())
             return getDiffPTDataTy()->getDiffPts(rep);
         else
             return getPTDataTy()->getPts(rep);
@@ -260,7 +260,7 @@ protected:
     /// Handle propagated points-to set.
     inline void updatePropaPts(NodeID dstId, NodeID srcId)
     {
-        if (!Options::DiffPts)
+        if (!Options::DiffPts())
             return;
         NodeID srcRep = sccRepNode(srcId);
         NodeID dstRep = sccRepNode(dstId);
@@ -268,7 +268,7 @@ protected:
     }
     inline void clearPropaPts(NodeID src)
     {
-        if (Options::DiffPts)
+        if (Options::DiffPts())
         {
             NodeID rep = sccRepNode(src);
             getDiffPTDataTy()->clearPropaPts(rep);

--- a/lib/AbstractExecution/SVFIR2ItvExeState.cpp
+++ b/lib/AbstractExecution/SVFIR2ItvExeState.cpp
@@ -659,9 +659,9 @@ void SVFIR2ItvExeState::translateGep(const GepStmt *gep)
     {
         VAddrs gepAddrs;
         s32_t ub = offsetPair.second;
-        if (offsetPair.second - offsetPair.first > (s32_t)Options::MaxFieldLimit - 1)
+        if (offsetPair.second - offsetPair.first > (s32_t)Options::MaxFieldLimit() - 1)
         {
-            ub = offsetPair.first + (s32_t)Options::MaxFieldLimit - 1;
+            ub = offsetPair.first + (s32_t)Options::MaxFieldLimit() - 1;
         }
         for (s32_t i = offsetPair.first; i <= ub; i++)
         {

--- a/lib/CFL/CFLAlias.cpp
+++ b/lib/CFL/CFLAlias.cpp
@@ -208,14 +208,14 @@ void CFLAlias::finalize()
 {
     numOfChecks = solver->numOfChecks;
 
-    if(Options::PrintCFL == true)
+    if(Options::PrintCFL() == true)
     {
-        if (Options::CFLGraph.empty())
+        if (Options::CFLGraph().empty())
             svfir->dump("IR");
         grammar->dump("Grammar");
         graph->dump("CFLGraph");
     }
-    if (Options::CFLGraph.empty())
+    if (Options::CFLGraph().empty())
         PointerAnalysis::finalize();
 }
 
@@ -225,7 +225,7 @@ void CFLAlias::solve()
     double start = stat->getClk(true);
 
     solver->solve();
-    if (Options::CFLGraph.empty())
+    if (Options::CFLGraph().empty())
     {
         while (updateCallGraph(svfir->getIndirectCallsites()))
         {

--- a/lib/CFL/CFLBase.cpp
+++ b/lib/CFL/CFLBase.cpp
@@ -51,7 +51,7 @@ void CFLBase::buildCFLGrammar()
     // Start building grammar
     double start = stat->getClk(true);
 
-    GrammarBuilder grammarBuilder = GrammarBuilder(Options::GrammarFilename);
+    GrammarBuilder grammarBuilder = GrammarBuilder(Options::GrammarFilename());
     grammarBase = grammarBuilder.build();
 
     // Get time of build grammar
@@ -65,18 +65,18 @@ void CFLBase::buildCFLGraph()
     double start = stat->getClk(true);
 
     AliasCFLGraphBuilder cflGraphBuilder = AliasCFLGraphBuilder();
-    if (Options::CFLGraph.empty()) // built from svfir
+    if (Options::CFLGraph().empty()) // built from svfir
     {
         PointerAnalysis::initialize();
         ConstraintGraph *consCG = new ConstraintGraph(svfir);
-        if (Options::PEGTransfer)
+        if (Options::PEGTransfer())
             graph = cflGraphBuilder.buildBiPEGgraph(consCG, grammarBase->getStartKind(), grammarBase, svfir);
         else
             graph = cflGraphBuilder.buildBigraph(consCG, grammarBase->getStartKind(), grammarBase);
         delete consCG;
     }
     else
-        graph = cflGraphBuilder.buildFromDot(Options::CFLGraph, grammarBase);
+        graph = cflGraphBuilder.buildFromDot(Options::CFLGraph(), grammarBase);
 
     // Check CFL Graph and Grammar are accordance with grammar
     CFLGramGraphChecker cflChecker = CFLGramGraphChecker();

--- a/lib/CFL/CFLGraphBuilder.cpp
+++ b/lib/CFL/CFLGraphBuilder.cpp
@@ -139,7 +139,7 @@ CFLGraph * CFLGraphBuilder::buildFromDot(std::string fileName, GrammarBase *gram
                 }
                 else
                 {
-                    if(Options::FlexSymMap == true)
+                    if(Options::FlexSymMap() == true)
                     {
                         label2KindMap.insert({matches.str(3), current++});
                         cflGraph->addCFLEdge(src, dst, label2KindMap[matches.str(3)]);

--- a/lib/CFL/CFLVF.cpp
+++ b/lib/CFL/CFLVF.cpp
@@ -37,7 +37,7 @@ void CFLVF::buildCFLGraph()
 {
     // Build CFL Graph
     VFCFLGraphBuilder cflGraphBuilder = VFCFLGraphBuilder();
-    if (Options::CFLGraph.empty()) // built from svfir
+    if (Options::CFLGraph().empty()) // built from svfir
     {
         PointerAnalysis::initialize();
         AndersenWaveDiff* ander = AndersenWaveDiff::createAndersenWaveDiff(pag);
@@ -45,7 +45,7 @@ void CFLVF::buildCFLGraph()
         graph = cflGraphBuilder.buildBigraph(svfg, grammarBase->getStartKind(), grammarBase);
     }
     else
-        graph = cflGraphBuilder.buildFromDot(Options::CFLGraph, grammarBase);
+        graph = cflGraphBuilder.buildFromDot(Options::CFLGraph(), grammarBase);
 
     // Check CFL Graph and Grammar are accordance with grammar
     CFLGramGraphChecker cflChecker = CFLGramGraphChecker();
@@ -69,9 +69,9 @@ void CFLVF::initialize()
 
 void CFLVF::finalize()
 {
-    if(Options::PrintCFL == true)
+    if(Options::PrintCFL())
     {
-        if (Options::CFLGraph.empty())
+        if (Options::CFLGraph().empty())
             svfir->dump("IR");
         grammar->dump("Grammar");
         graph->dump("CFLGraph");

--- a/lib/DDA/ContextDDA.cpp
+++ b/lib/DDA/ContextDDA.cpp
@@ -76,7 +76,7 @@ const CxtPtSet& ContextDDA::computeDDAPts(const CxtVar& var)
 {
 
     resetQuery();
-    LocDPItem::setMaxBudget(Options::CxtBudget);
+    LocDPItem::setMaxBudget(Options::CxtBudget());
 
     NodeID id = var.get_id();
     PAGNode* node = getPAG()->getGNode(id);

--- a/lib/DDA/DDAPass.cpp
+++ b/lib/DDA/DDAPass.cpp
@@ -62,7 +62,8 @@ void DDAPass::runOnModule(SVFIR* pag)
     for (u32_t i = PointerAnalysis::FlowS_DDA;
             i < PointerAnalysis::Default_PTA; i++)
     {
-        if (Options::DDASelected.isSet(i))
+        PointerAnalysis::PTATY iPtTy = static_cast<PointerAnalysis::PTATY>(i);
+        if (Options::DDASelected(iPtTy))
             runPointerAnalysis(pag, i);
     }
 }
@@ -71,14 +72,14 @@ void DDAPass::runOnModule(SVFIR* pag)
 void DDAPass::selectClient(SVFModule* module)
 {
 
-    if (!Options::UserInputQuery.empty())
+    if (!Options::UserInputQuery().empty())
     {
         /// solve function pointer
-        if (Options::UserInputQuery == "funptr")
+        if (Options::UserInputQuery() == "funptr")
         {
             _client = new FunptrDDAClient(module);
         }
-        else if (Options::UserInputQuery == "alias")
+        else if (Options::UserInputQuery() == "alias")
         {
             _client = new AliasDDAClient(module);
         }
@@ -86,10 +87,10 @@ void DDAPass::selectClient(SVFModule* module)
         else
         {
             _client = new DDAClient(module);
-            if (Options::UserInputQuery != "all")
+            if (Options::UserInputQuery() != "all")
             {
                 u32_t buf; // Have a buffer
-                stringstream ss(Options::UserInputQuery); // Insert the user input string into a stream
+                stringstream ss(Options::UserInputQuery()); // Insert the user input string into a stream
                 while (ss >> buf)
                     _client->setQuery(buf);
             }
@@ -107,8 +108,8 @@ void DDAPass::selectClient(SVFModule* module)
 void DDAPass::runPointerAnalysis(SVFIR* pag, u32_t kind)
 {
 
-    ContextCond::setMaxPathLen(Options::MaxPathLen);
-    ContextCond::setMaxCxtLen(Options::MaxContextLen);
+    ContextCond::setMaxPathLen(Options::MaxPathLen());
+    ContextCond::setMaxCxtLen(Options::MaxContextLen());
 
     /// Initialize pointer analysis.
     switch (kind)
@@ -128,7 +129,7 @@ void DDAPass::runPointerAnalysis(SVFIR* pag, u32_t kind)
         break;
     }
 
-    if(Options::WPANum)
+    if(Options::WPANum())
     {
         _client->collectWPANum(pag->getModule());
     }
@@ -140,13 +141,13 @@ void DDAPass::runPointerAnalysis(SVFIR* pag, u32_t kind)
         _client->answerQueries(_pta.get());
         ///finalize
         _pta->finalize();
-        if(Options::PrintCPts)
+        if(Options::PrintCPts())
             _pta->dumpCPts();
 
         if (_pta->printStat())
             _client->performStat(_pta.get());
 
-        if (Options::PrintQueryPts)
+        if (Options::PrintQueryPts())
             printQueryPTS();
     }
 }
@@ -157,9 +158,9 @@ void DDAPass::runPointerAnalysis(SVFIR* pag, u32_t kind)
  */
 void DDAPass::initCxtInsensitiveEdges(PointerAnalysis* pta, const SVFG* svfg,const SVFGSCC* svfgSCC, SVFGEdgeSet& insensitveEdges)
 {
-    if(Options::InsenRecur)
+    if(Options::InsenRecur())
         collectCxtInsenEdgeForRecur(pta,svfg,insensitveEdges);
-    else if(Options::InsenCycle)
+    else if(Options::InsenCycle())
         collectCxtInsenEdgeForVFCycle(pta,svfg,svfgSCC,insensitveEdges);
 }
 

--- a/lib/DDA/FlowDDA.cpp
+++ b/lib/DDA/FlowDDA.cpp
@@ -43,7 +43,7 @@ using namespace SVFUtil;
 void FlowDDA::computeDDAPts(NodeID id)
 {
     resetQuery();
-    LocDPItem::setMaxBudget(Options::FlowBudget);
+    LocDPItem::setMaxBudget(Options::FlowBudget());
 
     PAGNode* node = getPAG()->getGNode(id);
     LocDPItem dpm = getDPIm(node->getId(),getDefSVFGNode(node));

--- a/lib/Graphs/ConsG.cpp
+++ b/lib/Graphs/ConsG.cpp
@@ -632,7 +632,7 @@ void ConstraintGraph::view()
 //@{
 ConstraintNode::iterator ConstraintNode::directOutEdgeBegin()
 {
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
         return directOutEdges.begin();
     else
         return copyOutEdges.begin();
@@ -640,7 +640,7 @@ ConstraintNode::iterator ConstraintNode::directOutEdgeBegin()
 
 ConstraintNode::iterator ConstraintNode::directOutEdgeEnd()
 {
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
         return directOutEdges.end();
     else
         return copyOutEdges.end();
@@ -648,7 +648,7 @@ ConstraintNode::iterator ConstraintNode::directOutEdgeEnd()
 
 ConstraintNode::iterator ConstraintNode::directInEdgeBegin()
 {
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
         return directInEdges.begin();
     else
         return copyInEdges.begin();
@@ -656,7 +656,7 @@ ConstraintNode::iterator ConstraintNode::directInEdgeBegin()
 
 ConstraintNode::iterator ConstraintNode::directInEdgeEnd()
 {
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
         return directInEdges.end();
     else
         return copyInEdges.end();
@@ -664,7 +664,7 @@ ConstraintNode::iterator ConstraintNode::directInEdgeEnd()
 
 ConstraintNode::const_iterator ConstraintNode::directOutEdgeBegin() const
 {
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
         return directOutEdges.begin();
     else
         return copyOutEdges.begin();
@@ -672,7 +672,7 @@ ConstraintNode::const_iterator ConstraintNode::directOutEdgeBegin() const
 
 ConstraintNode::const_iterator ConstraintNode::directOutEdgeEnd() const
 {
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
         return directOutEdges.end();
     else
         return copyOutEdges.end();
@@ -680,7 +680,7 @@ ConstraintNode::const_iterator ConstraintNode::directOutEdgeEnd() const
 
 ConstraintNode::const_iterator ConstraintNode::directInEdgeBegin() const
 {
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
         return directInEdges.begin();
     else
         return copyInEdges.begin();
@@ -688,7 +688,7 @@ ConstraintNode::const_iterator ConstraintNode::directInEdgeBegin() const
 
 ConstraintNode::const_iterator ConstraintNode::directInEdgeEnd() const
 {
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
         return directInEdges.end();
     else
         return copyInEdges.end();
@@ -723,7 +723,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<SVFIR*>
     static bool isNodeHidden(NodeType *n)
     {
 #endif
-        if (Options::ShowHiddenNode) return false;
+        if (Options::ShowHiddenNode()) return false;
         else return (n->getInEdges().empty() && n->getOutEdges().empty());
     }
 
@@ -732,7 +732,7 @@ struct DOTGraphTraits<ConstraintGraph*> : public DOTGraphTraits<SVFIR*>
     static std::string getNodeLabel(NodeType *n, ConstraintGraph*)
     {
         PAGNode* node = SVFIR::getPAG()->getGNode(n->getId());
-        bool briefDisplay = Options::BriefConsCGDotGraph;
+        bool briefDisplay = Options::BriefConsCGDotGraph();
         bool nameDisplay = true;
         std::string str;
         std::stringstream rawstr(str);

--- a/lib/Graphs/ICFG.cpp
+++ b/lib/Graphs/ICFG.cpp
@@ -508,7 +508,7 @@ void ICFG::updateCallGraph(PTACallGraph* callgraph)
         }
     }
     // dump ICFG
-    if (Options::DumpICFG)
+    if (Options::DumpICFG())
     {
         dump("icfg_final");
     }

--- a/lib/Graphs/IRGraph.cpp
+++ b/lib/Graphs/IRGraph.cpp
@@ -144,7 +144,7 @@ struct DOTGraphTraits<IRGraph*> : public DefaultDOTGraphTraits
     static bool isNodeHidden(SVFVar *node)
     {
 #endif
-        if (Options::ShowHiddenNode) return false;
+        if (Options::ShowHiddenNode()) return false;
         else return node->isIsolatedNode();
     }
 

--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -226,9 +226,9 @@ void SVFG::buildSVFG()
     DBOUT(DGENERAL, outs() << pasMsg("Build Sparse Value-Flow Graph \n"));
 
     stat->startClk();
-    if (!Options::ReadSVFG.empty())
+    if (!Options::ReadSVFG().empty())
     {
-        readFile(Options::ReadSVFG);
+        readFile(Options::ReadSVFG());
     }
     else
     {
@@ -240,8 +240,8 @@ void SVFG::buildSVFG()
         stat->indVFEdgeStart();
         connectIndirectSVFGEdges();
         stat->indVFEdgeEnd();
-        if (!Options::WriteSVFG.empty())
-            writeToFile(Options::WriteSVFG);
+        if (!Options::WriteSVFG().empty())
+            writeToFile(Options::WriteSVFG());
     }
 }
 
@@ -788,7 +788,7 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<SVFIR*>
     static bool isNodeHidden(SVFGNode *node)
     {
 #endif
-        if (Options::ShowHiddenNode) return false;
+        if (Options::ShowHiddenNode()) return false;
         else return node->getInEdges().empty() && node->getOutEdges().empty();
     }
 

--- a/lib/Graphs/SVFGOPT.cpp
+++ b/lib/Graphs/SVFGOPT.cpp
@@ -48,12 +48,12 @@ void SVFGOPT::buildSVFG()
 {
     SVFG::buildSVFG();
 
-    if(Options::DumpVFG)
+    if(Options::DumpVFG())
         dump("SVFG_before_opt");
 
     DBOUT(DGENERAL, outs() << SVFUtil::pasMsg("\tSVFG Optimisation\n"));
 
-    keepActualOutFormalIn = Options::KeepAOFI;
+    keepActualOutFormalIn = Options::KeepAOFI();
 
     stat->sfvgOptStart();
     handleInterValueFlow();
@@ -67,7 +67,7 @@ void SVFGOPT::buildSVFG()
  */
 SVFGEdge* SVFGOPT::addCallIndirectSVFGEdge(NodeID srcId, NodeID dstId, CallSiteID csid, const NodeBS& cpts)
 {
-    if (Options::ContextInsensitive)
+    if (Options::ContextInsensitive())
         return addIntraIndirectVFEdge(srcId, dstId, cpts);
     else
         return addCallIndirectVFEdge(srcId, dstId, cpts, csid);
@@ -78,7 +78,7 @@ SVFGEdge* SVFGOPT::addCallIndirectSVFGEdge(NodeID srcId, NodeID dstId, CallSiteI
  */
 SVFGEdge* SVFGOPT::addRetIndirectSVFGEdge(NodeID srcId, NodeID dstId, CallSiteID csid, const NodeBS& cpts)
 {
-    if (Options::ContextInsensitive)
+    if (Options::ContextInsensitive())
         return addIntraIndirectVFEdge(srcId, dstId, cpts);
     else
         return addRetIndirectVFEdge(srcId, dstId, cpts, csid);
@@ -371,7 +371,7 @@ bool SVFGOPT::canBeRemoved(const SVFGNode * node)
  */
 void SVFGOPT::parseSelfCycleHandleOption()
 {
-    std::string choice = (Options::SelfCycle.getValue().empty()) ? "" : Options::SelfCycle.getValue();
+    std::string choice = (Options::SelfCycle().empty()) ? "" : Options::SelfCycle();
     if (choice.empty() || choice == KeepAllSelfCycle)
         keepAllSelfCycle = true;
     else if (choice == KeepContextSelfCycle)

--- a/lib/Graphs/VFG.cpp
+++ b/lib/Graphs/VFG.cpp
@@ -835,7 +835,7 @@ void VFG::connectDirectVFGEdges()
     }
 
     /// connect direct value-flow edges (parameter passing) for thread fork/join
-    if(Options::EnableThreadCallGraph)
+    if(Options::EnableThreadCallGraph())
     {
         /// add fork edge
         SVFStmt::SVFStmtSetTy& forks = getPAGEdgeSet(SVFStmt::ThreadFork);

--- a/lib/MSSA/MemRegion.cpp
+++ b/lib/MSSA/MemRegion.cpp
@@ -178,7 +178,7 @@ void MRGenerator::collectModRefForLoadStore()
         const SVFFunction& fun = **fi;
 
         /// if this function does not have any caller, then we do not care its MSSA
-        if (Options::IgnoreDeadFun && fun.isUncalledFunction())
+        if (Options::IgnoreDeadFun() && fun.isUncalledFunction())
             continue;
 
         for (SVFFunction::const_iterator iter = fun.begin(), eiter = fun.end();

--- a/lib/MSSA/MemSSA.cpp
+++ b/lib/MSSA/MemSSA.cpp
@@ -49,11 +49,11 @@ MemSSA::MemSSA(BVDataPTAImpl* p, bool ptrOnlyMSSA)
     assert((pta->getAnalysisTy()!=PointerAnalysis::Default_PTA)
            && "please specify a pointer analysis");
 
-    if (Options::MemPar == MemPartition::Distinct)
+    if (Options::MemPar() == MemPartition::Distinct)
         mrGen = new DistinctMRG(pta, ptrOnlyMSSA);
-    else if (Options::MemPar == MemPartition::IntraDisjoint)
+    else if (Options::MemPar() == MemPartition::IntraDisjoint)
         mrGen = new IntraDisjointMRG(pta, ptrOnlyMSSA);
-    else if (Options::MemPar == MemPartition::InterDisjoint)
+    else if (Options::MemPar() == MemPartition::InterDisjoint)
         mrGen = new InterDisjointMRG(pta, ptrOnlyMSSA);
     else
         assert(false && "unrecognised memory partition strategy");
@@ -585,7 +585,7 @@ void MemSSA::dumpMSSA(OutStream& Out)
             fit != efit; ++fit)
     {
         const SVFFunction* fun = *fit;
-        if(Options::MSSAFun!="" && Options::MSSAFun!=fun->getName())
+        if(Options::MSSAFun()!="" && Options::MSSAFun()!=fun->getName())
             continue;
 
         Out << "==========FUNCTION: " << fun->getName() << "==========\n";

--- a/lib/MSSA/SVFGBuilder.cpp
+++ b/lib/MSSA/SVFGBuilder.cpp
@@ -40,7 +40,7 @@ using namespace SVFUtil;
 
 SVFG* SVFGBuilder::buildPTROnlySVFG(BVDataPTAImpl* pta)
 {
-    if(Options::OPTSVFG)
+    if(Options::OPTSVFG())
         return build(pta, VFG::PTRONLYSVFG_OPT);
     else
         return build(pta, VFG::PTRONLYSVFG);
@@ -74,13 +74,13 @@ SVFG* SVFGBuilder::build(BVDataPTAImpl* pta, VFG::VFGK kind)
     buildSVFG();
 
     /// Update call graph using pre-analysis results
-    if(Options::SVFGWithIndirectCall || SVFGWithIndCall)
+    if(Options::SVFGWithIndirectCall() || SVFGWithIndCall)
         svfg->updateCallGraph(pta);
 
     if(svfg->getMSSA()->getPTA()->printStat())
         svfg->performStat();
 
-    if(Options::DumpVFG)
+    if(Options::DumpVFG())
         svfg->dump("svfg_final");
 
     return svfg.get();
@@ -114,7 +114,7 @@ std::unique_ptr<MemSSA> SVFGBuilder::buildMSSA(BVDataPTAImpl* pta, bool ptrOnlyM
     }
 
     mssa->performStat();
-    if (Options::DumpMSSA)
+    if (Options::DumpMSSA())
     {
         mssa->dumpMSSA();
     }

--- a/lib/MTA/FSMPTA.cpp
+++ b/lib/MTA/FSMPTA.cpp
@@ -48,7 +48,7 @@ void MTASVFGBuilder::buildSVFG()
 {
     MemSSA* mssa = svfg->getMSSA();
     svfg->buildSVFG();
-    if (ADDEDGE_NOEDGE != Options::AddModelFlag)
+    if (ADDEDGE_NOEDGE != Options::AddModelFlag())
     {
         DBOUT(DGENERAL, outs() << SVFUtil::pasMsg("FSMPTA adding edge\n"));
         DBOUT(DMTA, outs() << SVFUtil::pasMsg("FSMPTA adding edge\n"));
@@ -486,10 +486,10 @@ void MTASVFGBuilder::handleStoreLoad(const StmtSVFGNode* n1,const StmtSVFGNode* 
     const SVFInstruction* i1 = n1->getInst();
     const SVFInstruction* i2 = n2->getInst();
     /// MHP
-    if (ADDEDGE_NOMHP!=Options::AddModelFlag && !mhp->mayHappenInParallel(i1, i2))
+    if (ADDEDGE_NOMHP!=Options::AddModelFlag() && !mhp->mayHappenInParallel(i1, i2))
         return;
     /// Alias
-    if (ADDEDGE_NOALIAS!=Options::AddModelFlag && !pta->alias(n1->getPAGDstNodeID(), n2->getPAGSrcNodeID()))
+    if (ADDEDGE_NOALIAS!=Options::AddModelFlag() && !pta->alias(n1->getPAGDstNodeID(), n2->getPAGSrcNodeID()))
         return;
 
 
@@ -502,7 +502,7 @@ void MTASVFGBuilder::handleStoreLoad(const StmtSVFGNode* n1,const StmtSVFGNode* 
     /// This constrait is too strong. All cxt lock under different cxt cannot be identified.
 
 
-    if (ADDEDGE_NOLOCK!=Options::AddModelFlag && lockana->isProtectedByCommonLock(i1, i2))
+    if (ADDEDGE_NOLOCK!=Options::AddModelFlag() && lockana->isProtectedByCommonLock(i1, i2))
     {
         if (isTailofSpan(n1) && isHeadofSpan(n2))
             addTDEdges(n1->getId(), n2->getId(), pts);
@@ -520,17 +520,17 @@ void MTASVFGBuilder::handleStoreStore(const StmtSVFGNode* n1,const StmtSVFGNode*
     const SVFInstruction* i1 = n1->getInst();
     const SVFInstruction* i2 = n2->getInst();
     /// MHP
-    if (ADDEDGE_NOMHP!=Options::AddModelFlag && !mhp->mayHappenInParallel(i1, i2))
+    if (ADDEDGE_NOMHP!=Options::AddModelFlag() && !mhp->mayHappenInParallel(i1, i2))
         return;
     /// Alias
-    if (ADDEDGE_NOALIAS!=Options::AddModelFlag && !pta->alias(n1->getPAGDstNodeID(), n2->getPAGDstNodeID()))
+    if (ADDEDGE_NOALIAS!=Options::AddModelFlag() && !pta->alias(n1->getPAGDstNodeID(), n2->getPAGDstNodeID()))
         return;
 
     PointsTo pts = pta->getPts(n1->getPAGDstNodeID());
     pts &= pta->getPts(n2->getPAGDstNodeID());
 
     /// Lock
-    if (ADDEDGE_NOLOCK!=Options::AddModelFlag && lockana->isProtectedByCommonLock(i1, i2))
+    if (ADDEDGE_NOLOCK!=Options::AddModelFlag() && lockana->isProtectedByCommonLock(i1, i2))
     {
         if (isTailofSpan(n1) && isHeadofSpan(n2))
             addTDEdges(n1->getId(), n2->getId(), pts);
@@ -706,7 +706,7 @@ void MTASVFGBuilder::readPrecision()
 void MTASVFGBuilder::connectMHPEdges(PointerAnalysis* pta)
 {
     PCG* pcg = new PCG(pta);
-    if ((ADDEDGE_NONSPARSE==Options::AddModelFlag) && Options::UsePCG)
+    if ((ADDEDGE_NONSPARSE==Options::AddModelFlag()) && Options::UsePCG())
     {
         pcg->analyze();
     }
@@ -725,9 +725,9 @@ void MTASVFGBuilder::connectMHPEdges(PointerAnalysis* pta)
         {
             const StmtSVFGNode* n2 = SVFUtil::cast<StmtSVFGNode>(*it2);
             const SVFInstruction* i2 = n2->getInst();
-            if (ADDEDGE_NONSPARSE==Options::AddModelFlag)
+            if (ADDEDGE_NONSPARSE==Options::AddModelFlag())
             {
-                if (Options::UsePCG)
+                if (Options::UsePCG())
                 {
                     if (pcg->mayHappenInParallel(i1, i2) || mhp->mayHappenInParallel(i1, i2))
                         handleStoreLoadNonSparse(n1, n2, pta);
@@ -747,9 +747,9 @@ void MTASVFGBuilder::connectMHPEdges(PointerAnalysis* pta)
         {
             const StmtSVFGNode* n2 = SVFUtil::cast<StmtSVFGNode>(*it2);
             const SVFInstruction* i2 = n2->getInst();
-            if (ADDEDGE_NONSPARSE == Options::AddModelFlag)
+            if (ADDEDGE_NONSPARSE == Options::AddModelFlag())
             {
-                if (Options::UsePCG)
+                if (Options::UsePCG())
                 {
                     if(pcg->mayHappenInParallel(i1, i2) || mhp->mayHappenInParallel(i1, i2))
                         handleStoreStoreNonSparse(n1, n2, pta);
@@ -766,7 +766,7 @@ void MTASVFGBuilder::connectMHPEdges(PointerAnalysis* pta)
         }
     }
 
-    if(Options::ReadPrecisionTDEdge && ADDEDGE_NORP!=Options::AddModelFlag)
+    if(Options::ReadPrecisionTDEdge() && ADDEDGE_NORP!=Options::AddModelFlag())
     {
         DBOUT(DGENERAL,outs()<<"Read precision edge removing \n");
         DBOUT(DMTA,outs()<<"Read precision edge removing \n");

--- a/lib/MTA/MHP.cpp
+++ b/lib/MTA/MHP.cpp
@@ -134,7 +134,7 @@ void MHP::analyzeInterleaving()
     /// update non-candidate functions' interleaving
     updateNonCandidateFunInterleaving();
 
-    if (Options::PrintInterLev)
+    if (Options::PrintInterLev())
         printInterleaving();
 }
 

--- a/lib/MTA/MTA.cpp
+++ b/lib/MTA/MTA.cpp
@@ -67,12 +67,12 @@ bool MTA::runOnModule(SVFIR* pag)
 
 
     /*
-    if (Options::AndersenAnno) {
+    if (Options::AndersenAnno()) {
         pta = mhp->getTCT()->getPTA();
         if (pta->printStat())
             stat->performMHPPairStat(mhp,lsa);
         AndersenWaveDiff::releaseAndersenWaveDiff();
-    } else if (Options::FSAnno) {
+    } else if (Options::FSAnno()) {
 
         reportMemoryUsageKB("Mem before analysis");
         DBOUT(DGENERAL, outs() << pasMsg("FSMPTA analysis\n"));

--- a/lib/MTA/MTAStat.cpp
+++ b/lib/MTA/MTAStat.cpp
@@ -113,7 +113,7 @@ void MTAStat::performMHPPairStat(MHP* mhp, LockAnalysis* lsa)
 {
 
     SVFIR* pag = SVFIR::getPAG();
-    if(Options::AllPairMHP)
+    if(Options::AllPairMHP())
     {
         Set<const SVFInstruction*> instSet1;
         Set<const SVFInstruction*> instSet2;

--- a/lib/MTA/PCG.cpp
+++ b/lib/MTA/PCG.cpp
@@ -27,6 +27,7 @@
  *      Author: Yulei Sui, Peng Di
  */
 
+#include "Util/CommandLine.h"
 #include "Util/Options.h"
 #include "MTA/PCG.h"
 #include "Util/SVFUtil.h"
@@ -39,7 +40,12 @@ using namespace SVFUtil;
  * Whether two functions may happen in parallel
  */
 
-//static llvm::cl::opt<bool> TDPrint("print-td", llvm::cl::init(true), llvm::cl::desc("Print Thread Analysis Results"));
+//static Option<bool> TDPrint(
+//    "print-td",
+//    true,
+//    "Print Thread Analysis Results"
+//);
+
 bool PCG::analyze()
 {
 
@@ -53,7 +59,7 @@ bool PCG::analyze()
 
     //interferenceAnalysis();
 
-    //if (Options::TDPrint) {
+    //if (Options::TDPrint()) {
     //printResults();
     //tdAPI->performAPIStat(mod);
     //}

--- a/lib/MTA/TCT.cpp
+++ b/lib/MTA/TCT.cpp
@@ -429,7 +429,7 @@ void TCT::build()
 
     collectMultiForkedThreads();
 
-    if (Options::TCTDotGraph)
+    if (Options::TCTDotGraph())
     {
         print();
         dump("tct");
@@ -511,7 +511,7 @@ void TCT::dumpCxt(CallStrCxt& cxt)
  */
 void TCT::dump(const std::string& filename)
 {
-    if (Options::TCTDotGraph)
+    if (Options::TCTDotGraph())
         GraphPrinter::WriteGraphToFile(outs(), filename, this);
 }
 

--- a/lib/MemoryModel/PointerAnalysis.cpp
+++ b/lib/MemoryModel/PointerAnalysis.cpp
@@ -70,10 +70,10 @@ PointerAnalysis::PointerAnalysis(SVFIR* p, PTATY ty, bool alias_check) :
     svfMod(nullptr),ptaTy(ty),stat(nullptr),ptaCallGraph(nullptr),callGraphSCC(nullptr),icfg(nullptr),chgraph(nullptr),typeSystem(nullptr)
 {
     pag = p;
-    OnTheFlyIterBudgetForStat = Options::StatBudget;
-    print_stat = Options::PStat;
+    OnTheFlyIterBudgetForStat = Options::StatBudget();
+    print_stat = Options::PStat();
     ptaImplTy = BaseImpl;
-    alias_validation = (alias_check && Options::EnableAliasCheck);
+    alias_validation = (alias_check && Options::EnableAliasCheck());
 }
 
 /*!
@@ -110,7 +110,7 @@ void PointerAnalysis::initialize()
     chgraph = pag->getCHG();
 
     /// initialise pta call graph for every pointer analysis instance
-    if(Options::EnableThreadCallGraph)
+    if(Options::EnableThreadCallGraph())
     {
         ThreadCallGraph* cg = new ThreadCallGraph();
         ThreadCallGraphBuilder bd(cg, pag->getICFG());
@@ -125,7 +125,7 @@ void PointerAnalysis::initialize()
     callGraphSCCDetection();
 
     // dump callgraph
-    if (Options::CallGraphDotGraph)
+    if (Options::CallGraphDotGraph())
         getPTACallGraph()->dump("callgraph_initial");
 }
 
@@ -183,31 +183,31 @@ void PointerAnalysis::finalize()
     dumpStat();
 
     /// Dump results
-    if (Options::PTSPrint)
+    if (Options::PTSPrint())
     {
         dumpTopLevelPtsTo();
         //dumpAllPts();
         //dumpCPts();
     }
 
-    if (Options::TypePrint)
+    if (Options::TypePrint())
         dumpAllTypes();
 
-    if(Options::PTSAllPrint)
+    if(Options::PTSAllPrint())
         dumpAllPts();
 
-    if (Options::FuncPointerPrint)
+    if (Options::FuncPointerPrint())
         printIndCSTargets();
 
     getPTACallGraph()->verifyCallGraph();
 
-    if (Options::CallGraphDotGraph)
+    if (Options::CallGraphDotGraph())
         getPTACallGraph()->dump("callgraph_final");
 
     if(!pag->isBuiltFromFile() && alias_validation)
         validateTests();
 
-    if (!Options::UsePreCompFieldSensitive)
+    if (!Options::UsePreCompFieldSensitive())
         resetObjFieldSensitive();
 }
 
@@ -392,7 +392,7 @@ void PointerAnalysis::resolveIndCalls(const CallICFGNode* cs, const PointsTo& ta
             ii != ie; ii++)
     {
 
-        if(getNumOfResolvedIndCallEdge() >= Options::IndirectCallLimit)
+        if(getNumOfResolvedIndCallEdge() >= Options::IndirectCallLimit())
         {
             wrnMsg("Resolved Indirect Call Edges are Out-Of-Budget, please increase the limit");
             return;
@@ -504,7 +504,7 @@ void PointerAnalysis::resolveCPPIndCalls(const CallICFGNode* cs, const PointsTo&
     assert(SVFUtil::getSVFCallSite(cs->getCallSite()).isVirtualCall() && "not cpp virtual call");
 
     VFunSet vfns;
-    if (Options::ConnectVCallOnCHA)
+    if (Options::ConnectVCallOnCHA())
         getVFnsFromCHA(cs, vfns);
     else
         getVFnsFromPts(cs, target, vfns);

--- a/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -51,37 +51,37 @@ BVDataPTAImpl::BVDataPTAImpl(SVFIR* p, PointerAnalysis::PTATY type, bool alias_c
     {
         // Only maintain reverse points-to when the analysis is field-sensitive, as objects turning
         // field-insensitive is all it is used for.
-        bool maintainRevPts = Options::MaxFieldLimit != 0;
-        if (Options::ptDataBacking == PTBackingType::Mutable) ptD = std::make_unique<MutDiffPTDataTy>(maintainRevPts);
-        else if (Options::ptDataBacking == PTBackingType::Persistent) ptD = std::make_unique<PersDiffPTDataTy>(getPtCache(), maintainRevPts);
+        bool maintainRevPts = Options::MaxFieldLimit() != 0;
+        if (Options::ptDataBacking() == PTBackingType::Mutable) ptD = std::make_unique<MutDiffPTDataTy>(maintainRevPts);
+        else if (Options::ptDataBacking() == PTBackingType::Persistent) ptD = std::make_unique<PersDiffPTDataTy>(getPtCache(), maintainRevPts);
         else assert(false && "BVDataPTAImpl::BVDataPTAImpl: unexpected points-to backing type!");
     }
     else if (type == Steensgaard_WPA)
     {
         // Steensgaard is only field-insensitive (for now?), so no reverse points-to.
-        if (Options::ptDataBacking == PTBackingType::Mutable) ptD = std::make_unique<MutDiffPTDataTy>(false);
-        else if (Options::ptDataBacking == PTBackingType::Persistent) ptD = std::make_unique<PersDiffPTDataTy>(getPtCache(), false);
+        if (Options::ptDataBacking() == PTBackingType::Mutable) ptD = std::make_unique<MutDiffPTDataTy>(false);
+        else if (Options::ptDataBacking() == PTBackingType::Persistent) ptD = std::make_unique<PersDiffPTDataTy>(getPtCache(), false);
         else assert(false && "BVDataPTAImpl::BVDataPTAImpl: unexpected points-to backing type!");
     }
     else if (type == FSSPARSE_WPA)
     {
-        if (Options::INCDFPTData)
+        if (Options::INCDFPTData())
         {
-            if (Options::ptDataBacking == PTBackingType::Mutable) ptD = std::make_unique<MutIncDFPTDataTy>(false);
-            else if (Options::ptDataBacking == PTBackingType::Persistent) ptD = std::make_unique<PersIncDFPTDataTy>(getPtCache(), false);
+            if (Options::ptDataBacking() == PTBackingType::Mutable) ptD = std::make_unique<MutIncDFPTDataTy>(false);
+            else if (Options::ptDataBacking() == PTBackingType::Persistent) ptD = std::make_unique<PersIncDFPTDataTy>(getPtCache(), false);
             else assert(false && "BVDataPTAImpl::BVDataPTAImpl: unexpected points-to backing type!");
         }
         else
         {
-            if (Options::ptDataBacking == PTBackingType::Mutable) ptD = std::make_unique<MutDFPTDataTy>(false);
-            else if (Options::ptDataBacking == PTBackingType::Persistent) ptD = std::make_unique<PersDFPTDataTy>(getPtCache(), false);
+            if (Options::ptDataBacking() == PTBackingType::Mutable) ptD = std::make_unique<MutDFPTDataTy>(false);
+            else if (Options::ptDataBacking() == PTBackingType::Persistent) ptD = std::make_unique<PersDFPTDataTy>(getPtCache(), false);
             else assert(false && "BVDataPTAImpl::BVDataPTAImpl: unexpected points-to backing type!");
         }
     }
     else if (type == VFS_WPA)
     {
-        if (Options::ptDataBacking == PTBackingType::Mutable) ptD = std::make_unique<MutVersionedPTDataTy>(false);
-        else if (Options::ptDataBacking == PTBackingType::Persistent) ptD = std::make_unique<PersVersionedPTDataTy>(getPtCache(), false);
+        if (Options::ptDataBacking() == PTBackingType::Mutable) ptD = std::make_unique<MutVersionedPTDataTy>(false);
+        else if (Options::ptDataBacking() == PTBackingType::Persistent) ptD = std::make_unique<PersVersionedPTDataTy>(getPtCache(), false);
         else assert(false && "BVDataPTAImpl::BVDataPTAImpl: unexpected points-to backing type!");
     }
     else assert(false && "no points-to data available");
@@ -94,7 +94,7 @@ void BVDataPTAImpl::finalize()
     normalizePointsTo();
     PointerAnalysis::finalize();
 
-    if (Options::ptDataBacking == PTBackingType::Persistent && print_stat)
+    if (Options::ptDataBacking() == PTBackingType::Persistent && print_stat)
     {
         std::string moduleName(pag->getModule()->getModuleIdentifier());
         std::vector<std::string> names = SVFUtil::split(moduleName,'/');

--- a/lib/MemoryModel/PointsTo.cpp
+++ b/lib/MemoryModel/PointsTo.cpp
@@ -23,7 +23,7 @@ PointsTo::MappingPtr PointsTo::currentBestNodeMapping = nullptr;
 PointsTo::MappingPtr PointsTo::currentBestReverseNodeMapping = nullptr;
 
 PointsTo::PointsTo()
-    : type(Options::PtType), nodeMapping(currentBestNodeMapping),
+    : type(Options::PtType()), nodeMapping(currentBestNodeMapping),
       reverseNodeMapping(currentBestReverseNodeMapping)
 {
     if (type == SBV) new (&sbv) SparseBitVector<>();

--- a/lib/SABER/DoubleFreeChecker.cpp
+++ b/lib/SABER/DoubleFreeChecker.cpp
@@ -45,7 +45,7 @@ void DoubleFreeChecker::reportBug(ProgSlice* slice)
                         << cs->getCallSite()->getSourceLoc() << ")\n";
         SVFUtil::errs() << "\t\t double free path: \n" << slice->evalFinalCond() << "\n";
     }
-    if(Options::ValidateTests)
+    if(Options::ValidateTests())
         testsValidation(slice);
 }
 

--- a/lib/SABER/LeakChecker.cpp
+++ b/lib/SABER/LeakChecker.cpp
@@ -175,7 +175,7 @@ void LeakChecker::reportBug(ProgSlice* slice)
         SVFUtil::errs() << "\t\t conditional free path: \n" << slice->evalFinalCond() << "\n";
     }
 
-    if(Options::ValidateTests)
+    if(Options::ValidateTests())
         testsValidation(slice);
 }
 

--- a/lib/SABER/SaberCondAllocator.cpp
+++ b/lib/SABER/SaberCondAllocator.cpp
@@ -72,7 +72,7 @@ void SaberCondAllocator::allocate(const SVFModule *M)
         }
     }
 
-    if (Options::PrintPathCond)
+    if (Options::PrintPathCond())
         printPathCond();
 
     DBOUT(DGENERAL, outs() << pasMsg("path condition allocation ends\n"));

--- a/lib/SABER/SrcSnkDDA.cpp
+++ b/lib/SABER/SrcSnkDDA.cpp
@@ -43,7 +43,7 @@ void SrcSnkDDA::initialize(SVFModule* module)
     SVFIR* pag = PAG::getPAG();
 
     AndersenWaveDiff* ander = AndersenWaveDiff::createAndersenWaveDiff(pag);
-    if(Options::SABERFULLSVFG)
+    if(Options::SABERFULLSVFG())
         svfg =  memSSA.buildFullSVFG(ander);
     else
         svfg =  memSSA.buildPTROnlySVFG(ander);
@@ -62,7 +62,7 @@ void SrcSnkDDA::analyze(SVFModule* module)
 
     initialize(module);
 
-    ContextCond::setMaxCxtLen(Options::CxtLimit);
+    ContextCond::setMaxCxtLen(Options::CxtLimit());
 
     for (SVFGNodeSetIter iter = sourcesBegin(), eiter = sourcesEnd();
             iter != eiter; ++iter)
@@ -94,7 +94,7 @@ void SrcSnkDDA::analyze(SVFModule* module)
 
             DBOUT(DSaber, outs() << "Backward process for slice:" << (*iter)->getId() << " (size = " << getCurSlice()->getBackwardSliceSize() << ")\n");
 
-            if(Options::DumpSlice)
+            if(Options::DumpSlice())
                 annotateSlice(_curSlice);
 
             if(_curSlice->AllPathReachableSolve())
@@ -133,7 +133,7 @@ bool SrcSnkDDA::isInAWrapper(const SVFGNode* src, CallSiteSet& csIdSet)
         else
             continue;
         // reaching maximum steps when traversing on SVFG to identify a memory allocation wrapper
-        if (step++ > Options::MaxStepInWrapper)
+        if (step++ > Options::MaxStepInWrapper())
             return false;
 
         for (SVFGNode::const_iterator it = node->OutEdgeBegin(), eit =
@@ -295,7 +295,7 @@ void SrcSnkDDA::annotateSlice(ProgSlice* slice)
 void SrcSnkDDA::dumpSlices()
 {
 
-    if(Options::DumpSlice)
+    if(Options::DumpSlice())
         const_cast<SVFG*>(getSVFG())->dump("Slice",true);
 }
 

--- a/lib/SVF-LLVM/CHGBuilder.cpp
+++ b/lib/SVF-LLVM/CHGBuilder.cpp
@@ -82,7 +82,7 @@ void CHGBuilder::buildCHG()
     timeEnd = PTAStat::getClk(true);
     chg->buildingCHGTime = (timeEnd - timeStart) / TIMEINTERVAL;
 
-    if (Options::DumpCHA)
+    if (Options::DumpCHA())
         chg->dump("cha");
 }
 

--- a/lib/SVF-LLVM/DCHG.cpp
+++ b/lib/SVF-LLVM/DCHG.cpp
@@ -529,7 +529,7 @@ void DCHGraph::buildCHG(bool extend)
         }
     }
 
-    if (Options::PrintDCHG)
+    if (Options::PrintDCHG())
     {
         print();
     }

--- a/lib/SVF-LLVM/LLVMLoopAnalysis.cpp
+++ b/lib/SVF-LLVM/LLVMLoopAnalysis.cpp
@@ -111,7 +111,7 @@ void LLVMLoopAnalysis::buildSVFLoops(ICFG *icfg, std::vector<const Loop *> &llvm
                 nodes.insert(icfg->getICFGNode(svfInst));
             }
         }
-        SVFLoop *svf_loop = new SVFLoop(nodes, Options::LoopBound);
+        SVFLoop *svf_loop = new SVFLoop(nodes, Options::LoopBound());
         for (const auto &node: nodes)
         {
             icfg->addNodeToSVFLoop(node, svf_loop);

--- a/lib/SVF-LLVM/LLVMModule.cpp
+++ b/lib/SVF-LLVM/LLVMModule.cpp
@@ -140,7 +140,7 @@ void LLVMModuleSet::build()
     buildFunToFunMap();
     buildGlobalDefToRepMap();
 
-    if (Options::SVFMain)
+    if (Options::SVFMain())
         addSVFMain();
 
     createSVFDataStructure();
@@ -407,7 +407,7 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
 {
 
     // We read SVFIR from LLVM IR
-    if(Options::Graphtxt.getValue().empty())
+    if(Options::Graphtxt().empty())
     {
         if(moduleNameVec.empty())
         {
@@ -418,7 +418,7 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
     }
     // We read SVFIR from a user-defined txt instead of parsing SVFIR from LLVM IR
     else
-        SVFModule::setPagFromTXT(Options::Graphtxt.getValue());
+        SVFModule::setPagFromTXT(Options::Graphtxt());
 
     //
     // To avoid the following type bugs (t1 != t3) when parsing multiple modules,

--- a/lib/SVF-LLVM/LLVMModule.cpp
+++ b/lib/SVF-LLVM/LLVMModule.cpp
@@ -439,6 +439,12 @@ void LLVMModuleSet::loadModules(const std::vector<std::string> &moduleNameVec)
 
     for (const std::string& moduleName : moduleNameVec)
     {
+        if (!LLVMUtil::isIRFile(moduleName))
+        {
+            SVFUtil::errs() << "not an IR file: " << moduleName << std::endl;
+            abort();
+        }
+
         SMDiagnostic Err;
         std::unique_ptr<Module> mod = parseIRFile(moduleName, Err, *cxts);
         if (mod == nullptr)

--- a/lib/SVF-LLVM/SVFIRBuilder.cpp
+++ b/lib/SVF-LLVM/SVFIRBuilder.cpp
@@ -144,18 +144,18 @@ SVFIR* SVFIRBuilder::build()
     pag->setNodeNumAfterPAGBuild(pag->getTotalNodeNum());
 
     // dump SVFIR
-    if (Options::PAGDotGraph)
+    if (Options::PAGDotGraph())
         pag->dump("svfir_initial");
 
     // print to command line of the SVFIR graph
-    if (Options::PAGPrint)
+    if (Options::PAGPrint())
         pag->print();
 
     // dump ICFG
-    if (Options::DumpICFG)
+    if (Options::DumpICFG())
         pag->getICFG()->dump("icfg_initial");
 
-    if (Options::LoopAnalysis)
+    if (Options::LoopAnalysis())
     {
         LLVMLoopAnalysis loopAnalysis;
         loopAnalysis.build(pag->getICFG());
@@ -281,7 +281,7 @@ bool SVFIRBuilder::computeGepOffset(const User *V, LocationSet& ls)
         //The int value of the current index operand
         const ConstantInt* op = SVFUtil::dyn_cast<ConstantInt>(offsetVal);
 
-        // if Options::ModelConsts is disabled. We will treat whole array as one,
+        // if Options::ModelConsts() is disabled. We will treat whole array as one,
         // but we can distinguish different field of an array of struct, e.g. s[1].f1 is differet from s[0].f2
         if(const ArrayType* arrTy = SVFUtil::dyn_cast<ArrayType>(gepTy))
         {
@@ -513,7 +513,7 @@ void SVFIRBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
     }
     else if (SVFUtil::isa<ConstantArray, ConstantStruct>(C))
     {
-        if(cppUtil::isValVtbl(gvar) && !Options::VtableInSVFIR)
+        if(cppUtil::isValVtbl(gvar) && !Options::VtableInSVFIR())
             return;
         for (u32_t i = 0, e = C->getNumOperands(); i != e; i++)
         {
@@ -523,7 +523,7 @@ void SVFIRBuilder::InitialGlobal(const GlobalVariable *gvar, Constant *C,
     }
     else if(ConstantData* data = SVFUtil::dyn_cast<ConstantData>(C))
     {
-        if(Options::ModelConsts)
+        if(Options::ModelConsts())
         {
             if(ConstantDataSequential* seq = SVFUtil::dyn_cast<ConstantDataSequential>(data))
             {
@@ -1540,7 +1540,7 @@ void SVFIRBuilder::updateCallGraph(PTACallGraph* callgraph)
     }
 
     // dump SVFIR
-    if (Options::PAGDotGraph)
+    if (Options::PAGDotGraph())
         pag->dump("svfir_final");
 }
 

--- a/lib/SVF-LLVM/SymbolTableBuilder.cpp
+++ b/lib/SVF-LLVM/SymbolTableBuilder.cpp
@@ -213,7 +213,7 @@ void SymbolTableBuilder::buildMemModel(SVFModule* svfModule)
     }
 
     symInfo->totalSymNum = NodeIDAllocator::get()->endSymbolAllocation();
-    if (Options::SymTabPrint)
+    if (Options::SymTabPrint())
     {
         symInfo->dump();
     }
@@ -514,7 +514,7 @@ void SymbolTableBuilder::handleGlobalInitializerCE(const Constant *C)
     }
     else if(const ConstantData* data = SVFUtil::dyn_cast<ConstantData>(C))
     {
-        if(Options::ModelConsts)
+        if(Options::ModelConsts())
         {
             if(const ConstantDataSequential* seq = SVFUtil::dyn_cast<ConstantDataSequential>(data))
             {
@@ -559,7 +559,7 @@ ObjTypeInfo* SymbolTableBuilder::createObjTypeInfo(const Value *val)
     if (refTy)
     {
         Type* objTy = getPtrElementType(refTy);
-        ObjTypeInfo* typeInfo = new ObjTypeInfo(LLVMModuleSet::getLLVMModuleSet()->getSVFType(objTy), Options::MaxFieldLimit);
+        ObjTypeInfo* typeInfo = new ObjTypeInfo(LLVMModuleSet::getLLVMModuleSet()->getSVFType(objTy), Options::MaxFieldLimit());
         initTypeInfo(typeInfo,val, objTy);
         return typeInfo;
     }
@@ -748,7 +748,7 @@ u32_t SymbolTableBuilder::getObjSize(const Type* ety)
 /// Number of flattenned elements of an array or struct
 u32_t SymbolTableBuilder::getNumOfFlattenElements(const Type* T)
 {
-    if(Options::ModelArrays)
+    if(Options::ModelArrays())
         return getOrAddSVFTypeInfo(T)->getNumOfFlattenElements();
     else
         return getOrAddSVFTypeInfo(T)->getNumOfFlattenFields();

--- a/lib/SVFIR/SVFIR.cpp
+++ b/lib/SVFIR/SVFIR.cpp
@@ -276,7 +276,7 @@ RetPE* SVFIR::addRetPE(NodeID src, NodeID dst, const CallICFGNode* cs, const Fun
  */
 SVFStmt* SVFIR::addBlackHoleAddrStmt(NodeID node)
 {
-    if(Options::HandBlackHole)
+    if(Options::HandBlackHole())
         return pag->addAddrStmt(pag->getBlackHoleNode(), node);
     else
         return pag->addCopyStmt(pag->getNullPtr(), node);
@@ -430,7 +430,7 @@ NodeID SVFIR::getGepObjVar(const MemObj* obj, const LocationSet& ls)
     LocationSet newLS = pag->getSymbolInfo()->getModulusOffset(obj,ls);
 
     // Base and first field are the same memory location.
-    if (Options::FirstFieldEqBase && newLS.accumulateConstantFieldIdx() == 0) return base;
+    if (Options::FirstFieldEqBase() && newLS.accumulateConstantFieldIdx() == 0) return base;
 
     NodeLocationSetMap::iterator iter = GepObjVarMap.find(std::make_pair(base, newLS));
     if (iter == GepObjVarMap.end())
@@ -450,7 +450,7 @@ NodeID SVFIR::addGepObjNode(const MemObj* obj, const LocationSet& ls)
     assert(0==GepObjVarMap.count(std::make_pair(base, ls))
            && "this node should not be created before");
 
-    NodeID gepId = NodeIDAllocator::get()->allocateGepObjectId(base, ls.accumulateConstantFieldIdx(), Options::MaxFieldLimit);
+    NodeID gepId = NodeIDAllocator::get()->allocateGepObjectId(base, ls.accumulateConstantFieldIdx(), Options::MaxFieldLimit());
     GepObjVarMap[std::make_pair(base, ls)] = gepId;
     GepObjVar *node = new GepObjVar(obj, gepId, ls);
     memToFieldsMap[base].set(gepId);
@@ -719,7 +719,7 @@ bool SVFIR::isValidTopLevelPtr(const SVFVar* node)
  */
 void SVFIR::handleBlackHole(bool b)
 {
-    Options::HandBlackHole = b;
+    Options::HandBlackHole.setValue(b);
 }
 
 

--- a/lib/SVFIR/SVFStatements.cpp
+++ b/lib/SVFIR/SVFStatements.cpp
@@ -74,7 +74,7 @@ const std::string AddrStmt::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "AddrStmt: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -87,7 +87,7 @@ const std::string CopyStmt::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "CopyStmt: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -103,7 +103,7 @@ const std::string PhiStmt::toString() const
     for(u32_t i = 0; i < getOpVarNum(); i++)
         rawstr << "[Var" << getOpVar(i)->getId() << ", ICFGNode" << getOpICFGNode(i)->getId() <<  "],";
     rawstr << ")]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -119,7 +119,7 @@ const std::string SelectStmt::toString() const
     for(const SVFVar* op : getOpndVars())
         rawstr << op->getId() << ",";
     rawstr << ")]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -132,7 +132,7 @@ const std::string CmpStmt::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "CmpStmt: [Var" << getResID() << " <-- (Var" << getOpVarID(0) << " predicate" << getPredicate() << " Var" << getOpVarID(1) << ")]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -145,7 +145,7 @@ const std::string BinaryOPStmt::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "BinaryOPStmt: [Var" << getResID() << " <-- (Var" << getOpVarID(0) << " opcode" << getOpcode() << " Var" << getOpVarID(1) << ")]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -158,7 +158,7 @@ const std::string UnaryOPStmt::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "UnaryOPStmt: [Var" << getResID() << " <-- " << " opcode" << getOpcode() << " Var" << getOpVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -178,7 +178,7 @@ const std::string BranchStmt::toString() const
     for(u32_t i = 0; i < getNumSuccessors(); i++)
         rawstr << "Successor " << i << " ICFGNode" << getSuccessor(i)->getId() << "   ";
 
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -192,7 +192,7 @@ const std::string LoadStmt::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "LoadStmt: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -205,7 +205,7 @@ const std::string StoreStmt::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "StoreStmt: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -218,7 +218,7 @@ const std::string GepStmt::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "GepStmt: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -231,7 +231,7 @@ const std::string CallPE::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "CallPE: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -244,7 +244,7 @@ const std::string RetPE::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "RetPE: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -257,7 +257,7 @@ const std::string TDForkPE::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "TDForkPE: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();
@@ -270,7 +270,7 @@ const std::string TDJoinPE::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "TDJoinPE: [Var" << getLHSVarID() << " <-- Var" << getRHSVarID() << "]\t";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << getValue()->toString();

--- a/lib/SVFIR/SVFVariables.cpp
+++ b/lib/SVFIR/SVFVariables.cpp
@@ -107,7 +107,7 @@ const std::string ValVar::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "ValVar ID: " << getId();
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << value->toString();
@@ -120,7 +120,7 @@ const std::string ObjVar::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "ObjVar ID: " << getId();
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << value->toString();
@@ -133,7 +133,7 @@ const std::string GepValVar::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "GepValVar ID: " << getId() << " with offset_" + std::to_string(getConstantFieldIdx());
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << value->toString();
@@ -146,7 +146,7 @@ const std::string GepObjVar::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "GepObjVar ID: " << getId() << " with offset_" + std::to_string(ls.accumulateConstantFieldIdx());
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << value->toString();
@@ -159,7 +159,7 @@ const std::string FIObjVar::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "FIObjVar ID: " << getId() << " (base object)";
-    if (Options::ShowSVFIRValue)
+    if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";
         rawstr << value->toString();

--- a/lib/SVFIR/SymbolTableInfo.cpp
+++ b/lib/SVFIR/SymbolTableInfo.cpp
@@ -66,7 +66,7 @@ const StInfo* SymbolTableInfo::getTypeInfo(const SVFType* T) const
  */
 ObjTypeInfo* SymbolTableInfo::createObjTypeInfo(const SVFType* type)
 {
-    ObjTypeInfo* typeInfo = new ObjTypeInfo(type, Options::MaxFieldLimit);
+    ObjTypeInfo* typeInfo = new ObjTypeInfo(type, Options::MaxFieldLimit());
     if(type && type->isPointerTy())
     {
         typeInfo->setFlag(ObjTypeInfo::HEAP_OBJ);
@@ -83,7 +83,7 @@ SymbolTableInfo* SymbolTableInfo::SymbolInfo()
     if (symInfo == nullptr)
     {
         symInfo = new SymbolTableInfo();
-        symInfo->setModelConstants(Options::ModelConsts);
+        symInfo->setModelConstants(Options::ModelConsts());
     }
     return symInfo;
 }
@@ -146,7 +146,7 @@ const MemObj* SymbolTableInfo::createDummyObj(SymID symId, const SVFType* type)
 /// Number of flattenned elements of an array or struct
 u32_t SymbolTableInfo::getNumOfFlattenElements(const SVFType* T)
 {
-    if(Options::ModelArrays)
+    if(Options::ModelArrays())
         return getTypeInfo(T)->getNumOfFlattenElements();
     else
         return getTypeInfo(T)->getNumOfFlattenFields();
@@ -155,7 +155,7 @@ u32_t SymbolTableInfo::getNumOfFlattenElements(const SVFType* T)
 /// Flatterned offset information of a struct or an array including its array fields
 u32_t SymbolTableInfo::getFlattenedElemIdx(const SVFType* T, u32_t origId)
 {
-    if(Options::ModelArrays)
+    if(Options::ModelArrays())
     {
         const std::vector<u32_t>& so = getTypeInfo(T)->getFlattenedElemIdxVec();
         assert ((unsigned)origId < so.size() && !so.empty() && "element index out of bounds, can't get flattened index!");
@@ -186,7 +186,7 @@ const SVFType* SymbolTableInfo::getOriginalElemType(const SVFType* baseType, u32
 /// Return the type of a flattened element given a flattened index
 const SVFType* SymbolTableInfo::getFlatternedElemType(const SVFType* baseType, u32_t flatten_idx)
 {
-    if(Options::ModelArrays)
+    if(Options::ModelArrays())
     {
         const std::vector<const SVFType*>& so = getTypeInfo(baseType)->getFlattenElementTypes();
         assert (flatten_idx < so.size() && !so.empty() && "element index out of bounds or struct opaque type, can't get element type!");
@@ -365,7 +365,7 @@ bool ObjTypeInfo::isNonPtrFieldObj(const LocationSet& ls)
     if (SVFUtil::isa<SVFStructType, SVFArrayType>(ety))
     {
         u32_t sz = 0;
-        if(Options::ModelArrays)
+        if(Options::ModelArrays())
             sz = SymbolTableInfo::SymbolInfo()->getTypeInfo(ety)->getFlattenElementTypes().size();
         else
             sz = SymbolTableInfo::SymbolInfo()->getTypeInfo(ety)->getFlattenFieldTypes().size();

--- a/lib/Util/CommandLine.cpp
+++ b/lib/Util/CommandLine.cpp
@@ -1,4 +1,0 @@
-#include <Util/CommandLine.h>
-
-std::map<std::string, OptionBase *> OptionBase::options;
-std::vector<std::string> OptionBase::helpNames = { "help", "h", "-help" };

--- a/lib/Util/CommandLine.cpp
+++ b/lib/Util/CommandLine.cpp
@@ -1,0 +1,4 @@
+#include <Util/CommandLine.h>
+
+std::map<std::string, OptionBase *> OptionBase::options;
+std::vector<std::string> OptionBase::helpNames = { "help", "h", "-help" };

--- a/lib/Util/NodeIDAllocator.cpp
+++ b/lib/Util/NodeIDAllocator.cpp
@@ -43,7 +43,7 @@ void NodeIDAllocator::unset(void)
 
 // Initialise counts to 4 because that's how many special nodes we have.
 NodeIDAllocator::NodeIDAllocator(void)
-    : numObjects(4), numValues(4), numSymbols(4), numNodes(4), strategy(Options::NodeAllocStrat)
+    : numObjects(4), numValues(4), numSymbols(4), numNodes(4), strategy(Options::NodeAllocStrat())
 { }
 
 NodeID NodeIDAllocator::allocateObjectId(void)
@@ -188,7 +188,7 @@ const std::string NodeIDAllocator::Clusterer::NumNonTrivialRegionObjects = "NumN
 std::vector<NodeID> NodeIDAllocator::Clusterer::cluster(BVDataPTAImpl *pta, const std::vector<std::pair<NodeID, unsigned>> keys, std::vector<std::pair<hclust_fast_methods, std::vector<NodeID>>> &candidates, std::string evalSubtitle)
 {
     assert(pta != nullptr && "Clusterer::cluster: given null BVDataPTAImpl");
-    assert(Options::NodeAllocStrat == Strategy::DENSE && "Clusterer::cluster: only dense allocation clustering currently supported");
+    assert(Options::NodeAllocStrat() == Strategy::DENSE && "Clusterer::cluster: only dense allocation clustering currently supported");
 
     Map<std::string, std::string> overallStats;
     double fastClusterTime = 0.0;
@@ -235,7 +235,7 @@ std::vector<NodeID> NodeIDAllocator::Clusterer::cluster(BVDataPTAImpl *pta, cons
 
     size_t numRegions = 0;
     std::vector<unsigned> objectsRegion;
-    if (Options::RegionedClustering)
+    if (Options::RegionedClustering())
     {
         objectsRegion = regionObjects(coPointeeGraph, numObjects, numRegions);
     }
@@ -307,7 +307,7 @@ std::vector<NodeID> NodeIDAllocator::Clusterer::cluster(BVDataPTAImpl *pta, cons
     overallStats[NumRegions] = std::to_string(numRegions);
 
     std::vector<hclust_fast_methods> methods;
-    if (Options::ClusterMethod == HCLUST_METHOD_SVF_BEST)
+    if (Options::ClusterMethod() == HCLUST_METHOD_SVF_BEST)
     {
         methods.push_back(HCLUST_METHOD_SINGLE);
         methods.push_back(HCLUST_METHOD_COMPLETE);
@@ -315,7 +315,7 @@ std::vector<NodeID> NodeIDAllocator::Clusterer::cluster(BVDataPTAImpl *pta, cons
     }
     else
     {
-        methods.push_back(Options::ClusterMethod);
+        methods.push_back(Options::ClusterMethod());
     }
 
     for (const hclust_fast_methods method : methods)
@@ -331,7 +331,7 @@ std::vector<NodeID> NodeIDAllocator::Clusterer::cluster(BVDataPTAImpl *pta, cons
             const size_t regionNumObjects = regionsObjects[region].size();
             // Round up to next Word: ceiling of current allocation to get how
             // many words and multiply to get the number of bits; if we're aligning.
-            if (Options::RegionAlign)
+            if (Options::RegionAlign())
             {
                 allocCounter =
                     ((allocCounter + NATIVE_INT_SIZE - 1) / NATIVE_INT_SIZE) * NATIVE_INT_SIZE;
@@ -656,7 +656,7 @@ std::pair<hclust_fast_methods, std::vector<NodeID>> NodeIDAllocator::Clusterer::
     std::pair<hclust_fast_methods, std::vector<NodeID>> bestMapping = candidates[0];
     // Number of bits required for the best candidate.
     size_t bestWords = std::numeric_limits<size_t>::max();
-    if (evalSubtitle != "" || Options::ClusterMethod == HCLUST_METHOD_SVF_BEST)
+    if (evalSubtitle != "" || Options::ClusterMethod() == HCLUST_METHOD_SVF_BEST)
     {
         for (const std::pair<hclust_fast_methods, std::vector<NodeID>> &candidate : candidates)
         {
@@ -673,8 +673,8 @@ std::pair<hclust_fast_methods, std::vector<NodeID>> NodeIDAllocator::Clusterer::
             printStats(evalSubtitle + ": candidate " + candidateMethodName, candidateStats);
 
             size_t candidateWords = 0;
-            if (Options::PtType == PointsTo::SBV) candidateWords = std::stoull(candidateStats[NewSbvNumWords]);
-            else if (Options::PtType == PointsTo::CBV) candidateWords = std::stoull(candidateStats[NewBvNumWords]);
+            if (Options::PtType() == PointsTo::SBV) candidateWords = std::stoull(candidateStats[NewSbvNumWords]);
+            else if (Options::PtType() == PointsTo::CBV) candidateWords = std::stoull(candidateStats[NewBvNumWords]);
             else assert(false && "Clusterer::cluster: unsupported BV type for clustering.");
 
             if (candidateWords < bestWords)

--- a/lib/Util/Options.cpp
+++ b/lib/Util/Options.cpp
@@ -1,825 +1,839 @@
 //===- Options.cpp -- Command line options ------------------------//
 
 #include "Util/Options.h"
+#include "Util/CommandLine.h"
 
 namespace SVF
 {
-const llvm::cl::opt<enum PTAStat::ClockType> Options::ClockType(
+const OptionMap<enum PTAStat::ClockType> Options::ClockType(
     "clock-type",
-    llvm::cl::init(PTAStat::ClockType::CPU),
-    llvm::cl::desc("how time should be measured"),
-    llvm::cl::values(
-        clEnumValN(PTAStat::ClockType::Wall, "wall", "use wall time"),
-        clEnumValN(PTAStat::ClockType::CPU, "cpu", "use CPU time")
-    )
+    "how time should be measured",
+    PTAStat::ClockType::CPU,
+    {
+        {PTAStat::ClockType::Wall, "wall", "use wall time"},
+        {PTAStat::ClockType::CPU, "cpu", "use CPU time"},
+    }
 );
 
-const llvm::cl::opt<bool> Options::MarkedClocksOnly(
+const Option<bool> Options::MarkedClocksOnly(
     "marked-clocks-only",
-    llvm::cl::init(true),
-    llvm::cl::desc("Only measure times where explicitly marked"));
+    "Only measure times where explicitly marked",
+    true
+);
 
-const llvm::cl::opt<NodeIDAllocator::Strategy> Options::NodeAllocStrat(
+const OptionMap<NodeIDAllocator::Strategy> Options::NodeAllocStrat(
     "node-alloc-strat",
-    llvm::cl::init(NodeIDAllocator::Strategy::SEQ),
-    llvm::cl::desc("Method of allocating (LLVM) values and memory objects as node IDs"),
-    llvm::cl::values(
-        clEnumValN(NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together [0-n] and values together [m-MAX], separately"),
-        clEnumValN(NodeIDAllocator::Strategy::REVERSE_DENSE, "reverse-dense", "like dense but flipped, objects are [m-MAX], values are [0-n]"),
-        clEnumValN(NodeIDAllocator::Strategy::SEQ, "seq", "allocate values and objects sequentially, intermixed (default)"),
-        clEnumValN(NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets")));
+    "Method of allocating (LLVM) values and memory objects as node IDs",
+    NodeIDAllocator::Strategy::SEQ,
+    {
+        {NodeIDAllocator::Strategy::DENSE, "dense", "allocate objects together [0-n] and values together [m-MAX], separately"},
+        {NodeIDAllocator::Strategy::REVERSE_DENSE, "reverse-dense", "like dense but flipped, objects are [m-MAX], values are [0-n]"},
+        {NodeIDAllocator::Strategy::SEQ, "seq", "allocate values and objects sequentially, intermixed (default)"},
+        {NodeIDAllocator::Strategy::DEBUG, "debug", "allocate value and objects sequentially, intermixed, except GEP objects as offsets"},
+    }
+);
 
-const llvm::cl::opt<unsigned> Options::MaxFieldLimit(
+const Option<u32_t> Options::MaxFieldLimit(
     "field-limit",
-    llvm::cl::init(512),
-    llvm::cl::desc("Maximum number of fields for field sensitive analysis"));
+    "Maximum number of fields for field sensitive analysis",
+    512
+);
 
-const llvm::cl::opt<BVDataPTAImpl::PTBackingType> Options::ptDataBacking(
+const OptionMap<BVDataPTAImpl::PTBackingType> Options::ptDataBacking(
     "ptd",
-    llvm::cl::init(BVDataPTAImpl::PTBackingType::Persistent),
-    llvm::cl::desc("Overarching points-to data structure"),
-    llvm::cl::values(
-        clEnumValN(BVDataPTAImpl::PTBackingType::Mutable, "mutable", "points-to set per pointer"),
-        clEnumValN(BVDataPTAImpl::PTBackingType::Persistent, "persistent", "points-to set ID per pointer, operations hash-consed")));
+    "Overarching points-to data structure",
+    BVDataPTAImpl::PTBackingType::Persistent,
+    {
+        {BVDataPTAImpl::PTBackingType::Mutable, "mutable", "points-to set per pointer"},
+        {BVDataPTAImpl::PTBackingType::Persistent, "persistent", "points-to set ID per pointer, operations hash-consed"},
+    }
+);
 
-const llvm::cl::opt<unsigned> Options::FsTimeLimit(
+const Option<u32_t> Options::FsTimeLimit(
     "fs-time-limit",
-    llvm::cl::init(0),
-    llvm::cl::desc("time limit for main phase of flow-sensitive analyses")
+    "time limit for main phase of flow-sensitive analyses",
+    0
 );
 
-const llvm::cl::opt<unsigned> Options::VersioningThreads(
+const Option<u32_t> Options::VersioningThreads(
     "versioning-threads",
-    llvm::cl::init(1),
-    llvm::cl::desc("number of threads to use in the versioning phase of versioned flow-sensitive analysis")
+    "number of threads to use in the versioning phase of versioned flow-sensitive analysis",
+    1
 );
 
-const llvm::cl::opt<unsigned> Options::AnderTimeLimit(
+const Option<u32_t> Options::AnderTimeLimit(
     "ander-time-limit",
-    llvm::cl::init(0),
-    llvm::cl::desc("time limit for Andersen's analyses (ignored when -fs-time-limit set)")
+    "time limit for Andersen's analyses (ignored when -fs-time-limit set)",
+    0
 );
 
 // ContextDDA.cpp
-const llvm::cl::opt<unsigned long long> Options::CxtBudget(
+const Option<u32_t> Options::CxtBudget(
     "cxt-bg",
-    llvm::cl::init(10000),
-    llvm::cl::desc("Maximum step budget of context-sensitive traversing")
+    "Maximum step budget of context-sensitive traversing",
+    10000
 );
 
 
 // DDAClient.cpp
-const llvm::cl::opt<bool> Options::SingleLoad(
+const Option<bool> Options::SingleLoad(
     "single-load",
-    llvm::cl::init(true),
-    llvm::cl::desc("Count load pointer with same source operand as one query")
+    "Count load pointer with same source operand as one query",
+    true
 );
 
-const llvm::cl::opt<bool> Options::DumpFree(
+const Option<bool> Options::DumpFree(
     "dump-free",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump use after free locations")
+    "Dump use after free locations",
+    false
 );
 
-const llvm::cl::opt<bool> Options::DumpUninitVar(
+const Option<bool> Options::DumpUninitVar(
     "dump-uninit-var",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump uninitialised variables")
+    "Dump uninitialised variables",
+    false
 );
 
-const llvm::cl::opt<bool> Options::DumpUninitPtr(
+const Option<bool> Options::DumpUninitPtr(
     "dump-uninit-ptr",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump uninitialised pointers")
+    "Dump uninitialised pointers",
+    false
 );
 
-const llvm::cl::opt<bool> Options::DumpSUPts(
+const Option<bool> Options::DumpSUPts(
     "dump-su-pts",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump strong updates store")
+    "Dump strong updates store",
+    false
 );
 
-const llvm::cl::opt<bool> Options::DumpSUStore(
+const Option<bool> Options::DumpSUStore(
     "dump-su-store",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump strong updates store")
+    "Dump strong updates store",
+    false
 );
 
-const llvm::cl::opt<bool> Options::MallocOnly(
+const Option<bool> Options::MallocOnly(
     "malloc-only",
-    llvm::cl::init(true),
-    llvm::cl::desc("Only add tainted objects for malloc")
+    "Only add tainted objects for malloc",
+    true
 );
 
-const llvm::cl::opt<bool> Options::TaintUninitHeap(
+const Option<bool> Options::TaintUninitHeap(
     "uninit-heap",
-    llvm::cl::init(true),
-    llvm::cl::desc("detect uninitialized heap variables")
+    "detect uninitialized heap variables",
+    true
 );
 
-const llvm::cl::opt<bool> Options::TaintUninitStack(
+const Option<bool> Options::TaintUninitStack(
     "uninit-stack",
-    llvm::cl::init(true),
-    llvm::cl::desc("detect uninitialized stack variables")
+    "detect uninitialized stack variables",
+    true
 );
 
 // DDAPass.cpp
-const llvm::cl::opt<unsigned> Options::MaxPathLen(
+const Option<u32_t> Options::MaxPathLen(
     "max-path",
-    llvm::cl::init(100000),
-    llvm::cl::desc("Maximum path limit for DDA")
+    "Maximum path limit for DDA",
+    100000
 );
 
-const llvm::cl::opt<unsigned> Options::MaxContextLen(
+const Option<u32_t> Options::MaxContextLen(
     "max-cxt",
-    llvm::cl::init(3),
-    llvm::cl::desc("Maximum context limit for DDA")
+    "Maximum context limit for DDA",
+    3
 );
 
-const llvm::cl::opt<unsigned> Options::MaxStepInWrapper(
+const Option<u32_t> Options::MaxStepInWrapper(
     "max-step",
-    llvm::cl::init(10),
-    llvm::cl::desc("Maximum steps when traversing on SVFG to identify a memory allocation wrapper")
+    "Maximum steps when traversing on SVFG to identify a memory allocation wrapper",
+    10
 );
 
-const llvm::cl::opt<std::string> Options::UserInputQuery(
+const Option<std::string> Options::UserInputQuery(
     "query",
-    llvm::cl::init("all"),
-    llvm::cl::desc("Please specify queries by inputing their pointer ids")
+    "Please specify queries by inputing their pointer ids",
+    "all"
 );
 
-const llvm::cl::opt<bool> Options::InsenRecur(
+const Option<bool> Options::InsenRecur(
     "in-recur",
-    llvm::cl::init(false),
-    llvm::cl::desc("Mark context insensitive SVFG edges due to function recursions")
+    "Mark context insensitive SVFG edges due to function recursions",
+    false
 );
 
-const llvm::cl::opt<bool> Options::InsenCycle(
+const Option<bool> Options::InsenCycle(
     "in-cycle",
-    llvm::cl::init(false),
-    llvm::cl::desc("Mark context insensitive SVFG edges due to value-flow cycles")
+    "Mark context insensitive SVFG edges due to value-flow cycles",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PrintCPts(
+const Option<bool> Options::PrintCPts(
     "cpts",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump conditional points-to set ")
+    "Dump conditional points-to set ",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PrintQueryPts(
+const Option<bool> Options::PrintQueryPts(
     "print-query-pts",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump queries' conditional points-to set ")
+    "Dump queries' conditional points-to set ",
+    false
 );
 
-const llvm::cl::opt<bool> Options::WPANum(
+const Option<bool> Options::WPANum(
     "wpa-num",
-    llvm::cl::init(false),
-    llvm::cl::desc("collect WPA FS number only ")
+    "collect WPA FS number only ",
+    false
 );
 
 /// register this into alias analysis group
 //static RegisterAnalysisGroup<AliasAnalysis> AA_GROUP(DDAPA);
-llvm::cl::bits<PointerAnalysis::PTATY> Options::DDASelected(
-    llvm::cl::desc("Select pointer analysis"),
-    llvm::cl::values(
-        clEnumValN(PointerAnalysis::FlowS_DDA, "dfs", "Demand-driven flow sensitive analysis"),
-        clEnumValN(PointerAnalysis::Cxt_DDA, "cxt", "Demand-driven context- flow- sensitive analysis")
-    ));
+OptionMultiple<PointerAnalysis::PTATY> Options::DDASelected(
+    "Select pointer analysis",
+    {
+        {PointerAnalysis::FlowS_DDA, "dfs", "Demand-driven flow sensitive analysis"},
+        {PointerAnalysis::Cxt_DDA, "cxt", "Demand-driven context- flow- sensitive analysis"},
+    }
+);
 
 // FlowDDA.cpp
-const llvm::cl::opt<unsigned long long> Options::FlowBudget(
+const Option<u32_t> Options::FlowBudget(
     "flow-bg",
-    llvm::cl::init(10000),
-    llvm::cl::desc("Maximum step budget of flow-sensitive traversing")
+    "Maximum step budget of flow-sensitive traversing",
+    10000
 );
 
 
 // Offline constraint graph (OfflineConsG.cpp)
-const llvm::cl::opt<bool> Options::OCGDotGraph(
+const Option<bool> Options::OCGDotGraph(
     "dump-ocg",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump dot graph of Offline Constraint Graph")
+    "Dump dot graph of Offline Constraint Graph",
+    false
 );
 
 
 // Program Assignment Graph for pointer analysis (SVFIR.cpp)
-llvm::cl::opt<bool> Options::HandBlackHole(
+Option<bool> Options::HandBlackHole(
     "blk",
-    llvm::cl::init(false),
-    llvm::cl::desc("Hanle blackhole edge")
+    "Hanle blackhole edge",
+    false
 );
 
-const llvm::cl::opt<bool> Options::FirstFieldEqBase(
+const Option<bool> Options::FirstFieldEqBase(
     "ff-eq-base",
-    llvm::cl::init(false),
-    llvm::cl::desc("Treat base objects as their first fields")
+    "Treat base objects as their first fields",
+    false
 );
 
 
 // SVFG optimizer (SVFGOPT.cpp)
-const llvm::cl::opt<bool> Options::ContextInsensitive(
+const Option<bool> Options::ContextInsensitive(
     "ci-svfg",
-    llvm::cl::init(false),
-    llvm::cl::desc("Reduce SVFG into a context-insensitive one")
+    "Reduce SVFG into a context-insensitive one",
+    false
 );
 
-const llvm::cl::opt<bool> Options::KeepAOFI(
+const Option<bool> Options::KeepAOFI(
     "keep-aofi",
-    llvm::cl::init(false),
-    llvm::cl::desc("Keep formal-in and actual-out parameters")
+    "Keep formal-in and actual-out parameters",
+    false
 );
 
-const llvm::cl::opt<std::string> Options::SelfCycle(
+const Option<std::string> Options::SelfCycle(
     "keep-self-cycle",
-    llvm::cl::value_desc("keep self cycle"),
-    llvm::cl::desc("How to handle self cycle edges: all, context, none")
+    "How to handle self cycle edges: all, context, none",
+    ""
 );
 
 
 // Sparse value-flow graph (VFG.cpp)
-const llvm::cl::opt<bool> Options::DumpVFG(
+const Option<bool> Options::DumpVFG(
     "dump-vfg",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump dot graph of VFG")
+    "Dump dot graph of VFG",
+    false
 );
 
 
 // Location set for modeling abstract memory object (LocationSet.cpp)
-const llvm::cl::opt<bool> Options::SingleStride(
+const Option<bool> Options::SingleStride(
     "stride-only",
-    llvm::cl::init(false),
-    llvm::cl::desc("Only use single stride in LocMemoryModel")
+    "Only use single stride in LocMemoryModel",
+    false
 );
 
 
 // Base class of pointer analyses (PointerAnalysis.cpp)
-const llvm::cl::opt<bool> Options::TypePrint(
+const Option<bool> Options::TypePrint(
     "print-type",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print type")
+    "Print type",
+    false
 );
 
-const llvm::cl::opt<bool> Options::FuncPointerPrint(
+const Option<bool> Options::FuncPointerPrint(
     "print-fp",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print targets of indirect call site")
+    "Print targets of indirect call site",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PTSPrint(
+const Option<bool> Options::PTSPrint(
     "print-pts",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print points-to set of top-level pointers")
+    "Print points-to set of top-level pointers",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PTSAllPrint(
+const Option<bool> Options::PTSAllPrint(
     "print-all-pts",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print all points-to set of both top-level and address-taken variables")
+    "Print all points-to set of both top-level and address-taken variables",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PStat(
+const Option<bool> Options::PStat(
     "stat",
-    llvm::cl::init(true),
-    llvm::cl::desc("Statistic for Pointer analysis")
+    "Statistic for Pointer analysis",
+    true
 );
 
-const llvm::cl::opt<unsigned> Options::StatBudget(
+const Option<u32_t> Options::StatBudget(
     "stat-limit",
-    llvm::cl::init(20),
-    llvm::cl::desc("Iteration budget for On-the-fly statistics")
+    "Iteration budget for On-the-fly statistics",
+    20
 );
 
-const llvm::cl::opt<bool> Options::PAGDotGraph(
+const Option<bool> Options::PAGDotGraph(
     "dump-pag",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump dot graph of SVFIR")
+    "Dump dot graph of SVFIR",
+    false
 );
 
-const llvm::cl::opt<bool> Options::ShowSVFIRValue(
+const Option<bool> Options::ShowSVFIRValue(
     "show-ir-value",
-    llvm::cl::init(true),
-    llvm::cl::desc("Show values of SVFIR (e.g., when generating dot graph)")
+    "Show values of SVFIR (e.g., when generating dot graph)",
+    true
 );
 
-const llvm::cl::opt<bool> Options::DumpICFG(
+const Option<bool> Options::DumpICFG(
     "dump-icfg",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump dot graph of ICFG")
+    "Dump dot graph of ICFG",
+    false
 );
 
-const llvm::cl::opt<bool> Options::CallGraphDotGraph(
+const Option<bool> Options::CallGraphDotGraph(
     "dump-callgraph",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump dot graph of Call Graph")
+    "Dump dot graph of Call Graph",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PAGPrint(
+const Option<bool> Options::PAGPrint(
     "print-pag",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print SVFIR to command line")
+    "Print SVFIR to command line",
+    false
 );
 
-const llvm::cl::opt<unsigned> Options::IndirectCallLimit(
+const Option<u32_t> Options::IndirectCallLimit(
     "ind-call-limit",
-    llvm::cl::init(50000),
-    llvm::cl::desc("Indirect solved call edge limit")
+    "Indirect solved call edge limit",
+    50000
 );
 
-const llvm::cl::opt<bool> Options::UsePreCompFieldSensitive(
+const Option<bool> Options::UsePreCompFieldSensitive(
     "pre-field-sensitive",
-    llvm::cl::init(true),
-    llvm::cl::desc("Use pre-computed field-sensitivity for later analysis")
+    "Use pre-computed field-sensitivity for later analysis",
+    true
 );
 
-const llvm::cl::opt<bool> Options::EnableAliasCheck(
+const Option<bool> Options::EnableAliasCheck(
     "alias-check",
-    llvm::cl::init(true),
-    llvm::cl::desc("Enable alias check functions")
+    "Enable alias check functions",
+    true
 );
 
-const llvm::cl::opt<bool> Options::EnableThreadCallGraph(
+const Option<bool> Options::EnableThreadCallGraph(
     "enable-tcg",
-    llvm::cl::init(true),
-    llvm::cl::desc("Enable pointer analysis to use thread call graph")
+    "Enable pointer analysis to use thread call graph",
+    true
 );
 
-const llvm::cl::opt<bool> Options::ConnectVCallOnCHA(
+const Option<bool> Options::ConnectVCallOnCHA(
     "v-call-cha",
-    llvm::cl::init(false),
-    llvm::cl::desc("connect virtual calls using cha")
+    "connect virtual calls using cha",
+    false
 );
 
 
 // PointerAnalysisImpl.cpp
-const llvm::cl::opt<bool> Options::INCDFPTData(
+const Option<bool> Options::INCDFPTData(
     "inc-data",
-    llvm::cl::init(true),
-    llvm::cl::desc("Enable incremental DFPTData for flow-sensitive analysis")
+    "Enable incremental DFPTData for flow-sensitive analysis",
+    true
 );
 
-const llvm::cl::opt<bool> Options::ClusterAnder(
+const Option<bool> Options::ClusterAnder(
     "cluster-ander",
-    llvm::cl::init(false),
-    llvm::cl::desc("Stage Andersen's with Steensgard's and cluster based on that")
+    "Stage Andersen's with Steensgard's and cluster based on that",
+    false
 );
 
-const llvm::cl::opt<bool> Options::ClusterFs(
+const Option<bool> Options::ClusterFs(
     "cluster-fs",
-    llvm::cl::init(false),
-    llvm::cl::desc("Cluster for FS/VFS with auxiliary Andersen's")
+    "Cluster for FS/VFS with auxiliary Andersen's",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PlainMappingFs(
+const Option<bool> Options::PlainMappingFs(
     "plain-mapping-fs",
-    llvm::cl::init(false),
-    llvm::cl::desc("Use an explicitly (not null) plain mapping for FS")
+    "Use an explicitly (not null) plain mapping for FS",
+    false
 );
 
-const llvm::cl::opt<PointsTo::Type> Options::PtType(
+const OptionMap<PointsTo::Type> Options::PtType(
     "pt-type",
-    llvm::cl::init(PointsTo::Type::SBV),
-    llvm::cl::desc("points-to set data structure to use in all analyses"),
-    llvm::cl::values(
-        clEnumValN(PointsTo::Type::SBV, "sbv", "sparse bit-vector"),
-        clEnumValN(PointsTo::Type::CBV, "cbv", "core bit-vector (dynamic bit-vector without leading and trailing 0s)"),
-        clEnumValN(PointsTo::Type::BV, "bv", "bit-vector (dynamic bit-vector without trailing 0s)")
-    )
+    "points-to set data structure to use in all analyses",
+    PointsTo::Type::SBV,
+    {
+        {PointsTo::Type::SBV, "sbv", "sparse bit-vector"},
+        {PointsTo::Type::CBV, "cbv", "core bit-vector (dynamic bit-vector without leading and trailing 0s)"},
+        {PointsTo::Type::BV, "bv", "bit-vector (dynamic bit-vector without trailing 0s)"},
+    }
 );
 
-const llvm::cl::opt<enum hclust_fast_methods> Options::ClusterMethod(
+const OptionMap<enum hclust_fast_methods> Options::ClusterMethod(
     "cluster-method",
-    llvm::cl::init(HCLUST_METHOD_SVF_BEST),
-    llvm::cl::desc("hierarchical clustering method for objects"),
-    // TODO: maybe add descriptions.
-    llvm::cl::values(
-        clEnumValN(HCLUST_METHOD_SINGLE,     "single", "single linkage; minimum spanning tree algorithm"),
-        clEnumValN(HCLUST_METHOD_COMPLETE, "complete", "complete linkage; nearest-neighbour-chain algorithm"),
-        clEnumValN(HCLUST_METHOD_AVERAGE,   "average", "unweighted average linkage; nearest-neighbour-chain algorithm"),
-        clEnumValN(HCLUST_METHOD_SVF_BEST,     "best", "try all linkage criteria; choose best")
-    )
+    "hierarchical clustering method for objects",
+    HCLUST_METHOD_SVF_BEST,
+    {
+        {HCLUST_METHOD_SINGLE,     "single", "single linkage; minimum spanning tree algorithm"},
+        {HCLUST_METHOD_COMPLETE, "complete", "complete linkage; nearest-neighbour-chain algorithm"},
+        {HCLUST_METHOD_AVERAGE,   "average", "unweighted average linkage; nearest-neighbour-chain algorithm"},
+        {HCLUST_METHOD_SVF_BEST,     "best", "try all linkage criteria; choose best"},
+    }
 );
 
-const llvm::cl::opt<bool> Options::RegionedClustering(
+const Option<bool> Options::RegionedClustering(
     // Use cluster to "gather" the options closer together, even if it sounds a little worse.
     "cluster-regioned",
-    llvm::cl::init(true),
-    llvm::cl::desc("cluster regions separately")
+    "cluster regions separately",
+    true
 );
 
-const llvm::cl::opt<bool> Options::RegionAlign(
+const Option<bool> Options::RegionAlign(
     "cluster-region-aligned",
-    llvm::cl::init(true),
-    llvm::cl::desc("align each region's identifiers to the native word size")
+    "align each region's identifiers to the native word size",
+    true
 );
 
-const llvm::cl::opt<bool> Options::PredictPtOcc(
+const Option<bool> Options::PredictPtOcc(
     "cluster-predict-occ",
-    llvm::cl::init(false),
-    llvm::cl::desc("try to predict which points-to sets are more important in staged analysis")
+    "try to predict which points-to sets are more important in staged analysis",
+    false
 );
 
 // Memory region (MemRegion.cpp)
-const llvm::cl::opt<bool> Options::IgnoreDeadFun(
+const Option<bool> Options::IgnoreDeadFun(
     "mssa-ignore-dead-fun",
-    llvm::cl::init(false),
-    llvm::cl::desc("Don't construct memory SSA for deadfunction")
+    "Don't construct memory SSA for deadfunction",
+    false
 );
 
 
 // Base class of pointer analyses (MemSSA.cpp)
-const llvm::cl::opt<bool> Options::DumpMSSA(
+const Option<bool> Options::DumpMSSA(
     "dump-mssa",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump memory SSA")
+    "Dump memory SSA",
+    false
 );
 
-const llvm::cl::opt<std::string> Options::MSSAFun(
+const Option<std::string> Options::MSSAFun(
     "mssa-fun",
-    llvm::cl::init(""),
-    llvm::cl::desc("Please specify which function needs to be dumped")
+    "Please specify which function needs to be dumped",
+    ""
 );
 
-const llvm::cl::opt<MemSSA::MemPartition> Options::MemPar(
+const OptionMap<MemSSA::MemPartition> Options::MemPar(
     "mem-par",
-    llvm::cl::init(MemSSA::MemPartition::IntraDisjoint),
-    llvm::cl::desc("Memory region partiion strategies (e.g., for SVFG construction)"),
-    llvm::cl::values(
-        clEnumValN(MemSSA::MemPartition::Distinct, "distinct", "memory region per each object"),
-        clEnumValN(MemSSA::MemPartition::IntraDisjoint, "intra-disjoint", "memory regions partioned based on each function"),
-        clEnumValN(MemSSA::MemPartition::InterDisjoint, "inter-disjoint", "memory regions partioned across functions"))
+    "Memory region partiion strategies (e.g., for SVFG construction)",
+    MemSSA::MemPartition::IntraDisjoint,
+    {
+        {MemSSA::MemPartition::Distinct, "distinct", "memory region per each object"},
+        {MemSSA::MemPartition::IntraDisjoint, "intra-disjoint", "memory regions partioned based on each function"},
+        {MemSSA::MemPartition::InterDisjoint, "inter-disjoint", "memory regions partioned across functions"},
+    }
 );
 
 
 // SVFG builder (SVFGBuilder.cpp)
-const llvm::cl::opt<bool> Options::SVFGWithIndirectCall(
+const Option<bool> Options::SVFGWithIndirectCall(
     "svfg-with-ind-call",
-    llvm::cl::init(false),
-    llvm::cl::desc("Update Indirect Calls for SVFG using pre-analysis")
+    "Update Indirect Calls for SVFG using pre-analysis",
+    false
 );
 
-llvm::cl::opt<bool> Options::OPTSVFG(
+Option<bool> Options::OPTSVFG(
     "opt-svfg",
-    llvm::cl::init(false),
-    llvm::cl::desc("Optimize SVFG to eliminate formal-in and actual-out")
+    "Optimize SVFG to eliminate formal-in and actual-out",
+    false
 );
 
-const llvm::cl::opt<std::string> Options::WriteSVFG(
+const Option<std::string> Options::WriteSVFG(
     "write-svfg",
-    llvm::cl::init(""),
-    llvm::cl::desc("Write SVFG's analysis results to a file")
+    "Write SVFG's analysis results to a file",
+    ""
 );
 
-const llvm::cl::opt<std::string> Options::ReadSVFG(
+const Option<std::string> Options::ReadSVFG(
     "read-svfg",
-    llvm::cl::init(""),
-    llvm::cl::desc("Read SVFG's analysis results from a file")
+    "Read SVFG's analysis results from a file",
+    ""
 );
 
 // FSMPTA.cpp
-const llvm::cl::opt<bool> Options::UsePCG(
+const Option<bool> Options::UsePCG(
     "pcg-td-edge",
-    llvm::cl::init(false),
-    llvm::cl::desc("Use PCG lock for non-sparsely adding SVFG edges")
+    "Use PCG lock for non-sparsely adding SVFG edges",
+    false
 );
 
-const llvm::cl::opt<bool> Options::IntraLock(
+const Option<bool> Options::IntraLock(
     "intra-lock-td-edge",
-    llvm::cl::init(true),
-    llvm::cl::desc("Use simple intra-procedual lock for adding SVFG edges")
+    "Use simple intra-procedual lock for adding SVFG edges",
+    true
 );
 
-const llvm::cl::opt<bool> Options::ReadPrecisionTDEdge(
+const Option<bool> Options::ReadPrecisionTDEdge(
     "rp-td-edge",
-    llvm::cl::init(false),
-    llvm::cl::desc("perform read precision to refine SVFG edges")
+    "perform read precision to refine SVFG edges",
+    false
 );
 
-const llvm::cl::opt<u32_t> Options::AddModelFlag(
+const Option<u32_t> Options::AddModelFlag(
     "add-td-edge",
-    llvm::cl::init(0),
-    llvm::cl::desc("Add thread SVFG edges with models: 0 Non Add Edge; 1 NonSparse; 2 All Optimisation; 3 No MHP; 4 No Alias; 5 No Lock; 6 No Read Precision.")
+    "Add thread SVFG edges with models: 0 Non Add Edge; 1 NonSparse; 2 All Optimisation; 3 No MHP; 4 No Alias; 5 No Lock; 6 No Read Precision.",
+    0
 );
 
 
 // LockAnalysis.cpp
-const llvm::cl::opt<bool> Options::PrintLockSpan(
+const Option<bool> Options::PrintLockSpan(
     "print-lock",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print Thread Interleaving Results")
+    "Print Thread Interleaving Results",
+    false
 );
 
 
 // MHP.cpp
-const llvm::cl::opt<bool> Options::PrintInterLev(
+const Option<bool> Options::PrintInterLev(
     "print-interlev",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print Thread Interleaving Results")
+    "Print Thread Interleaving Results",
+    false
 );
 
-const llvm::cl::opt<bool> Options::DoLockAnalysis(
+const Option<bool> Options::DoLockAnalysis(
     "lock-analysis",
-    llvm::cl::init(true),
-    llvm::cl::desc("Run Lock Analysis")
+    "Run Lock Analysis",
+    true
 );
 
 
 // MTA.cpp
-const llvm::cl::opt<bool> Options::AndersenAnno(
+const Option<bool> Options::AndersenAnno(
     "tsan-ander",
-    llvm::cl::init(false),
-    llvm::cl::desc("Add TSan annotation according to Andersen")
+    "Add TSan annotation according to Andersen",
+    false
 );
 
-const llvm::cl::opt<bool> Options::FSAnno(
+const Option<bool> Options::FSAnno(
     "tsan-fs",
-    llvm::cl::init(false),
-    llvm::cl::desc("Add TSan annotation according to flow-sensitive analysis")
+    "Add TSan annotation according to flow-sensitive analysis",
+    false
 );
 
 
 // MTAAnnotator.cpp
-const llvm::cl::opt<u32_t> Options::AnnoFlag(
+const Option<u32_t> Options::AnnoFlag(
     "anno",
-    llvm::cl::init(0),
-    llvm::cl::desc("prune annotated instructions: 0001 Thread Local; 0002 Alias; 0004 MHP.")
+    "prune annotated instructions: 0001 Thread Local; 0002 Alias; 0004 MHP.",
+    0
 );
 
 
 // MTAResultValidator.cpp
-const llvm::cl::opt<bool> Options::PrintValidRes(
+const Option<bool> Options::PrintValidRes(
     "mhp-validation",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print MHP Validation Results")
+    "Print MHP Validation Results",
+    false
 );
 // LockResultValidator.cpp
-const llvm::cl::opt<bool> Options::LockValid(
+const Option<bool> Options::LockValid(
     "lock-validation",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print Lock Validation Results")
+    "Print Lock Validation Results",
+    false
 );
 
 
 // MTAStat.cpp
-const llvm::cl::opt<bool> Options::AllPairMHP(
+const Option<bool> Options::AllPairMHP(
     "all-pair-mhp",
-    llvm::cl::init(false),
-    llvm::cl::desc("All pair MHP computation")
+    "All pair MHP computation",
+    false
 );
 
 
 // PCG.cpp
-//const llvm::cl::opt<bool> TDPrint(
-// "print-td",
-// llvm::cl::init(true),
-// llvm::cl::desc("Print Thread Analysis Results"));
+//const Option<bool> TDPrint(
+//    "print-td",
+//    "Print Thread Analysis Results",
+//    true
+//);
 
 
 // TCT.cpp
-const llvm::cl::opt<bool> Options::TCTDotGraph(
+const Option<bool> Options::TCTDotGraph(
     "dump-tct",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump dot graph of Call Graph")
+    "Dump dot graph of Call Graph",
+    false
 );
 
 
 // LeakChecker.cpp
-const llvm::cl::opt<bool> Options::ValidateTests(
+const Option<bool> Options::ValidateTests(
     "valid-tests",
-    llvm::cl::init(false),
-    llvm::cl::desc("Validate memory leak tests")
+    "Validate memory leak tests",
+    false
 );
 
 
 // Source-sink analyzer (SrcSnkDDA.cpp)
-const llvm::cl::opt<bool> Options::DumpSlice(
+const Option<bool> Options::DumpSlice(
     "dump-slice",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump dot graph of Saber Slices")
+    "Dump dot graph of Saber Slices",
+    false
 );
 
-const llvm::cl::opt<unsigned> Options::CxtLimit(
+const Option<u32_t> Options::CxtLimit(
     "cxt-limit",
-    llvm::cl::init(3),
-    llvm::cl::desc("Source-Sink Analysis Contexts Limit")
+    "Source-Sink Analysis Contexts Limit",
+    3
 );
 
 
 // CHG.cpp
-const llvm::cl::opt<bool> Options::DumpCHA(
+const Option<bool> Options::DumpCHA(
     "dump-cha",
-    llvm::cl::init(false),
-    llvm::cl::desc("dump the class hierarchy graph")
+    "dump the class hierarchy graph",
+    false
 );
 
 
 // DCHG.cpp
-const llvm::cl::opt<bool> Options::PrintDCHG(
+const Option<bool> Options::PrintDCHG(
     "print-dchg",
-    llvm::cl::init(false),
-    llvm::cl::desc("print the DCHG if debug information is available")
+    "print the DCHG if debug information is available",
+    false
 );
 
 
 // LLVMModule.cpp
-const llvm::cl::opt<std::string> Options::Graphtxt(
+const Option<std::string> Options::Graphtxt(
     "graph-txt",
-    llvm::cl::value_desc("filename"),
-    llvm::cl::desc("graph txt file to build SVFIR")
+    "graph txt file to build SVFIR",
+    ""
 );
 
-const llvm::cl::opt<bool> Options::SVFMain(
+const Option<bool> Options::SVFMain(
     "svf-main",
-    llvm::cl::init(false),
-    llvm::cl::desc("add svf.main()")
+    "add svf.main()",
+    false
 );
 
-const llvm::cl::opt<bool> Options::ModelConsts(
+const Option<bool> Options::ModelConsts(
     "model-consts",
-    llvm::cl::init(false),
-    llvm::cl::desc("Modeling individual constant objects")
+    "Modeling individual constant objects",
+    false
 );
 
-const llvm::cl::opt<bool> Options::ModelArrays(
+const Option<bool> Options::ModelArrays(
     "model-arrays",
-    llvm::cl::init(false),
-    llvm::cl::desc("Modeling Gep offsets for array accesses")
+    "Modeling Gep offsets for array accesses",
+    false
 );
 
-const llvm::cl::opt<bool> Options::SymTabPrint(
-    "print-symbol-table", llvm::cl::init(false),
-    llvm::cl::desc("Print Symbol Table to command line")
+const Option<bool> Options::SymTabPrint(
+    "print-symbol-table",
+    "Print Symbol Table to command line",
+    false
 );
 
 
 
 // Conditions.cpp
-const llvm::cl::opt<unsigned> Options::MaxZ3Size(
+const Option<u32_t> Options::MaxZ3Size(
     "max-z3-size",
-    llvm::cl::init(30),
-    llvm::cl::desc("Maximum size limit for Z3 expression")
+    "Maximum size limit for Z3 expression",
+    30
 );
 
 
 // SaberCondAllocator.cpp
-const llvm::cl::opt<bool> Options::PrintPathCond(
+const Option<bool> Options::PrintPathCond(
     "print-pc",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print out path condition")
+    "Print out path condition",
+    false
 );
 
 
 // SVFUtil.cpp
-const llvm::cl::opt<bool> Options::DisableWarn(
+const Option<bool> Options::DisableWarn(
     "dwarn",
-    llvm::cl::init(true),
-    llvm::cl::desc("Disable warning")
+    "Disable warning",
+    true
 );
 
 
 // Andersen.cpp
-const llvm::cl::opt<bool> Options::ConsCGDotGraph(
+const Option<bool> Options::ConsCGDotGraph(
     "dump-constraint-graph",
-    llvm::cl::init(false),
-    llvm::cl::desc("Dump dot graph of Constraint Graph")
+    "Dump dot graph of Constraint Graph",
+    false
 );
 
-const llvm::cl::opt<bool> Options::BriefConsCGDotGraph(
+const Option<bool> Options::BriefConsCGDotGraph(
     "brief-constraint-graph",
-    llvm::cl::init(true),
-    llvm::cl::desc("Dump dot graph of Constraint Graph")
+    "Dump dot graph of Constraint Graph",
+    true
 );
 
-const llvm::cl::opt<bool> Options::PrintCGGraph(
+const Option<bool> Options::PrintCGGraph(
     "print-constraint-graph",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print Constraint Graph to Terminal")
+    "Print Constraint Graph to Terminal",
+    false
 );
 
-const llvm::cl::opt<std::string> Options::WriteAnder(
+const Option<std::string> Options::WriteAnder(
     "write-ander",
-    llvm::cl::init(""),
-    llvm::cl::desc("-write-ander=ir_annotator (Annotated IR with Andersen's results) or write Andersen's analysis results to a user-specified text file")
+    "-write-ander=ir_annotator (Annotated IR with Andersen's results) or write Andersen's analysis results to a user-specified text file",
+    ""
 );
 
-const llvm::cl::opt<std::string> Options::ReadAnder(
+const Option<std::string> Options::ReadAnder(
     "read-ander",
-    llvm::cl::init(""),
-    llvm::cl::desc("-read-ander=ir_annotator (Read Andersen's analysis results from the annotated IR, e.g., *.pre.bc) or from a text file")
+    "-read-ander=ir_annotator (Read Andersen's analysis results from the annotated IR, e.g., *.pre.bc) or from a text file",
+    ""
 );
 
-const llvm::cl::opt<bool> Options::DiffPts(
+const Option<bool> Options::DiffPts(
     "diff",
-    llvm::cl::init(true),
-    llvm::cl::desc("Enable differential point-to set")
+    "Enable differential point-to set",
+    true
 );
 
-llvm::cl::opt<bool> Options::DetectPWC(
+Option<bool> Options::DetectPWC(
     "merge-pwc",
-    llvm::cl::init(true),
-    llvm::cl::desc("Enable PWC detection")
+    "Enable PWC detection",
+    true
 );
 
 //SVFIRBuilder.cpp
-const llvm::cl::opt<bool> Options::VtableInSVFIR(
+const Option<bool> Options::VtableInSVFIR(
     "vt-in-ir",
-    llvm::cl::init(false),
-    llvm::cl::desc("Handle vtable in ConstantArray/ConstantStruct in SVFIRBuilder (already handled in CHA?)")
+    "Handle vtable in ConstantArray/ConstantStruct in SVFIRBuilder (already handled in CHA?)",
+    false
 );
 
 
 //WPAPass.cpp
-const llvm::cl::opt<bool> Options::AnderSVFG(
+const Option<bool> Options::AnderSVFG(
     "svfg",
-    llvm::cl::init(false),
-    llvm::cl::desc("Generate SVFG after Andersen's Analysis")
+    "Generate SVFG after Andersen's Analysis",
+    false
 );
 
-const llvm::cl::opt<bool> Options::SABERFULLSVFG(
+const Option<bool> Options::SABERFULLSVFG(
     "saber-full-svfg",
-    llvm::cl::init(false),
-    llvm::cl::desc("When using SABER for bug detection pass, enable full svfg on top of the pointer-only one")
+    "When using SABER for bug detection pass, enable full svfg on top of the pointer-only one",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PrintAliases(
+const Option<bool> Options::PrintAliases(
     "print-aliases",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print results for all pair aliases")
+    "Print results for all pair aliases",
+    false
 );
 
-llvm::cl::bits<PointerAnalysis::PTATY> Options::PASelected(
-    llvm::cl::desc("Select pointer analysis"),
-    llvm::cl::values(
-        clEnumValN(PointerAnalysis::Andersen_WPA, "nander", "Standard inclusion-based analysis"),
-        clEnumValN(PointerAnalysis::AndersenSCD_WPA, "sander", "Selective cycle detection inclusion-based analysis"),
-        clEnumValN(PointerAnalysis::AndersenSFR_WPA, "sfrander", "Stride-based field representation includion-based analysis"),
-        clEnumValN(PointerAnalysis::AndersenWaveDiff_WPA, "ander", "Diff wave propagation inclusion-based analysis"),
-        clEnumValN(PointerAnalysis::Steensgaard_WPA, "steens", "Steensgaard's pointer analysis"),
+OptionMultiple<PointerAnalysis::PTATY> Options::PASelected(
+    "Select pointer analysis",
+    {
+        {PointerAnalysis::Andersen_WPA, "nander", "Standard inclusion-based analysis"},
+        {PointerAnalysis::AndersenSCD_WPA, "sander", "Selective cycle detection inclusion-based analysis"},
+        {PointerAnalysis::AndersenSFR_WPA, "sfrander", "Stride-based field representation includion-based analysis"},
+        {PointerAnalysis::AndersenWaveDiff_WPA, "ander", "Diff wave propagation inclusion-based analysis"},
+        {PointerAnalysis::Steensgaard_WPA, "steens", "Steensgaard's pointer analysis"},
         // Disabled till further work is done.
-        clEnumValN(PointerAnalysis::FSSPARSE_WPA, "fspta", "Sparse flow sensitive pointer analysis"),
-        clEnumValN(PointerAnalysis::VFS_WPA, "vfspta", "Versioned sparse flow-sensitive points-to analysis"),
-        clEnumValN(PointerAnalysis::TypeCPP_WPA, "type", "Type-based fast analysis for Callgraph, SVFIR and CHA")
-    ));
+        {PointerAnalysis::FSSPARSE_WPA, "fspta", "Sparse flow sensitive pointer analysis"},
+        {PointerAnalysis::VFS_WPA, "vfspta", "Versioned sparse flow-sensitive points-to analysis"},
+        {PointerAnalysis::TypeCPP_WPA, "type", "Type-based fast analysis for Callgraph, SVFIR and CHA"},
+    }
+);
 
 
-llvm::cl::bits<WPAPass::AliasCheckRule> Options::AliasRule(llvm::cl::desc("Select alias check rule"),
-        llvm::cl::values(
-            clEnumValN(WPAPass::Conservative, "conservative", "return MayAlias if any pta says alias"),
-            clEnumValN(WPAPass::Veto, "veto", "return NoAlias if any pta says no alias")
-        ));
+OptionMultiple<WPAPass::AliasCheckRule> Options::AliasRule(
+    "Select alias check rule",
+    {
+        {WPAPass::Conservative, "conservative", "return MayAlias if any pta says alias"},
+        {WPAPass::Veto, "veto", "return NoAlias if any pta says no alias"},
+    }
+);
 
-const llvm::cl::opt<bool> Options::ShowHiddenNode(
+const Option<bool> Options::ShowHiddenNode(
     "show-hidden-nodes",
-    llvm::cl::init(false),
-    llvm::cl::desc("Show hidden nodes on DOT Graphs (e.g., isolated node on a graph)")
+    "Show hidden nodes on DOT Graphs (e.g., isolated node on a graph)",
+    false
 );
 
-const llvm::cl::opt<std::string> Options::GrammarFilename(
+const Option<std::string> Options::GrammarFilename(
     "grammar",
-    llvm::cl::init(""),
-    llvm::cl::desc("<Grammar textfile>")
+    "<Grammar textfile>",
+    ""
 );
 
-const llvm::cl::opt<std::string> Options::CFLGraph(
+const Option<std::string> Options::CFLGraph(
     "cflgraph",
-    llvm::cl::init(""),
-    llvm::cl::desc("<Dot file as the CFLGraph input>")
+    "<Dot file as the CFLGraph input>",
+    ""
 );
 
-const llvm::cl::opt<bool> Options::PrintCFL(
+const Option<bool> Options::PrintCFL(
     "print-cfl",
-    llvm::cl::init(false),
-    llvm::cl::desc("Print ir, grammar and cflgraph for debug.")
+    "Print ir, grammar and cflgraph for debug.",
+    false
 );
 
-const llvm::cl::opt<bool> Options::FlexSymMap(
+const Option<bool> Options::FlexSymMap(
     "flex-symmap",
-    llvm::cl::init(false),
-    llvm::cl::desc("Extend exist sym map while read graph from dot if sym not in map.")
+    "Extend exist sym map while read graph from dot if sym not in map.",
+    false
 );
 
-const llvm::cl::opt<bool> Options::PEGTransfer(
+const Option<bool> Options::PEGTransfer(
     "peg-transfer",
-    llvm::cl::init(false),
-    llvm::cl::desc("When explicit to true, cfl graph builder will transfer PAG load and store edges to copy and addr.")
+    "When explicit to true, cfl graph builder will transfer PAG load and store edges to copy and addr.",
+    false
 );
 
-const llvm::cl::opt<bool> Options::CFLSVFG(
+const Option<bool> Options::CFLSVFG(
     "cflsvfg",
-    llvm::cl::init(false),
-    llvm::cl::desc("When explicit to true, cfl graph builder will transfer SVFG to CFL Reachability.")
+    "When explicit to true, cfl graph builder will transfer SVFG to CFL Reachability.",
+    false
 );
 
 
-const llvm::cl::opt<bool> Options::LoopAnalysis(
+const Option<bool> Options::LoopAnalysis(
     "loop-analysis",
-    llvm::cl::init(true),
-    llvm::cl::desc("Analyze every func and get loop info and loop bounds.")
+    "Analyze every func and get loop info and loop bounds.",
+    true
 );
 
-const llvm::cl::opt<unsigned> Options::LoopBound(
+const Option<u32_t> Options::LoopBound(
     "loop-bound",
-    llvm::cl::init(1),
-    llvm::cl::desc("Maximum number of loop"));
+    "Maximum number of loop",
+    1
+);
 
 } // namespace SVF.

--- a/lib/Util/SVFStat.cpp
+++ b/lib/Util/SVFStat.cpp
@@ -40,21 +40,21 @@ double SVFStat::timeOfBuildingSymbolTable = 0;
 
 SVFStat::SVFStat() : startTime(0), endTime(0)
 {
-    assert((Options::ClockType == ClockType::Wall || Options::ClockType == ClockType::CPU)
+    assert((Options::ClockType() == ClockType::Wall || Options::ClockType() == ClockType::CPU)
            && "PTAStat: unknown clock type!");
 }
 
 double SVFStat::getClk(bool mark)
 {
-    if (Options::MarkedClocksOnly && !mark) return 0.0;
+    if (Options::MarkedClocksOnly() && !mark) return 0.0;
 
-    if (Options::ClockType == ClockType::Wall)
+    if (Options::ClockType() == ClockType::Wall)
     {
         struct timespec time;
         clock_gettime(CLOCK_MONOTONIC, &time);
         return (double)(time.tv_nsec + time.tv_sec * 1000000000) / 1000000.0;
     }
-    else if (Options::ClockType == ClockType::CPU)
+    else if (Options::ClockType() == ClockType::CPU)
     {
         return CLOCK_IN_MS();
     }

--- a/lib/Util/SVFUtil.cpp
+++ b/lib/Util/SVFUtil.cpp
@@ -65,7 +65,7 @@ std::string SVFUtil::wrnMsg(std::string msg)
 
 void SVFUtil::writeWrnMsg(std::string msg)
 {
-    if(Options::DisableWarn) return;
+    if(Options::DisableWarn()) return;
     outs() << wrnMsg(msg) << "\n";
 }
 

--- a/lib/Util/Z3Expr.cpp
+++ b/lib/Util/Z3Expr.cpp
@@ -107,7 +107,7 @@ Z3Expr Z3Expr::AND(const Z3Expr &lhs, const Z3Expr &rhs)
     {
         Z3Expr expr = lhs && rhs;
         // check subexpression size and option limit
-        if (Z3Expr::getExprSize(expr) > Options::MaxZ3Size)
+        if (Z3Expr::getExprSize(expr) > Options::MaxZ3Size())
         {
             getSolver().push();
             getSolver().add(expr.getExpr());
@@ -145,7 +145,7 @@ Z3Expr Z3Expr::OR(const Z3Expr &lhs, const Z3Expr &rhs)
     {
         Z3Expr expr = lhs || rhs;
         // check subexpression size and option limit
-        if (Z3Expr::getExprSize(expr) > Options::MaxZ3Size)
+        if (Z3Expr::getExprSize(expr) > Options::MaxZ3Size())
         {
             getSolver().push();
             getSolver().add(expr.getExpr());

--- a/lib/WPA/Andersen.cpp
+++ b/lib/WPA/Andersen.cpp
@@ -79,7 +79,7 @@ void AndersenBase::initialize()
     setGraph(consCG);
     /// Create statistic class
     stat = new AndersenStat(this);
-    if (Options::ConsCGDotGraph)
+    if (Options::ConsCGDotGraph())
         consCG->dump("consCG_initial");
 }
 
@@ -89,10 +89,10 @@ void AndersenBase::initialize()
 void AndersenBase::finalize()
 {
     /// dump constraint graph if PAGDotGraph flag is enabled
-    if (Options::ConsCGDotGraph)
+    if (Options::ConsCGDotGraph())
         consCG->dump("consCG_final");
 
-    if (Options::PrintCGGraph)
+    if (Options::PrintCGGraph())
         consCG->print();
     BVDataPTAImpl::finalize();
 }
@@ -106,22 +106,22 @@ void AndersenBase::analyze()
     initialize();
 
     bool readResultsFromFile = false;
-    if(!Options::ReadAnder.empty())
+    if(!Options::ReadAnder().empty())
     {
-        readResultsFromFile = this->readFromFile(Options::ReadAnder);
+        readResultsFromFile = this->readFromFile(Options::ReadAnder());
         // Finalize the analysis
         PointerAnalysis::finalize();
     }
 
-    if (!Options::WriteAnder.empty())
-        this->writeObjVarToFile(Options::WriteAnder);
+    if (!Options::WriteAnder().empty())
+        this->writeObjVarToFile(Options::WriteAnder());
 
     if(!readResultsFromFile)
     {
         // Start solving constraints
         DBOUT(DGENERAL, outs() << SVFUtil::pasMsg("Start Solving Constraints\n"));
 
-        bool limitTimerSet = SVFUtil::startAnalysisLimitTimer(Options::AnderTimeLimit);
+        bool limitTimerSet = SVFUtil::startAnalysisLimitTimer(Options::AnderTimeLimit());
 
         initWorklist();
         do
@@ -147,9 +147,9 @@ void AndersenBase::analyze()
 
     }
 
-    if (!Options::WriteAnder.empty())
+    if (!Options::WriteAnder().empty())
     {
-        this->writeToFile(Options::WriteAnder);
+        this->writeToFile(Options::WriteAnder());
     }
 
     if (!readResultsFromFile)
@@ -196,7 +196,7 @@ void Andersen::initialize()
     resetData();
     AndersenBase::initialize();
 
-    if (Options::ClusterAnder) cluster();
+    if (Options::ClusterAnder()) cluster();
 
     /// Initialize worklist
     processAllAddr();
@@ -209,7 +209,7 @@ void Andersen::finalize()
 {
     // TODO: check -stat too.
     // TODO: broken
-    if (Options::ClusterAnder)
+    if (Options::ClusterAnder())
     {
         Map<std::string, std::string> stats;
         const PTDataTy *ptd = getPTDataTy();
@@ -844,7 +844,7 @@ void Andersen::updateNodeRepAndSubs(NodeID nodeId, NodeID newRepId)
 
 void Andersen::cluster(void) const
 {
-    assert(Options::MaxFieldLimit == 0 && "Andersen::cluster: clustering for Andersen's is currently only supported in field-insesnsitive analysis");
+    assert(Options::MaxFieldLimit() == 0 && "Andersen::cluster: clustering for Andersen's is currently only supported in field-insesnsitive analysis");
     Steensgaard *steens = Steensgaard::createSteensgaard(pag);
     std::vector<std::pair<unsigned, unsigned>> keys;
     for (SVFIR::iterator pit = pag->begin(); pit != pag->end(); ++pit)

--- a/lib/WPA/AndersenSCD.cpp
+++ b/lib/WPA/AndersenSCD.cpp
@@ -108,7 +108,7 @@ NodeStack& AndersenSCD::SCCDetect()
     double mergeEnd = stat->getClk();
     timeOfSCCMerges +=  (mergeEnd - mergeStart)/TIMEINTERVAL;
 
-    if (Options::DetectPWC)
+    if (Options::DetectPWC())
     {
         sccStart = stat->getClk();
         PWCDetect();
@@ -133,7 +133,7 @@ void AndersenSCD::PWCDetect()
     tmpSccCandidates.clear();
 
     // set scc edge type as direct edge
-    bool pwcFlag = Options::DetectPWC;
+    bool pwcFlag = Options::DetectPWC();
     setDetectPWC(true);
 
     getSCCDetector()->find(sccCandidates);
@@ -150,7 +150,7 @@ void AndersenSCD::handleCopyGep(ConstraintNode* node)
 {
     NodeID nodeId = node->getId();
 
-    if (!Options::DetectPWC && getSCCDetector()->subNodes(nodeId).count() > 1)
+    if (!Options::DetectPWC() && getSCCDetector()->subNodes(nodeId).count() > 1)
         processPWC(node);
     else if(isInWorklist(nodeId))
         Andersen::handleCopyGep(node);

--- a/lib/WPA/FlowSensitive.cpp
+++ b/lib/WPA/FlowSensitive.cpp
@@ -49,20 +49,20 @@ void FlowSensitive::initialize()
     stat = new FlowSensitiveStat(this);
 
     // TODO: support clustered aux. Andersen's.
-    assert(!Options::ClusterAnder && "FlowSensitive::initialize: clustering auxiliary Andersen's unsupported.");
+    assert(!Options::ClusterAnder() && "FlowSensitive::initialize: clustering auxiliary Andersen's unsupported.");
     ander = AndersenWaveDiff::createAndersenWaveDiff(getPAG());
 
     // If cluster option is not set, it will give us a no-mapping points-to set.
-    assert(!(Options::ClusterFs && Options::PlainMappingFs)
+    assert(!(Options::ClusterFs() && Options::PlainMappingFs())
            && "FS::init: plain-mapping and cluster-fs are mutually exclusive.");
-    if (Options::ClusterFs)
+    if (Options::ClusterFs())
     {
         cluster();
         // Reset the points-to cache although empty so the new mapping could
         // be applied to the inserted empty set.
         getPtCache().reset();
     }
-    else if (Options::PlainMappingFs)
+    else if (Options::PlainMappingFs())
     {
         plainMap();
         // As above.
@@ -80,7 +80,7 @@ void FlowSensitive::initialize()
  */
 void FlowSensitive::analyze()
 {
-    bool limitTimerSet = SVFUtil::startAnalysisLimitTimer(Options::FsTimeLimit);
+    bool limitTimerSet = SVFUtil::startAnalysisLimitTimer(Options::FsTimeLimit());
 
     /// Initialization for the Solver
     initialize();
@@ -120,7 +120,7 @@ void FlowSensitive::analyze()
  */
 void FlowSensitive::finalize()
 {
-    if(Options::DumpVFG)
+    if(Options::DumpVFG())
         svfg->dump("fs_solved", true);
 
     NodeStack& nodeStack = WPASolver<SVFG*>::SCCDetect();
@@ -139,7 +139,7 @@ void FlowSensitive::finalize()
     }
 
     // TODO: check -stat too.
-    if (Options::ClusterFs)
+    if (Options::ClusterFs())
     {
         Map<std::string, std::string> stats;
         const PTDataTy *ptd = getPTDataTy();
@@ -791,7 +791,7 @@ void FlowSensitive::cluster(void)
 
 void FlowSensitive::plainMap(void) const
 {
-    assert(Options::NodeAllocStrat == NodeIDAllocator::Strategy::DENSE
+    assert(Options::NodeAllocStrat() == NodeIDAllocator::Strategy::DENSE
            && "FS::cluster: plain mapping requires dense allocation strategy.");
 
     const size_t numObjects = NodeIDAllocator::get()->getNumObjects();

--- a/lib/WPA/TypeAnalysis.cpp
+++ b/lib/WPA/TypeAnalysis.cpp
@@ -44,7 +44,7 @@ using namespace std;
 void TypeAnalysis::initialize()
 {
     AndersenBase::initialize();
-    if (Options::DumpICFG)
+    if (Options::DumpICFG())
     {
         icfg = SVFIR::getPAG()->getICFG();
         icfg->dump("icfg_initial");

--- a/lib/WPA/VersionedFlowSensitive.cpp
+++ b/lib/WPA/VersionedFlowSensitive.cpp
@@ -39,7 +39,7 @@ VersionedFlowSensitive::VersionedFlowSensitive(SVFIR *_pag, PTATY type)
         if (SVFUtil::isa<ObjVar>(it->second)) equivalentObject[it->first] = it->first;
     }
 
-    assert(!Options::OPTSVFG && "VFS: -opt-svfg not currently supported with VFS.");
+    assert(!Options::OPTSVFG() && "VFS: -opt-svfg not currently supported with VFS.");
 }
 
 void VersionedFlowSensitive::initialize()
@@ -121,7 +121,7 @@ void VersionedFlowSensitive::meldLabel(void)
 {
     double start = stat->getClk(true);
 
-    assert(Options::VersioningThreads > 0 && "VFS::meldLabel: number of versioning threads must be > 0!");
+    assert(Options::VersioningThreads() > 0 && "VFS::meldLabel: number of versioning threads must be > 0!");
 
     // Nodes which have at least one object on them given a prelabel + the Andersen's points-to
     // set of interest so we don't keep calling getPts. For Store nodes, we'll fill that in, for
@@ -414,7 +414,7 @@ void VersionedFlowSensitive::meldLabel(void)
     };
 
     std::vector<std::thread> workers;
-    for (unsigned i = 0; i < Options::VersioningThreads; ++i) workers.push_back(std::thread(meldVersionWorker, i));
+    for (unsigned i = 0; i < Options::VersioningThreads(); ++i) workers.push_back(std::thread(meldVersionWorker, i));
     for (std::thread &worker : workers) worker.join();
 
     delete[] versionMutexes;
@@ -777,7 +777,7 @@ void VersionedFlowSensitive::cluster(void)
     {
         unsigned occ = 1;
         unsigned v = pit->first;
-        if (Options::PredictPtOcc && pag->getObject(v) != nullptr) occ = stmtReliance[v].size() + 1;
+        if (Options::PredictPtOcc() && pag->getObject(v) != nullptr) occ = stmtReliance[v].size() + 1;
         assert(occ != 0);
         keys.push_back(std::make_pair(v, occ));
     }

--- a/lib/WPA/WPAPass.cpp
+++ b/lib/WPA/WPAPass.cpp
@@ -70,7 +70,8 @@ void WPAPass::runOnModule(SVFIR* pag)
 {
     for (u32_t i = 0; i<= PointerAnalysis::Default_PTA; i++)
     {
-        if (Options::PASelected.isSet(i))
+        PointerAnalysis::PTATY iPtaTy = static_cast<PointerAnalysis::PTATY>(i);
+        if (Options::PASelected(iPtaTy))
             runPointerAnalysis(pag, i);
     }
     assert(!ptaVector.empty() && "No pointer analysis is specified.\n");
@@ -115,17 +116,17 @@ void WPAPass::runPointerAnalysis(SVFIR* pag, u32_t kind)
 
     ptaVector.push_back(_pta);
     _pta->analyze();
-    if (Options::AnderSVFG)
+    if (Options::AnderSVFG())
     {
         SVFGBuilder memSSA(true);
         assert(SVFUtil::isa<AndersenBase>(_pta) && "supports only andersen/steensgaard for pre-computed SVFG");
         SVFG *svfg = memSSA.buildFullSVFG((BVDataPTAImpl*)_pta);
         /// support mod-ref queries only for -ander
-        if (Options::PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA))
+        if (Options::PASelected(PointerAnalysis::AndersenWaveDiff_WPA))
             _svfg = svfg;
     }
 
-    if (Options::PrintAliases)
+    if (Options::PrintAliases())
         PrintAliasPairs(_pta);
 }
 
@@ -172,7 +173,7 @@ AliasResult WPAPass::alias(const SVFValue* V1, const SVFValue* V2)
     if (pag->hasValueNode(V1) && pag->hasValueNode(V2))
     {
         /// Veto is used by default
-        if (Options::AliasRule.getBits() == 0 || Options::AliasRule.isSet(Veto))
+        if (Options::AliasRule.nothingSet() || Options::AliasRule(Veto))
         {
             /// Return NoAlias if any PTA gives NoAlias result
             result = AliasResult::MayAlias;
@@ -184,7 +185,7 @@ AliasResult WPAPass::alias(const SVFValue* V1, const SVFValue* V2)
                     result = AliasResult::NoAlias;
             }
         }
-        else if (Options::AliasRule.isSet(Conservative))
+        else if (Options::AliasRule(Conservative))
         {
             /// Return MayAlias if any PTA gives MayAlias result
             result = AliasResult::NoAlias;
@@ -206,7 +207,7 @@ AliasResult WPAPass::alias(const SVFValue* V1, const SVFValue* V2)
  */
 ModRefInfo WPAPass::getModRefInfo(const CallSite callInst)
 {
-    assert(Options::PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA) && Options::AnderSVFG && "mod-ref query is only support with -ander and -svfg turned on");
+    assert(Options::PASelected(PointerAnalysis::AndersenWaveDiff_WPA) && Options::AnderSVFG() && "mod-ref query is only support with -ander and -svfg turned on");
     ICFG* icfg = _svfg->getPAG()->getICFG();
     const CallICFGNode* cbn = icfg->getCallICFGNode(callInst.getInstruction());
     return _svfg->getMSSA()->getMRGenerator()->getModRefInfo(cbn);
@@ -217,7 +218,7 @@ ModRefInfo WPAPass::getModRefInfo(const CallSite callInst)
  */
 ModRefInfo WPAPass::getModRefInfo(const CallSite callInst, const SVFValue* V)
 {
-    assert(Options::PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA) && Options::AnderSVFG && "mod-ref query is only support with -ander and -svfg turned on");
+    assert(Options::PASelected(PointerAnalysis::AndersenWaveDiff_WPA) && Options::AnderSVFG() && "mod-ref query is only support with -ander and -svfg turned on");
     ICFG* icfg = _svfg->getPAG()->getICFG();
     const CallICFGNode* cbn = icfg->getCallICFGNode(callInst.getInstruction());
     return _svfg->getMSSA()->getMRGenerator()->getModRefInfo(cbn, V);
@@ -228,7 +229,7 @@ ModRefInfo WPAPass::getModRefInfo(const CallSite callInst, const SVFValue* V)
  */
 ModRefInfo WPAPass::getModRefInfo(const CallSite callInst1, const CallSite callInst2)
 {
-    assert(Options::PASelected.isSet(PointerAnalysis::AndersenWaveDiff_WPA) && Options::AnderSVFG && "mod-ref query is only support with -ander and -svfg turned on");
+    assert(Options::PASelected(PointerAnalysis::AndersenWaveDiff_WPA) && Options::AnderSVFG() && "mod-ref query is only support with -ander and -svfg turned on");
     ICFG* icfg = _svfg->getPAG()->getICFG();
     const CallICFGNode* cbn1 = icfg->getCallICFGNode(callInst1.getInstruction());
     const CallICFGNode* cbn2 = icfg->getCallICFGNode(callInst2.getInstruction());

--- a/tools/CFL/cfl.cpp
+++ b/tools/CFL/cfl.cpp
@@ -35,29 +35,21 @@
 using namespace llvm;
 using namespace SVF;
 
-static cl::opt<bool>
-StandardCompileOpts("std-compile-opts",
-                    cl::desc("Include the standard compile time optimizations"));
-
-static llvm::cl::opt<std::string> InputFilename(llvm::cl::Positional,
-        llvm::cl::desc("<input bitcode>"), llvm::cl::init("-"));
-
 int main(int argc, char ** argv)
 {
-    int arg_num = 0;
     char **arg_value = new char*[argc];
     std::vector<std::string> moduleNameVec;
-    LLVMUtil::processArguments(argc, argv, arg_num, arg_value, moduleNameVec);
-    cl::ParseCommandLineOptions(arg_num, arg_value,
-                                "CFL Reachability Analysis\n");
+    moduleNameVec = OptionBase::parseOptions(
+        argc, argv, "CFL Reachability Analysis", "[options] <input-bitcode...>"
+    );
 
-    if (Options::WriteAnder == "ir_annotator")
+    if (Options::WriteAnder() == "ir_annotator")
     {
         LLVMModuleSet::getLLVMModuleSet()->preProcessBCs(moduleNameVec);
     }
 
     SVFIR* svfir = nullptr;
-    if (Options::CFLGraph.empty())
+    if (Options::CFLGraph().empty())
     {
         SVFModule* svfModule = LLVMModuleSet::getLLVMModuleSet()->buildSVFModule(moduleNameVec);
         SVFIRBuilder builder(svfModule);
@@ -65,7 +57,7 @@ int main(int argc, char ** argv)
     }  // if no dot form CFLGraph is specified, we use svfir from .bc.
 
     std::unique_ptr<CFLBase> cfl;
-    if (Options::CFLSVFG)
+    if (Options::CFLSVFG())
         cfl = std::make_unique<CFLVF>(svfir);
     else
         cfl = std::make_unique<CFLAlias>(svfir); // if no svfg is specified, we use CFLAlias as the default one.

--- a/tools/DDA/dda.cpp
+++ b/tools/DDA/dda.cpp
@@ -14,45 +14,55 @@
 using namespace llvm;
 using namespace SVF;
 
-static cl::opt<bool>
-StandardCompileOpts("std-compile-opts",
-                    cl::desc("Include the standard compile time optimizations"));
-
-static llvm::cl::opt<std::string> InputFilename(llvm::cl::Positional,
-        llvm::cl::desc("<input bitcode>"), llvm::cl::init("-"));
-
 //static cl::list<const PassInfo*, bool, PassNameParser>
 //PassList(cl::desc("Optimizations available:"));
 
-static cl::opt<bool> DAA("daa", cl::init(false),
-                         cl::desc("Demand-Driven Alias Analysis Pass"));
+static Option<bool> DAA(
+    "daa",
+    "Demand-Driven Alias Analysis Pass",
+    false
+);
 
-static cl::opt<bool> REGPT("dreg", cl::init(false),
-                           cl::desc("Demand-driven regular points-to analysis"));
+static Option<bool> REGPT(
+    "dreg",
+    "Demand-driven regular points-to analysis",
+    false
+);
 
-static cl::opt<bool> RFINEPT("dref", cl::init(false),
-                             cl::desc("Demand-driven refinement points-to analysis"));
+static Option<bool> RFINEPT(
+    "dref",
+    "Demand-driven refinement points-to analysis",
+    false
+);
 
-static cl::opt<bool> ENABLEFIELD("fdaa", cl::init(false),
-                                 cl::desc("enable field-sensitivity for demand-driven analysis"));
+static Option<bool> ENABLEFIELD(
+    "fdaa",
+    "enable field-sensitivity for demand-driven analysis",
+    false
+);
 
-static cl::opt<bool> ENABLECONTEXT("cdaa", cl::init(false),
-                                   cl::desc("enable context-sensitivity for demand-driven analysis"));
+static Option<bool> ENABLECONTEXT(
+    "cdaa",
+    "enable context-sensitivity for demand-driven analysis",
+    false
+);
 
-static cl::opt<bool> ENABLEFLOW("ldaa", cl::init(false),
-                                cl::desc("enable flow-sensitivity for demand-driven analysis"));
+static Option<bool> ENABLEFLOW(
+    "ldaa",
+    "enable flow-sensitivity for demand-driven analysis",
+    false
+);
 
 int main(int argc, char ** argv)
 {
 
-    int arg_num = 0;
     char **arg_value = new char*[argc];
     std::vector<std::string> moduleNameVec;
-    LLVMUtil::processArguments(argc, argv, arg_num, arg_value, moduleNameVec);
-    cl::ParseCommandLineOptions(arg_num, arg_value,
-                                "Demand-Driven Points-to Analysis\n");
+    moduleNameVec = OptionBase::parseOptions(
+        argc, argv, "Demand-Driven Points-to Analysis", "[options] <input-bitcode...>"
+    );
 
-    if (Options::WriteAnder == "ir_annotator")
+    if (Options::WriteAnder() == "ir_annotator")
     {
         LLVMModuleSet::getLLVMModuleSet()->preProcessBCs(moduleNameVec);
     }

--- a/tools/Example/svf-ex.cpp
+++ b/tools/Example/svf-ex.cpp
@@ -30,14 +30,12 @@
 #include "Graphs/SVFG.h"
 #include "WPA/Andersen.h"
 #include "SVF-LLVM/SVFIRBuilder.h"
+#include "Util/CommandLine.h"
 #include "Util/Options.h"
 
 using namespace llvm;
 using namespace std;
 using namespace SVF;
-
-static llvm::cl::opt<std::string> InputFilename(llvm::cl::Positional,
-        llvm::cl::desc("<input bitcode>"), llvm::cl::init("-"));
 
 /*!
  * An example to query alias results of two LLVM values
@@ -145,14 +143,13 @@ void traverseOnVFG(const SVFG* vfg, SVFValue* val)
 int main(int argc, char ** argv)
 {
 
-    int arg_num = 0;
     char **arg_value = new char*[argc];
     std::vector<std::string> moduleNameVec;
-    LLVMUtil::processArguments(argc, argv, arg_num, arg_value, moduleNameVec);
-    cl::ParseCommandLineOptions(arg_num, arg_value,
-                                "Whole Program Points-to Analysis\n");
+    moduleNameVec = OptionBase::parseOptions(
+        argc, argv, "Whole Program Points-to Analysis", "[options] <input-bitcode...>"
+    );
 
-    if (Options::WriteAnder == "ir_annotator")
+    if (Options::WriteAnder() == "ir_annotator")
     {
         LLVMModuleSet::getLLVMModuleSet()->preProcessBCs(moduleNameVec);
     }

--- a/tools/MTA/LockResultValidator.cpp
+++ b/tools/MTA/LockResultValidator.cpp
@@ -155,7 +155,7 @@ LockResultValidator::LOCK_FLAG LockResultValidator::validateStmtInLock()
         CxtLockSetStr LS = instToCxtLockSet[inst];
         if(LS.size() != (*it).second.size())
         {
-            if (Options::PrintValidRes)
+            if (Options::PrintValidRes())
             {
                 outs() << errMsg("\nValidate Stmt's Lock : Wrong at: ") << inst->toString() << "\n";
                 outs() << "Reason: The number of lock on current stmt is wrong\n";
@@ -185,7 +185,7 @@ LockResultValidator::LOCK_FLAG LockResultValidator::validateStmtInLock()
             std::string lockName = SVFUtil::getSVFCallSite(call).getArgOperand(0)->getName();
             if(!match(lockName, LS))
             {
-                if(Options::PrintValidRes)
+                if(Options::PrintValidRes())
                 {
                     outs() << "\nValidate Stmt's Lock : Wrong at (" << inst->toString() << ")\n";
                     outs() << "Reason: The number of lock on current stmt is wrong\n";

--- a/tools/MTA/MTAAnnotator.cpp
+++ b/tools/MTA/MTAAnnotator.cpp
@@ -108,14 +108,14 @@ void MTAAnnotator::initialize(MHP* m, LockAnalysis* la)
 {
     mhp = m;
     lsa = la;
-    if (!Options::AnnoFlag)
+    if (!Options::AnnoFlag())
         return;
     collectLoadStoreInst(mhp->getTCT()->getPTA()->getModule());
 }
 
 void MTAAnnotator::pruneThreadLocal(PointerAnalysis* pta)
 {
-    bool AnnoLocal = Options::AnnoFlag & ANNO_LOCAL;
+    bool AnnoLocal = Options::AnnoFlag() & ANNO_LOCAL;
     if (!AnnoLocal)
         return;
 
@@ -202,8 +202,8 @@ void MTAAnnotator::pruneThreadLocal(PointerAnalysis* pta)
 void MTAAnnotator::pruneAliasMHP(PointerAnalysis* pta)
 {
 
-    bool AnnoMHP = Options::AnnoFlag & ANNO_MHP;
-    bool AnnoAlias = Options::AnnoFlag & ANNO_ALIAS;
+    bool AnnoMHP = Options::AnnoFlag() & ANNO_MHP;
+    bool AnnoAlias = Options::AnnoFlag() & ANNO_ALIAS;
 
     if (!AnnoMHP && !AnnoAlias)
         return;
@@ -280,7 +280,7 @@ void MTAAnnotator::pruneAliasMHP(PointerAnalysis* pta)
 }
 void MTAAnnotator::performAnnotate()
 {
-    if (!Options::AnnoFlag)
+    if (!Options::AnnoFlag())
         return;
     for (InstSet::iterator it = storeset.begin(), eit = storeset.end(); it != eit; ++it)
     {

--- a/tools/MTA/MTAResultValidator.cpp
+++ b/tools/MTA/MTAResultValidator.cpp
@@ -375,7 +375,7 @@ bool MTAResultValidator::validateCxtThread()
     if (tct->getTCTNodeNum() != vthdToCxt.size())
     {
         res = false;
-        if (Options::PrintValidRes)
+        if (Options::PrintValidRes())
         {
             outs() << errMsg("\nValidate CxtThread: The number of CxtThread is different from given result!!!\n");
             outs() << "Given threads:\t" << vthdToCxt.size() << "\nAnalysis result:\t" << tct->getTCTNodeNum() << "\n";
@@ -397,7 +397,7 @@ bool MTAResultValidator::validateCxtThread()
                 if (visitedvthd.find(vthdid) != visitedvthd.end())
                 {
                     res = false;
-                    if (Options::PrintValidRes)
+                    if (Options::PrintValidRes())
                     {
                         outs() << "\nValidate CxtThread: Repeat real CxtThread !!!\n";
                         rthd.dump();
@@ -414,7 +414,7 @@ bool MTAResultValidator::validateCxtThread()
         if (!matched)
         {
             res = false;
-            if (Options::PrintValidRes)
+            if (Options::PrintValidRes())
             {
                 SVFUtil::errs() << errMsg("\nValidate CxtThread: Cannot match real CxtThread !!!\n");
                 rthd.dump();
@@ -425,7 +425,7 @@ bool MTAResultValidator::validateCxtThread()
     if (visitedvthd.size() != vthdToCxt.size())
     {
         res = false;
-        if (Options::PrintValidRes)
+        if (Options::PrintValidRes())
         {
             SVFUtil::errs() << errMsg("\nValidate CxtThread: Some given CxtThreads cannot be found !!!\n");
             assert(false && "test case failed!");
@@ -471,7 +471,7 @@ bool MTAResultValidator::validateTCT()
                 res_node = false;
             }
         }
-        if ((!res_node) && Options::PrintValidRes)
+        if ((!res_node) && Options::PrintValidRes())
         {
             outs() << errMsg("\nValidate TCT: Wrong at TID ") << rthdTovthd[i] << "\n";
             outs() << "Given children: \t";
@@ -505,7 +505,7 @@ MTAResultValidator::INTERLEV_FLAG MTAResultValidator::validateInterleaving()
 
         if ((*seti).second.size() != tsSet.size())
         {
-            if (Options::PrintValidRes)
+            if (Options::PrintValidRes())
             {
                 outs() << errMsg("\n Validate Interleaving: Wrong at : ") << inst->getSourceLoc() << "\n";
                 outs() << "Reason: The number of thread running on stmt is wrong\n";
@@ -542,7 +542,7 @@ MTAResultValidator::INTERLEV_FLAG MTAResultValidator::validateInterleaving()
                     NodeBS lev2 = threadStmtToInterLeaving[ts2];
                     if (lev != lev2)
                     {
-                        if (Options::PrintValidRes)
+                        if (Options::PrintValidRes())
                         {
                             outs() << errMsg("\nValidate Interleaving: Wrong at: ") << inst->getSourceLoc() << "\n";
                             outs() << "Reason: thread interleaving on stmt is wrong\n";
@@ -578,7 +578,7 @@ MTAResultValidator::INTERLEV_FLAG MTAResultValidator::validateInterleaving()
 
             if (!matched)
             {
-                if (Options::PrintValidRes)
+                if (Options::PrintValidRes())
                 {
                     outs() << errMsg("\nValidate Interleaving: Wrong at:") << inst->getSourceLoc() << "\n";
                     outs() << "Reason: analysis thread cxt is not matched by given thread cxt\n";

--- a/tools/MTA/mta.cpp
+++ b/tools/MTA/mta.cpp
@@ -1,6 +1,7 @@
 #include "SVF-LLVM/LLVMUtil.h"
 #include "SVF-LLVM/SVFIRBuilder.h"
 #include "MTA/MTA.h"
+#include "Util/CommandLine.h"
 #include "Util/Options.h"
 #include "MTAResultValidator.h"
 #include "LockResultValidator.h"
@@ -8,20 +9,16 @@ using namespace llvm;
 using namespace std;
 using namespace SVF;
 
-static llvm::cl::opt<std::string> InputFilename(llvm::cl::Positional,
-        llvm::cl::desc("<input bitcode>"), llvm::cl::init("-"));
-
 int main(int argc, char ** argv)
 {
 
-    int arg_num = 0;
     char **arg_value = new char*[argc];
     std::vector<std::string> moduleNameVec;
-    LLVMUtil::processArguments(argc, argv, arg_num, arg_value, moduleNameVec);
-    cl::ParseCommandLineOptions(arg_num, arg_value,
-                                "MTA Analysis\n");
+    moduleNameVec = OptionBase::parseOptions(
+        argc, argv, "MTA Analysis", "[options] <input-bitcode...>"
+    );
 
-    if (Options::WriteAnder == "ir_annotator")
+    if (Options::WriteAnder() == "ir_annotator")
     {
         LLVMModuleSet::getLLVMModuleSet()->preProcessBCs(moduleNameVec);
     }

--- a/tools/WPA/wpa.cpp
+++ b/tools/WPA/wpa.cpp
@@ -29,26 +29,23 @@
 #include "SVF-LLVM/LLVMUtil.h"
 #include "SVF-LLVM/SVFIRBuilder.h"
 #include "WPA/WPAPass.h"
+#include "Util/CommandLine.h"
 #include "Util/Options.h"
 
 using namespace llvm;
 using namespace std;
 using namespace SVF;
 
-static llvm::cl::opt<std::string> InputFilename(llvm::cl::Positional,
-        llvm::cl::desc("<input bitcode>"), llvm::cl::init("-"));
-
 int main(int argc, char ** argv)
 {
 
-    int arg_num = 0;
     char **arg_value = new char*[argc];
     std::vector<std::string> moduleNameVec;
-    LLVMUtil::processArguments(argc, argv, arg_num, arg_value, moduleNameVec);
-    cl::ParseCommandLineOptions(arg_num, arg_value,
-                                "Whole Program Points-to Analysis\n");
+    moduleNameVec = OptionBase::parseOptions(
+        argc, argv, "Whole Program Points-to Analysis", "[options] <input-bitcode...>"
+    );
 
-    if (Options::WriteAnder == "ir_annotator")
+    if (Options::WriteAnder() == "ir_annotator")
     {
         LLVMModuleSet::getLLVMModuleSet()->preProcessBCs(moduleNameVec);
     }


### PR DESCRIPTION
As title.

Some notable changes from LLVM:
* If the option is called `Foo`, to get the value, you do `Foo()`. If it is like `llvm::cl::bits` (`OptionMultiple`), you do `Foo(x)` instead of `Foo.isSet(x)`.
* In usage message, showing `=<xyz>`, might be nice to add later. Not sure how necessary.
* Options are `-foo` and `--foo` isn't supported.
* Everything requires an explicit initial value.
* Positional arguments get returned by the `parse` method in the order they came in. There is no way to set an `Option` object to be the positional arguments. Didn't fully get how it is in LLVM anyway.

Files implementing it are CommandLine.h and a little in CommandLine.cpp.