### PR TITLE
Simplify return logic

### DIFF
--- a/include/AbstractExecution/IntervalExeState.h
+++ b/include/AbstractExecution/IntervalExeState.h
@@ -387,10 +387,8 @@ public:
     bool operator<(const IntervalExeState &rhs) const
     {
         // judge from path constraint
-        if (lessThanVarToValMap(_varToItvVal, rhs.getVarToVal()) ||
-                lessThanVarToValMap(_locToItvVal, rhs.getLocToVal()))
-            return true;
-        return false;
+        return (lessThanVarToValMap(_varToItvVal, rhs.getVarToVal()) ||
+                lessThanVarToValMap(_locToItvVal, rhs.getLocToVal()));
     }
 
 

--- a/include/DDA/DDAVFSolver.h
+++ b/include/DDA/DDAVFSolver.h
@@ -480,9 +480,7 @@ protected:
     /// If the points-to contain the object obj, we could move forward along indirect value-flow edge
     virtual inline bool propagateViaObj(const CVar& storeObj, const CVar& loadObj)
     {
-        if(getPtrNodeID(storeObj) == getPtrNodeID(loadObj))
-            return true;
-        return false;
+        return getPtrNodeID(storeObj) == getPtrNodeID(loadObj);
     }
     /// resolve function pointer
     void resolveFunPtr(const DPIm& dpm)

--- a/include/MTA/LockAnalysis.h
+++ b/include/MTA/LockAnalysis.h
@@ -384,9 +384,7 @@ private:
         {
             tgrlockset.erase(*it);
         }
-        if(!toBeDeleted.empty())
-            return true;
-        return false;
+        return !toBeDeleted.empty();
     }
 
     /// Clear flags

--- a/include/MTA/MHP.h
+++ b/include/MTA/MHP.h
@@ -342,18 +342,14 @@ public:
     {
         bool nonhp = HBPair.find(std::make_pair(tid1,tid2))!=HBPair.end();
         bool hp = HPPair.find(std::make_pair(tid1,tid2))!=HPPair.end();
-        if(nonhp && !hp)
-            return true;
-        return false;
+        return nonhp && !hp;
     }
     /// Whether t1 fully joins t2
     inline bool isFullJoin(NodeID tid1, NodeID tid2)
     {
         bool full = fullJoin.find(std::make_pair(tid1,tid2))!=fullJoin.end();
         bool partial = partialJoin.find(std::make_pair(tid1,tid2))!=partialJoin.end();
-        if(full && !partial)
-            return true;
-        return false;
+        return full && !partial;
     }
 
     /// Get exit instruction of the start routine function of tid's parent thread

--- a/include/Util/CommandLine.h
+++ b/include/Util/CommandLine.h
@@ -360,11 +360,14 @@ public:
 
 private:
     // Convert string to boolean, returning whether we succeeded.
-    static bool fromString(const std::string s, bool &value)
+    static bool fromString(const std::string& s, bool& value)
     {
-        if (s == "true") value = true;
-        else if (s == "false") value = false;
-        else return false;
+        if (s == "true")
+            value = true;
+        else if (s == "false")
+            value = false;
+        else
+            return false;
         return true;
     }
 

--- a/lib/AbstractExecution/RelExeState.cpp
+++ b/lib/AbstractExecution/RelExeState.cpp
@@ -128,9 +128,8 @@ bool RelExeState::operator==(const RelExeState &rhs) const
  */
 bool RelExeState::operator<(const RelExeState &rhs) const
 {
-    if (lessThanVarToValMap(_varToVal, rhs.getVarToVal()) || lessThanVarToValMap(_locToVal, rhs.getLocToVal()))
-        return true;
-    return false;
+    return lessThanVarToValMap(_varToVal, rhs.getVarToVal()) ||
+           lessThanVarToValMap(_locToVal, rhs.getLocToVal());
 }
 
 bool RelExeState::eqVarToValMap(const VarToValMap &lhs, const VarToValMap &rhs) const

--- a/lib/MTA/LockAnalysis.cpp
+++ b/lib/MTA/LockAnalysis.cpp
@@ -598,10 +598,7 @@ bool LockAnalysis::isProtectedByCommonCxtLock(const CxtStmt& cxtStmt1, const Cxt
         return true;
     const CxtLockSet& lockset1 = getCxtLockfromCxtStmt(cxtStmt1);
     const CxtLockSet& lockset2 = getCxtLockfromCxtStmt(cxtStmt2);
-    if (alias(lockset1,lockset2))
-        return true;
-
-    return false;
+    return alias(lockset1,lockset2);
 }
 
 /*!
@@ -676,10 +673,7 @@ bool LockAnalysis::isInSameCSSpan(const CxtStmt& cxtStmt1, const CxtStmt& cxtStm
         return true;
     const CxtLockSet& lockset1 = getCxtLockfromCxtStmt(cxtStmt1);
     const CxtLockSet& lockset2 = getCxtLockfromCxtStmt(cxtStmt2);
-    if (intersects(lockset1,lockset2))
-        return true;
-
-    return false;
+    return intersects(lockset1,lockset2);
 }
 /*!
  * Return true if two instructions are inside at least one common contex-sensitive lock span

--- a/lib/SVFIR/SVFIR.cpp
+++ b/lib/SVFIR/SVFIR.cpp
@@ -706,9 +706,7 @@ bool SVFIR::isValidTopLevelPtr(const SVFVar* node)
     {
         if (isValidPointer(node->getId()) && node->hasValue())
         {
-            if (SVFUtil::isArgOfUncalledFunction(node->getValue()))
-                return false;
-            return true;
+            return !SVFUtil::isArgOfUncalledFunction(node->getValue());
         }
     }
     return false;

--- a/lib/Util/CoreBitVector.cpp
+++ b/lib/Util/CoreBitVector.cpp
@@ -49,7 +49,9 @@ CoreBitVector &CoreBitVector::operator=(CoreBitVector &&rhs)
 
 bool CoreBitVector::empty(void) const
 {
-    for (const Word &w : words) if (w) return false;
+    for (const Word& w : words)
+        if (w)
+            return false;
     return true;
 }
 

--- a/tools/MTA/MTAResultValidator.cpp
+++ b/tools/MTA/MTAResultValidator.cpp
@@ -236,9 +236,7 @@ bool MTAResultValidator::collectCallsiteTargets()
             }
         }
     }
-    if (csnumToInstMap.empty())
-        return false;
-    return true;
+    return !csnumToInstMap.empty();
 }
 
 bool MTAResultValidator::collectCxtThreadTargets()


### PR DESCRIPTION
```
if (X)
  return true;
else
  return false;
```
is redundant. It is actually `return X`.