### PR TITLE
Passing `std::string` by const reference instead of by value

### DIFF
--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1186,7 +1186,7 @@ void SVFIRBuilder::parseOperations(std::vector<ExtAPI::Operation>  &operations, 
         std::vector<NodeID>& operands = operation.getOperands();
         if (operation.getOperator() == "funptr_ops" || operation.getOperator() == "Rb_tree_ops")
             continue;
-        for (std::string s: operation.getOperandStr())
+        for (const std::string& s : operation.getOperandStr())
         {
             // There is already a NodeID in nodeIDMap
             if (nodeIDMap.find(s) != nodeIDMap.end())

--- a/svf-llvm/tools/MTA/LockResultValidator.h
+++ b/svf-llvm/tools/MTA/LockResultValidator.h
@@ -80,12 +80,12 @@ private:
         return nullptr;
     }
 
-    inline bool inFilter(std::string name)
+    inline bool inFilter(const std::string& name)
     {
         return filterFun.find(name) != filterFun.end();
     }
 
-    inline bool match(std::string lockName, CxtLockSetStr LS)
+    inline bool match(const std::string& lockName, CxtLockSetStr LS)
     {
         return LS.find(lockName) != LS.end();
     }

--- a/svf/include/SVFIR/SVFModule.h
+++ b/svf/include/SVFIR/SVFModule.h
@@ -1,4 +1,4 @@
-//===- SVFModule.h -- SVFModule* class-----------------------------------------//
+//===- SVFModule.h -- SVFModule* class----------------------------------------//
 //
 //                     SVF: Static Value-Flow Analysis
 //
@@ -42,6 +42,7 @@ class SVFModule
 {
     friend class SVFModuleWrite;
     friend class SVFModuleRead;
+
 public:
     typedef std::vector<const SVFFunction*> FunctionSetType;
     typedef std::vector<SVFGlobalValue*> GlobalSetType;
@@ -67,14 +68,12 @@ private:
     FunctionSetType FunctionSet;  ///< The Functions in the module
     GlobalSetType GlobalSet;      ///< The Global Variables in the module
     AliasSetType AliasSet;        ///< The Aliases in the module
-    ConstantType ConstantSet;        ///< The ConstantData in the module
-    OtherValueType  OtherValueSet;   ///< All other values in the module
+    ConstantType ConstantSet;     ///< The ConstantData in the module
+    OtherValueType OtherValueSet; ///< All other values in the module
 
 public:
     /// Constructors
-    SVFModule(std::string moduleName = "") : moduleIdentifier(moduleName)
-    {
-    }
+    SVFModule(std::string moduleName = "") : moduleIdentifier(moduleName) {}
 
     ~SVFModule();
 

--- a/svf/include/SVFIR/SVFModuleRW.h
+++ b/svf/include/SVFIR/SVFModuleRW.h
@@ -1,3 +1,25 @@
+//===- SVFModuleRW.h -- SVFModuleReader* class--------------------------------//
+//
+//                     SVF: Static Value-Flow Analysis
+//
+// Copyright (C) <2013-2017>  <Yulei Sui>
+//
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//===----------------------------------------------------------------------===//
+
 /*
  * SVFModuleRW.h
  *

--- a/svf/include/SVFIR/SVFType.h
+++ b/svf/include/SVFIR/SVFType.h
@@ -1,4 +1,4 @@
-//===- SVFBasicTypes.h -- Basic types used in SVF-------------------------------//
+//===- SVFBasicTypes.h -- Basic types used in SVF-----------------------------//
 //
 //                     SVF: Static Value-Flow Analysis
 //
@@ -168,8 +168,11 @@ public:
     /// Destructor
     ~StInfo() = default;
 
-    ///  struct A { int id; int salary; }; struct B { char name[20]; struct A a;}  B b;
-    // OriginalFieldType of b with field_idx 1 : Struct A
+    ///  struct A { int id; int salary; };
+    ///  struct B { char name[20]; struct A a;}
+    ///  B b;
+    ///
+    ///  OriginalFieldType of b with field_idx 1 : Struct A
     ///  FlatternedFieldType of b with field_idx 1 : int
     //{@
     const SVFType* getOriginalElemType(u32_t fldIdx) const;

--- a/svf/include/Util/SVFUtil.h
+++ b/svf/include/Util/SVFUtil.h
@@ -70,27 +70,28 @@ void dumpSparseSet(const NodeBS& To);
 void dumpAliasSet(unsigned node, NodeBS To) ;
 
 /// Returns successful message by converting a string into green string output
-std::string sucMsg(std::string msg);
+std::string sucMsg(const std::string& msg);
 
 /// Returns warning message by converting a string into yellow string output
-std::string wrnMsg(std::string msg);
+std::string wrnMsg(const std::string& msg);
 
 /// Writes a message run through wrnMsg.
-void writeWrnMsg(std::string msg);
+void writeWrnMsg(const std::string& msg);
 
 /// Print error message by converting a string into red string output
 //@{
-std::string  errMsg(std::string msg);
-std::string  bugMsg1(std::string msg);
-std::string  bugMsg2(std::string msg);
-std::string  bugMsg3(std::string msg);
+std::string  errMsg(const std::string& msg);
+std::string  bugMsg1(const std::string& msg);
+std::string  bugMsg2(const std::string& msg);
+std::string  bugMsg3(const std::string& msg);
 //@}
 
 /// Print each pass/phase message by converting a string into blue string output
-std::string  pasMsg(std::string msg);
+std::string  pasMsg(const std::string& msg);
 
 /// Print memory usage in KB.
-void reportMemoryUsageKB(const std::string& infor, OutStream & O = SVFUtil::outs());
+void reportMemoryUsageKB(const std::string& infor,
+                         OutStream& O = SVFUtil::outs());
 
 /// Get memory usage from system file. Return TRUE if succeed.
 bool getMemoryUsageKB(u32_t* vmrss_kb, u32_t* vmsize_kb);

--- a/svf/lib/Util/SVFUtil.cpp
+++ b/svf/lib/Util/SVFUtil.cpp
@@ -50,7 +50,7 @@ using namespace SVF;
 /*!
  * print successful message by converting a string into green string output
  */
-std::string SVFUtil::sucMsg(std::string msg)
+std::string SVFUtil::sucMsg(const std::string& msg)
 {
     return KGRN + msg + KNRM;
 }
@@ -58,36 +58,37 @@ std::string SVFUtil::sucMsg(std::string msg)
 /*!
  * print warning message by converting a string into yellow string output
  */
-std::string SVFUtil::wrnMsg(std::string msg)
+std::string SVFUtil::wrnMsg(const std::string& msg)
 {
     return KYEL + msg + KNRM;
 }
 
-void SVFUtil::writeWrnMsg(std::string msg)
+void SVFUtil::writeWrnMsg(const std::string& msg)
 {
-    if(Options::DisableWarn()) return;
+    if (Options::DisableWarn())
+        return;
     outs() << wrnMsg(msg) << "\n";
 }
 
 /*!
  * print error message by converting a string into red string output
  */
-std::string SVFUtil::errMsg(std::string msg)
+std::string SVFUtil::errMsg(const std::string& msg)
 {
     return KRED + msg + KNRM;
 }
 
-std::string SVFUtil::bugMsg1(std::string msg)
+std::string SVFUtil::bugMsg1(const std::string& msg)
 {
     return KYEL + msg + KNRM;
 }
 
-std::string SVFUtil::bugMsg2(std::string msg)
+std::string SVFUtil::bugMsg2(const std::string& msg)
 {
     return KPUR + msg + KNRM;
 }
 
-std::string SVFUtil::bugMsg3(std::string msg)
+std::string SVFUtil::bugMsg3(const std::string& msg)
 {
     return KCYA + msg + KNRM;
 }
@@ -95,7 +96,7 @@ std::string SVFUtil::bugMsg3(std::string msg)
 /*!
  * print each pass/phase message by converting a string into blue string output
  */
-std::string SVFUtil::pasMsg(std::string msg)
+std::string SVFUtil::pasMsg(const std::string& msg)
 {
     return KBLU + msg + KNRM;
 }


### PR DESCRIPTION
Passing `std::string` requires a clone of a new string everytime, which is inefficient.
We should do with with `const std::string&` instead.