### PR TITLE
Undefined BB

### DIFF
--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1557,13 +1557,9 @@ void SVFIRBuilder::updateCallGraph(PTACallGraph* callgraph)
 
             if (isExtCall(*func_iter))
             {
-                if (callee->empty()) {
-                    // calling getEntryBlock (which calls `front()` of the fun's BBs)
-                    // for empty function will cause undefined behaviour
-                    setCurrentLocation(callee, nullptr);
-                } else {
-                    setCurrentLocation(callee, &callee->getEntryBlock());
-                }
+                // calling getEntryBlock (which calls `front()` of the fun's BBs)
+                // for empty function will cause undefined behaviour
+                setCurrentLocation(callee, callee->empty() ? nullptr : &callee->getEntryBlock());
                 handleExtCall(const_cast<CallBase*>(callbase), callee);
             }
             else

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1557,8 +1557,6 @@ void SVFIRBuilder::updateCallGraph(PTACallGraph* callgraph)
 
             if (isExtCall(*func_iter))
             {
-                // calling getEntryBlock (which calls `front()` of the fun's BBs)
-                // for empty function will cause undefined behaviour
                 setCurrentLocation(callee, callee->empty() ? nullptr : &callee->getEntryBlock());
                 handleExtCall(const_cast<CallBase*>(callbase), callee);
             }

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1557,7 +1557,13 @@ void SVFIRBuilder::updateCallGraph(PTACallGraph* callgraph)
 
             if (isExtCall(*func_iter))
             {
-                setCurrentLocation(callee, &callee->getEntryBlock());
+                if (callee->empty()) {
+                    // calling getEntryBlock (which calls `front()` of the fun's BBs)
+                    // for empty function will cause undefined behaviour
+                    setCurrentLocation(callee, nullptr);
+                } else {
+                    setCurrentLocation(callee, &callee->getEntryBlock());
+                }
                 handleExtCall(const_cast<CallBase*>(callbase), callee);
             }
             else


### PR DESCRIPTION
Calling getEntryBlock (which calls `front()` of the fun's BBs) for an empty function will cause undefined behaviour.