### PR TITLE
Fix a assertion failure cause i128 type

### DIFF
--- a/svf-llvm/lib/ICFGBuilder.cpp
+++ b/svf-llvm/lib/ICFGBuilder.cpp
@@ -134,7 +134,9 @@ void ICFGBuilder::processFunBody(WorkList& worklist)
                     /// branch condition value
                     const ConstantInt* condVal = const_cast<SwitchInst*>(si)->findCaseDest(const_cast<BasicBlock*>(succ->getParent()));
                     /// default case is set to -1;
-                    s32_t val = condVal ? condVal->getSExtValue() : -1;
+                    s64_t val = -1;
+                    if (condVal && condVal->getBitWidth() <= 64)
+                        val = condVal->getSExtValue();
                     icfg->addConditionalIntraEdge(srcNode, dstNode, LLVMModuleSet::getLLVMModuleSet()->getSVFValue(si->getCondition()),val);
                 }
                 else

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -937,7 +937,9 @@ void SVFIRBuilder::visitSwitchInst(SwitchInst &inst)
         const Instruction* succInst = &inst.getSuccessor(i)->front();
         const ConstantInt* condVal = inst.findCaseDest(inst.getSuccessor(i));
         /// default case is set to -1;
-        s32_t val = condVal ? condVal->getSExtValue() : -1;
+        s64_t val = -1;
+        if (condVal && condVal->getBitWidth() <= 64)
+            val = condVal->getSExtValue();
         const SVFInstruction* svfSuccInst = LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(succInst);
         const ICFGNode* icfgNode = pag->getICFG()->getICFGNode(svfSuccInst);
         successors.push_back(std::make_pair(icfgNode,val));

--- a/svf/include/Graphs/ICFGEdge.h
+++ b/svf/include/Graphs/ICFGEdge.h
@@ -139,13 +139,13 @@ public:
         return conditionVar;
     }
 
-    s32_t getSuccessorCondValue() const
+    s64_t getSuccessorCondValue() const
     {
         assert(getCondition() && "this is not a conditional branch edge");
         return branchCondVal;
     }
 
-    void setBranchCondition(const SVFValue* c, s32_t bVal)
+    void setBranchCondition(const SVFValue* c, s64_t bVal)
     {
         conditionVar = c;
         branchCondVal = bVal;
@@ -159,7 +159,7 @@ private:
     /// e.g., Inst1: br %cmp label 0, label 1,  Inst2 is label 0 and Inst 3 is label 1;
     /// for edge between Inst1 and Inst 2, the first element is %cmp and second element is 0
     const SVFValue* conditionVar;
-    s32_t branchCondVal;
+    s64_t branchCondVal;
 };
 
 /*!

--- a/svf/include/SVFIR/SVFStatements.h
+++ b/svf/include/SVFIR/SVFStatements.h
@@ -1048,7 +1048,7 @@ public:
     {
         return successors.at(i).first;
     }
-    s32_t getSuccessorCondValue (u32_t i) const
+    s64_t getSuccessorCondValue (u32_t i) const
     {
         return successors.at(i).second;
     }


### PR DESCRIPTION
When switch-case expression takes i128 type on case destination, getSExtValue raises assertion failure. This patch checks the bit width of ConstantInt and runs getSExtValue only if ConstantInt has a bit width smaller than 64.

Signed-off-by: ChoKyuWon <kyuwoncho18@gmail.com>