### PR TITLE
Making coding convention consistent

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMModule.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMModule.h
@@ -352,7 +352,7 @@ private:
     /// Invoke llvm passes to modify module
     void prePassSchedule();
     bool preProcessed;
-    void build_symbol_table() const;
+    void buildSymbolTable() const;
 };
 
 } // End namespace SVF

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -189,8 +189,7 @@ void LLVMModuleSet::createSVFDataStructure()
                 for (const Instruction& inst : bb)
                 {
                     SVFInstruction* svfInst = nullptr;
-                    if (const CallBase* call =
-                            SVFUtil::dyn_cast<CallBase>(&inst))
+                    if (const CallBase* call = SVFUtil::dyn_cast<CallBase>(&inst))
                     {
                         if (LLVMUtil::isVirtualCallSite(call))
                             svfInst = new SVFVirtualCallInst(
@@ -591,8 +590,11 @@ void LLVMModuleSet::addSVFMain()
         // Find main function
         for (auto &func : mod)
         {
-            assert(!func.getName().(SVF_MAIN_FUNC_NAME) && SVF_MAIN_FUNC_NAME " already defined");
-            if (func.getName().equals("main"))
+            auto funName = func.getName();
+
+            assert(!funName.equals(SVF_MAIN_FUNC_NAME) && SVF_MAIN_FUNC_NAME " already defined");
+
+            if (funName.equals("main"))
             {
                 orgMain = &func;
                 mainMod = &mod;
@@ -649,8 +651,7 @@ void LLVMModuleSet::addSVFMain()
         // emitted in the order of priority
         for (auto& dtor : dtor_funcs)
         {
-            auto target = M.getOrInsertFunction(
-                dtor->getName(), Type::getVoidTy(M.getContext()));
+            auto target = M.getOrInsertFunction(dtor->getName(), Type::getVoidTy(M.getContext()));
             Builder.CreateCall(target);
         }
         // return;
@@ -686,7 +687,7 @@ void LLVMModuleSet::buildFunToFunMap()
     // Find the intersectNames
     std::set_intersection(
         declNames.begin(), declNames.end(), defNames.begin(), defNames.end(),
-        std::inserter(intersectNames, intersectNames.begin()));
+        std::inserter(intersectNames, intersectNames.end()));
 
     ///// name to def map
     NameToFunDefMapTy nameToFunDefMap;

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -719,7 +719,7 @@ void LLVMModuleSet::buildFunToFunMap()
         string funName = fdecl->getName().str();
         NameToFunDefMapTy::iterator mit;
         if (intersectNames.find(funName) != intersectNames.end() &&
-            (mit = nameToFunDefMap.find(funName)) != nameToFunDefMap.end())
+                (mit = nameToFunDefMap.find(funName)) != nameToFunDefMap.end())
         {
             FunDeclToDefMap[fdecl] = mit->second;
         }

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -27,8 +27,9 @@
  *      Author: Xiaokang Fan
  */
 
-#include "Util/Options.h"
 #include <queue>
+#include <algorithm>
+#include "Util/Options.h"
 #include "SVFIR/SVFModule.h"
 #include "SVFIR/SVFModuleRW.h"
 #include "Util/SVFUtil.h"
@@ -95,7 +96,7 @@ SVFModule* LLVMModuleSet::buildSVFModule(Module &mod)
     double endSVFModuleTime = SVFStat::getClk(true);
     SVFStat::timeOfBuildingLLVMModule = (endSVFModuleTime - startSVFModuleTime)/TIMEINTERVAL;
 
-    build_symbol_table();
+    buildSymbolTable();
 
     return svfModule.get();
 }
@@ -118,12 +119,12 @@ SVFModule* LLVMModuleSet::buildSVFModule(const std::vector<std::string> &moduleN
     double endSVFModuleTime = SVFStat::getClk(true);
     SVFStat::timeOfBuildingLLVMModule = (endSVFModuleTime - startSVFModuleTime)/TIMEINTERVAL;
 
-    build_symbol_table();
+    buildSymbolTable();
 
     return svfModule.get();
 }
 
-void LLVMModuleSet::build_symbol_table() const
+void LLVMModuleSet::buildSymbolTable() const
 {
     double startSymInfoTime = SVFStat::getClk(true);
     if (!SVFModule::pagReadFromTXT())
@@ -134,7 +135,8 @@ void LLVMModuleSet::build_symbol_table() const
         builder.buildMemModel(svfModule.get());
     }
     double endSymInfoTime = SVFStat::getClk(true);
-    SVFStat::timeOfBuildingSymbolTable = (endSymInfoTime - startSymInfoTime)/TIMEINTERVAL;
+    SVFStat::timeOfBuildingSymbolTable =
+        (endSymInfoTime - startSymInfoTime) / TIMEINTERVAL;
 }
 
 void LLVMModuleSet::build()
@@ -158,67 +160,80 @@ void LLVMModuleSet::createSVFDataStructure()
     for (Module& mod : modules)
     {
         /// Function
-        for (Module::const_iterator it = mod.begin(), eit = mod.end(); it != eit; ++it)
+        for (const Function& func : mod.functions())
         {
-            const Function* func = &*it;
-            SVFLoopAndDomInfo* ld = new SVFLoopAndDomInfo();
-            SVFFunction* svfFunc = new SVFFunction(func->getName().str(), getSVFType(func->getType()), SVFUtil::cast<SVFFunctionType>(getSVFType(func->getFunctionType())), func->isDeclaration(), LLVMUtil::isIntrinsicFun(func), func->hasAddressTaken(), func->isVarArg(), ld);
+            SVFFunction* svfFunc = new SVFFunction(
+                func.getName().str(), getSVFType(func.getType()),
+                SVFUtil::cast<SVFFunctionType>(
+                    getSVFType(func.getFunctionType())),
+                func.isDeclaration(), LLVMUtil::isIntrinsicFun(&func),
+                func.hasAddressTaken(), func.isVarArg(), new SVFLoopAndDomInfo);
             svfModule->addFunctionSet(svfFunc);
-            addFunctionMap(func,svfFunc);
+            addFunctionMap(&func, svfFunc);
 
-            for (Function::const_arg_iterator I = func->arg_begin(), E = func->arg_end(); I != E; ++I)
+            for (const Argument& arg : func.args())
             {
-                const Argument* arg = &*I;
-                SVFArgument* svfarg = new SVFArgument(arg->getName().str(), getSVFType(arg->getType()), svfFunc, arg->getArgNo(), LLVMUtil::isArgOfUncalledFunction(arg));
+                SVFArgument* svfarg = new SVFArgument(
+                    arg.getName().str(), getSVFType(arg.getType()), svfFunc,
+                    arg.getArgNo(), LLVMUtil::isArgOfUncalledFunction(&arg));
                 svfFunc->addArgument(svfarg);
-                addArgumentMap(arg,svfarg);
+                addArgumentMap(&arg, svfarg);
             }
 
-            for (Function::const_iterator bit = func->begin(), ebit = func->end(); bit != ebit; ++bit)
+            for (const BasicBlock& bb : func)
             {
-                const BasicBlock* bb = &*bit;
-                SVFBasicBlock* svfBB = new SVFBasicBlock(bb->getName().str(), getSVFType(bb->getType()), svfFunc);
+                SVFBasicBlock* svfBB = new SVFBasicBlock(
+                    bb.getName().str(), getSVFType(bb.getType()), svfFunc);
                 svfFunc->addBasicBlock(svfBB);
-                addBasicBlockMap(bb,svfBB);
-                for (BasicBlock::const_iterator iit = bb->begin(), eiit = bb->end(); iit != eiit; ++iit)
+                addBasicBlockMap(&bb, svfBB);
+                for (const Instruction& inst : bb)
                 {
-                    const Instruction* inst = &*iit;
                     SVFInstruction* svfInst = nullptr;
-                    if(const CallBase* call = SVFUtil::dyn_cast<CallBase>(inst))
+                    if (const CallBase* call =
+                            SVFUtil::dyn_cast<CallBase>(&inst))
                     {
-                        if(LLVMUtil::isVirtualCallSite(call))
-                            svfInst = new SVFVirtualCallInst(call->getName().str(), getSVFType(call->getType()), svfBB,call->getFunctionType()->isVarArg(),inst->isTerminator());
+                        if (LLVMUtil::isVirtualCallSite(call))
+                            svfInst = new SVFVirtualCallInst(
+                                call->getName().str(),
+                                getSVFType(call->getType()), svfBB,
+                                call->getFunctionType()->isVarArg(),
+                                inst.isTerminator());
                         else
-                            svfInst = new SVFCallInst(call->getName().str(), getSVFType(call->getType()), svfBB,call->getFunctionType()->isVarArg(),inst->isTerminator());
+                            svfInst = new SVFCallInst(
+                                call->getName().str(),
+                                getSVFType(call->getType()), svfBB,
+                                call->getFunctionType()->isVarArg(),
+                                inst.isTerminator());
                     }
                     else
                     {
-                        svfInst = new SVFInstruction(inst->getName().str(),getSVFType(inst->getType()), svfBB, inst->isTerminator(), SVFUtil::isa<ReturnInst>(inst));
+                        svfInst = new SVFInstruction(
+                            inst.getName().str(), getSVFType(inst.getType()),
+                            svfBB, inst.isTerminator(),
+                            SVFUtil::isa<ReturnInst>(inst));
                     }
                     svfBB->addInstruction(svfInst);
-                    addInstructionMap(inst,svfInst);
+                    addInstructionMap(&inst, svfInst);
                 }
             }
         }
 
         /// GlobalVariable
-        for (Module::const_global_iterator it = mod.global_begin(),
-                eit = mod.global_end(); it != eit; ++it)
+        for (const GlobalVariable& global :  mod.globals())
         {
-            const GlobalVariable* global = &*it;
-            SVFGlobalValue* svfglobal = new SVFGlobalValue(global->getName().str(), getSVFType(global->getType()));
+            SVFGlobalValue* svfglobal = new SVFGlobalValue(
+                global.getName().str(), getSVFType(global.getType()));
             svfModule->addGlobalSet(svfglobal);
-            addGlobalValueMap(global,svfglobal);
+            addGlobalValueMap(&global, svfglobal);
         }
 
         /// GlobalAlias
-        for (Module::const_alias_iterator it = mod.alias_begin(),
-                eit = mod.alias_end(); it != eit; ++it)
+        for (const GlobalAlias& alias : mod.aliases())
         {
-            const GlobalAlias *alias = &*it;
-            SVFGlobalValue* svfalias = new SVFGlobalValue(alias->getName().str(), getSVFType(alias->getType()));
+            SVFGlobalValue* svfalias = new SVFGlobalValue(
+                alias.getName().str(), getSVFType(alias.getType()));
             svfModule->addAliasSet(svfalias);
-            addGlobalValueMap(alias,svfalias);
+            addGlobalValueMap(&alias, svfalias);
         }
     }
 }
@@ -228,15 +243,14 @@ void LLVMModuleSet::initSVFFunction()
     for (Module& mod : modules)
     {
         /// Function
-        for (Module::iterator it = mod.begin(), eit = mod.end(); it != eit; ++it)
+        for (const Function& f : mod.functions())
         {
-            const Function* f = &*it;
-            SVFFunction* svffun = getSVFFunction(f);
-            initSVFBasicBlock(f);
+            SVFFunction* svffun = getSVFFunction(&f);
+            initSVFBasicBlock(&f);
 
-            if (SVFUtil::isExtCall(svffun) == false)
+            if (!SVFUtil::isExtCall(svffun))
             {
-                initDomTree(svffun, f);
+                initDomTree(svffun, &f);
             }
         }
     }
@@ -554,36 +568,31 @@ std::vector<const Function* > LLVMModuleSet::getLLVMGlobalFunctions(const Global
 
 void LLVMModuleSet::addSVFMain()
 {
-    std::vector<const Function* > ctor_funcs;
-    std::vector<const Function* > dtor_funcs;
-    Function*  orgMain = 0;
+    std::vector<const Function*> ctor_funcs;
+    std::vector<const Function*> dtor_funcs;
+    Function* orgMain = 0;
     Module* mainMod = nullptr;
 
     for (Module &mod : modules)
     {
         // Collect ctor and dtor functions
-        for (Module::global_iterator it = mod.global_begin(), eit = mod.global_end(); it != eit; ++it)
+        for (const GlobalVariable& global : mod.globals())
         {
-            const GlobalVariable *global = &*it;
-
-            if (global->getName().equals(SVF_GLOBAL_CTORS) &&
-                    global->hasInitializer())
+            if (global.getName().equals(SVF_GLOBAL_CTORS) && global.hasInitializer())
             {
-                ctor_funcs = getLLVMGlobalFunctions(global);
+                ctor_funcs = getLLVMGlobalFunctions(&global);
             }
-            else if (global->getName().equals(SVF_GLOBAL_DTORS) &&
-                     global->hasInitializer())
+            else if (global.getName().equals(SVF_GLOBAL_DTORS) && global.hasInitializer())
             {
-                dtor_funcs = getLLVMGlobalFunctions(global);
+                dtor_funcs = getLLVMGlobalFunctions(&global);
             }
         }
 
         // Find main function
         for (auto &func : mod)
         {
-            if (func.getName().equals(SVF_MAIN_FUNC_NAME))
-                assert(false && SVF_MAIN_FUNC_NAME " already defined");
-            if(func.getName().equals("main"))
+            assert(!func.getName().(SVF_MAIN_FUNC_NAME) && SVF_MAIN_FUNC_NAME " already defined");
+            if (func.getName().equals("main"))
             {
                 orgMain = &func;
                 mainMod = &mod;
@@ -597,10 +606,10 @@ void LLVMModuleSet::addSVFMain()
             (ctor_funcs.size() > 0 || dtor_funcs.size() > 0))
     {
         assert(mainMod && "Module with main function not found.");
-        Module & M = *mainMod;
+        Module& M = *mainMod;
         // char **
-        Type*  i8ptr2 = PointerType::getInt8PtrTy(M.getContext())->getPointerTo();
-        Type*  i32 = IntegerType::getInt32Ty(M.getContext());
+        Type* i8ptr2 = PointerType::getInt8PtrTy(M.getContext())->getPointerTo();
+        Type* i32 = IntegerType::getInt32Ty(M.getContext());
         // define void @svf.main(i32, i8**, i8**)
 #if (LLVM_VERSION_MAJOR >= 9)
         FunctionCallee svfmainFn = M.getOrInsertFunction(
@@ -621,7 +630,7 @@ void LLVMModuleSet::addSVFMain()
         IRBuilder Builder(block);
         // emit "call void @ctor()". ctor_funcs is sorted so the functions are
         // emitted in the order of priority
-        for(auto & ctor: ctor_funcs)
+        for (auto& ctor : ctor_funcs)
         {
             auto target = M.getOrInsertFunction(
                               ctor->getName(),
@@ -632,18 +641,16 @@ void LLVMModuleSet::addSVFMain()
         // main() should be called after all ctor functions and before dtor
         // functions.
         Function::arg_iterator arg_it = svfmain->arg_begin();
-        Value*  args[] = {arg_it, arg_it + 1, arg_it + 2 };
+        Value* args[] = {arg_it, arg_it + 1, arg_it + 2};
         size_t cnt = orgMain->arg_size();
         assert(cnt <= 3 && "Too many arguments for main()");
-        Builder.CreateCall(orgMain, llvm::ArrayRef<Value*>(args,args + cnt));
+        Builder.CreateCall(orgMain, llvm::ArrayRef<Value*>(args, args + cnt));
         // emit "call void @dtor()". dtor_funcs is sorted so the functions are
         // emitted in the order of priority
-        for (auto &dtor : dtor_funcs)
+        for (auto& dtor : dtor_funcs)
         {
             auto target = M.getOrInsertFunction(
-                              dtor->getName(),
-                              Type::getVoidTy(M.getContext())
-                          );
+                dtor->getName(), Type::getVoidTy(M.getContext()));
             Builder.CreateCall(target);
         }
         // return;
@@ -662,107 +669,79 @@ void LLVMModuleSet::buildFunToFunMap()
     for (Module& mod : modules)
     {
         /// Function
-        for (Module::iterator it = mod.begin(), eit = mod.end(); it != eit; ++it)
+        for (const Function& fun : mod.functions())
         {
-            const Function* fun = &*it;
-            if (fun->isDeclaration())
+            if (fun.isDeclaration())
             {
-                funDecls.insert(fun);
-                declNames.insert(fun->getName().str());
+                funDecls.insert(&fun);
+                declNames.insert(fun.getName().str());
             }
             else
             {
-                funDefs.insert(fun);
-                defNames.insert(fun->getName().str());
+                funDefs.insert(&fun);
+                defNames.insert(fun.getName().str());
             }
         }
     }
     // Find the intersectNames
-    OrderedSet<string>::iterator declIter, defIter;
-    declIter = declNames.begin();
-    defIter = defNames.begin();
-    while (declIter != declNames.end() && defIter != defNames.end())
-    {
-        if (*declIter < *defIter)
-        {
-            declIter++;
-        }
-        else
-        {
-            if (!(*defIter < *declIter))
-            {
-                intersectNames.insert(*declIter);
-                declIter++;
-            }
-            defIter++;
-        }
-    }
+    std::set_intersection(
+        declNames.begin(), declNames.end(), defNames.begin(), defNames.end(),
+        std::inserter(intersectNames, intersectNames.begin()));
 
     ///// name to def map
     NameToFunDefMapTy nameToFunDefMap;
-    for (Set<const Function*>::iterator it = funDefs.begin(),
-            eit = funDefs.end(); it != eit; ++it)
+    for (const Function* fdef : funDefs)
     {
-        const Function* fdef = *it;
         string funName = fdef->getName().str();
-        if (intersectNames.find(funName) == intersectNames.end())
-            continue;
-        nameToFunDefMap[funName] = fdef;
+        if (intersectNames.find(funName) != intersectNames.end())
+        {
+            nameToFunDefMap.emplace(std::move(funName), fdef);
+        }
     }
 
     ///// name to decls map
     NameToFunDeclsMapTy nameToFunDeclsMap;
-    for (Set<const Function*>::iterator it = funDecls.begin(),
-            eit = funDecls.end(); it != eit; ++it)
+    for (const Function* fdecl : funDecls)
     {
-        const Function* fdecl = *it;
         string funName = fdecl->getName().str();
-        if (intersectNames.find(funName) == intersectNames.end())
-            continue;
-        NameToFunDeclsMapTy::iterator mit = nameToFunDeclsMap.find(funName);
-        if (mit == nameToFunDeclsMap.end())
+        if (intersectNames.find(funName) != intersectNames.end())
         {
-            Set<const Function*> decls;
-            decls.insert(fdecl);
-            nameToFunDeclsMap[funName] = decls;
-        }
-        else
-        {
-            Set<const Function*> &decls = mit->second;
-            decls.insert(fdecl);
+            // pair with key funName will be created automatically if it does
+            // not exist
+            nameToFunDeclsMap[std::move(funName)].insert(fdecl);
         }
     }
 
     /// Fun decl --> def
-    for (Set<const Function*>::iterator it = funDecls.begin(),
-            eit = funDecls.end(); it != eit; ++it)
+    for (const Function* fdecl : funDecls)
     {
-        const Function* fdecl = *it;
         string funName = fdecl->getName().str();
-        if (intersectNames.find(funName) == intersectNames.end())
-            continue;
-        NameToFunDefMapTy::iterator mit = nameToFunDefMap.find(funName);
-        if (mit == nameToFunDefMap.end())
-            continue;
-        FunDeclToDefMap[fdecl] = mit->second;
+        NameToFunDefMapTy::iterator mit;
+        if (intersectNames.find(funName) != intersectNames.end() &&
+            (mit = nameToFunDefMap.find(funName)) != nameToFunDefMap.end())
+        {
+            FunDeclToDefMap[fdecl] = mit->second;
+        }
     }
 
     /// Fun def --> decls
-    for (Set<const Function*>::iterator it = funDefs.begin(),
-            eit = funDefs.end(); it != eit; ++it)
+    for (const Function* fdef : funDefs)
     {
-        const Function* fdef = *it;
         string funName = fdef->getName().str();
         if (intersectNames.find(funName) == intersectNames.end())
             continue;
         NameToFunDeclsMapTy::iterator mit = nameToFunDeclsMap.find(funName);
         if (mit == nameToFunDeclsMap.end())
             continue;
+
         std::vector<const Function*>& decls = FunDefToDeclsMap[fdef];
-        for (Set<const Function*>::iterator sit = mit->second.begin(),
-                seit = mit->second.end(); sit != seit; ++sit)
+        const auto& declsSet = mit->second;
+        // Reserve space for decls to avoid more than 1 reallocation
+        decls.reserve(decls.size() + declsSet.size());
+
+        for (const Function* decl : declsSet)
         {
-            decls.push_back(*sit);
+            decls.push_back(decl);
         }
     }
 }
@@ -774,49 +753,27 @@ void LLVMModuleSet::buildGlobalDefToRepMap()
     for (Module &mod : modules)
     {
         // Collect ctor and dtor functions
-        for (Module::global_iterator it = mod.global_begin(), eit = mod.global_end(); it != eit; ++it)
+        for (GlobalVariable& global : mod.globals())
         {
-            GlobalVariable *global = &*it;
-            if (global->hasPrivateLinkage())
+            if (global.hasPrivateLinkage())
                 continue;
-            string name = global->getName().str();
+            string name = global.getName().str();
             if (name.empty())
                 continue;
-            NameToGlobalsMapTy::iterator mit = nameToGlobalsMap.find(name);
-            if (mit == nameToGlobalsMap.end())
-            {
-                Set<GlobalVariable*> globals;
-                globals.insert(global);
-                nameToGlobalsMap[name] = globals;
-            }
-            else
-            {
-                Set<GlobalVariable*> &globals = mit->second;
-                globals.insert(global);
-            }
+            nameToGlobalsMap[std::move(name)].insert(&global);
         }
     }
 
-    for (NameToGlobalsMapTy::iterator it = nameToGlobalsMap.begin(),
-            eit = nameToGlobalsMap.end(); it != eit; ++it)
+    for (auto& pair : nameToGlobalsMap)
     {
-        Set<GlobalVariable*> &globals = it->second;
-        GlobalVariable *rep = *(globals.begin());
+        Set<GlobalVariable*>& globals = pair.second;
         Set<GlobalVariable*>::iterator repit = globals.begin();
-        while (repit != globals.end())
+        auto it = std::find_if(globals.begin(), globals.end(),
+                               GlobalVariable::hasInitializer);
+        GlobalVariable* rep = it == globals.end() ? *repit : *it;
+
+        for (GlobalVariable* cur : globals)
         {
-            GlobalVariable *cur = *repit;
-            if (cur->hasInitializer())
-            {
-                rep = cur;
-                break;
-            }
-            repit++;
-        }
-        for (Set<GlobalVariable*>::iterator sit = globals.begin(),
-                seit = globals.end(); sit != seit; ++sit)
-        {
-            GlobalVariable *cur = *sit;
             GlobalDefToRepMap[cur] = rep;
         }
     }

--- a/svf-llvm/lib/SymbolTableBuilder.cpp
+++ b/svf-llvm/lib/SymbolTableBuilder.cpp
@@ -50,7 +50,7 @@ MemObj* SymbolTableBuilder::createBlkObj(SymID symId)
     LLVMModuleSet* llvmset = LLVMModuleSet::getLLVMModuleSet();
     MemObj* obj =
         new MemObj(symId, symInfo->createObjTypeInfo(llvmset->getSVFType(
-                              IntegerType::get(llvmset->getContext(), 32))));
+                       IntegerType::get(llvmset->getContext(), 32))));
     symInfo->objMap[symId] = obj;
     return obj;
 }
@@ -62,7 +62,7 @@ MemObj* SymbolTableBuilder::createConstantObj(SymID symId)
     LLVMModuleSet* llvmset = LLVMModuleSet::getLLVMModuleSet();
     MemObj* obj =
         new MemObj(symId, symInfo->createObjTypeInfo(llvmset->getSVFType(
-                              IntegerType::get(llvmset->getContext(), 32))));
+                       IntegerType::get(llvmset->getContext(), 32))));
     symInfo->objMap[symId] = obj;
     return obj;
 }
@@ -466,7 +466,7 @@ void SymbolTableBuilder::handleCE(const Value* val)
         }
         else
         {
-            assert(SVFUtil::isa<ConstantExpr>(val) &&
+            assert(!SVFUtil::isa<ConstantExpr>(val) &&
                    "we don't handle all other constant expression for now!");
             collectVal(ref);
         }

--- a/svf-llvm/lib/SymbolTableBuilder.cpp
+++ b/svf-llvm/lib/SymbolTableBuilder.cpp
@@ -196,8 +196,7 @@ void SymbolTableBuilder::buildMemModel(SVFModule* svfModule)
                 else if (const BranchInst* br =
                              SVFUtil::dyn_cast<BranchInst>(&inst))
                 {
-                    Value* opnd = br->isConditional() ? br->getCondition()
-                                                      : br->getOperand(0);
+                    Value* opnd = br->isConditional() ? br->getCondition() : br->getOperand(0);
                     collectSym(opnd);
                 }
                 else if (const SwitchInst* sw =
@@ -205,8 +204,7 @@ void SymbolTableBuilder::buildMemModel(SVFModule* svfModule)
                 {
                     collectSym(sw->getCondition());
                 }
-                else if (isNonInstricCallSite(LLVMModuleSet::getLLVMModuleSet()
-                                                  ->getSVFInstruction(&inst)))
+                else if (isNonInstricCallSite(LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(&inst)))
                 {
 
                     const CallBase* cs = LLVMUtil::getLLVMCallSite(&inst);
@@ -245,9 +243,9 @@ void SymbolTableBuilder::collectSVFTypeInfo(const Value* val)
     if(isGepConstantExpr(val) || SVFUtil::isa<GetElementPtrInst>(val))
     {
         for (bridge_gep_iterator
-                 gi = bridge_gep_begin(SVFUtil::cast<User>(val)),
-                 ge = bridge_gep_end(SVFUtil::cast<User>(val));
-             gi != ge; ++gi)
+                gi = bridge_gep_begin(SVFUtil::cast<User>(val)),
+                ge = bridge_gep_end(SVFUtil::cast<User>(val));
+                gi != ge; ++gi)
         {
             const Type* gepTy = *gi;
             (void)getOrAddSVFTypeInfo(gepTy);
@@ -265,9 +263,9 @@ void SymbolTableBuilder::collectSym(const Value* val)
 
     DBOUT(DMemModel,
           outs()
-              << "collect sym from ##"
-              << LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val)->toString()
-              << " \n");
+          << "collect sym from ##"
+          << LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val)->toString()
+          << " \n");
     //TODO handle constant expression value here??
     handleCE(val);
 
@@ -295,7 +293,7 @@ void SymbolTableBuilder::collectVal(const Value* val)
         return;
     }
     SymbolTableInfo::ValueToIDMapTy::iterator iter = symInfo->valSymMap.find(
-        LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
+                LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
     if (iter == symInfo->valSymMap.end())
     {
         // create val sym and sym type
@@ -320,7 +318,7 @@ void SymbolTableBuilder::collectObj(const Value* val)
 {
     val = LLVMUtil::getGlobalRep(val);
     SymbolTableInfo::ValueToIDMapTy::iterator iter = symInfo->objSymMap.find(
-        LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
+                LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
     if (iter == symInfo->objSymMap.end())
     {
         SVFValue* svfVal = LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val);
@@ -393,10 +391,10 @@ void SymbolTableBuilder::handleCE(const Value* val)
         if (const ConstantExpr* ce = isGepConstantExpr(ref))
         {
             DBOUT(DMemModelCE, outs() << "handle constant expression "
-                                      << LLVMModuleSet::getLLVMModuleSet()
-                                             ->getSVFValue(ref)
-                                             ->toString()
-                                      << "\n");
+                  << LLVMModuleSet::getLLVMModuleSet()
+                  ->getSVFValue(ref)
+                  ->toString()
+                  << "\n");
             collectVal(ce);
 
             // handle the recursive constant express case
@@ -410,10 +408,10 @@ void SymbolTableBuilder::handleCE(const Value* val)
         else if (const ConstantExpr* ce = isCastConstantExpr(ref))
         {
             DBOUT(DMemModelCE, outs() << "handle constant expression "
-                                      << LLVMModuleSet::getLLVMModuleSet()
-                                             ->getSVFValue(ref)
-                                             ->toString()
-                                      << "\n");
+                  << LLVMModuleSet::getLLVMModuleSet()
+                  ->getSVFValue(ref)
+                  ->toString()
+                  << "\n");
             collectVal(ce);
             collectVal(ce->getOperand(0));
             // handle the recursive constant express case
@@ -423,10 +421,10 @@ void SymbolTableBuilder::handleCE(const Value* val)
         else if (const ConstantExpr* ce = isSelectConstantExpr(ref))
         {
             DBOUT(DMemModelCE, outs() << "handle constant expression "
-                                      << LLVMModuleSet::getLLVMModuleSet()
-                                             ->getSVFValue(ref)
-                                             ->toString()
-                                      << "\n");
+                  << LLVMModuleSet::getLLVMModuleSet()
+                  ->getSVFValue(ref)
+                  ->toString()
+                  << "\n");
             collectVal(ce);
             collectVal(ce->getOperand(0));
             collectVal(ce->getOperand(1));
@@ -550,7 +548,7 @@ void SymbolTableBuilder::handleGlobalInitializerCE(const Constant* C)
         if (Options::ModelConsts())
         {
             if (const ConstantDataSequential* seq =
-                    SVFUtil::dyn_cast<ConstantDataSequential>(data))
+                        SVFUtil::dyn_cast<ConstantDataSequential>(data))
             {
                 for(u32_t i = 0; i < seq->getNumElements(); i++)
                 {
@@ -638,9 +636,9 @@ void SymbolTableBuilder::analyzeObjType(ObjTypeInfo* typeinfo, const Value* val)
         if (elemTy->isPointerTy())
             isPtrObj = true;
         if (SVFUtil::isa<GlobalVariable>(val) &&
-            SVFUtil::cast<GlobalVariable>(val)->hasInitializer() &&
-            SVFUtil::isa<ConstantArray>(
-                SVFUtil::cast<GlobalVariable>(val)->getInitializer()))
+                SVFUtil::cast<GlobalVariable>(val)->hasInitializer() &&
+                SVFUtil::isa<ConstantArray>(
+                    SVFUtil::cast<GlobalVariable>(val)->getInitializer()))
             typeinfo->setFlag(ObjTypeInfo::CONST_ARRAY_OBJ);
         else
             typeinfo->setFlag(ObjTypeInfo::VAR_ARRAY_OBJ);
@@ -650,11 +648,14 @@ void SymbolTableBuilder::analyzeObjType(ObjTypeInfo* typeinfo, const Value* val)
         const std::vector<const SVFType*>& flattenFields =
             getOrAddSVFTypeInfo(ST)->getFlattenFieldTypes();
         isPtrObj |= std::any_of(flattenFields.begin(), flattenFields.end(),
-                                SVFType::isPointerTy);
+                                [](const SVFType* ty)
+        {
+            return ty->isPointerTy();
+        });
         if (SVFUtil::isa<GlobalVariable>(val) &&
-            SVFUtil::cast<GlobalVariable>(val)->hasInitializer() &&
-            SVFUtil::isa<ConstantStruct>(
-                SVFUtil::cast<GlobalVariable>(val)->getInitializer()))
+                SVFUtil::cast<GlobalVariable>(val)->hasInitializer() &&
+                SVFUtil::isa<ConstantStruct>(
+                    SVFUtil::cast<GlobalVariable>(val)->getInitializer()))
             typeinfo->setFlag(ObjTypeInfo::CONST_STRUCT_OBJ);
         else
             typeinfo->setFlag(ObjTypeInfo::VAR_STRUCT_OBJ);

--- a/svf-llvm/lib/SymbolTableBuilder.cpp
+++ b/svf-llvm/lib/SymbolTableBuilder.cpp
@@ -48,7 +48,9 @@ MemObj* SymbolTableBuilder::createBlkObj(SymID symId)
     assert(symInfo->isBlkObj(symId));
     assert(symInfo->objMap.find(symId)==symInfo->objMap.end());
     LLVMModuleSet* llvmset = LLVMModuleSet::getLLVMModuleSet();
-    MemObj* obj = new MemObj(symId, symInfo->createObjTypeInfo(llvmset->getSVFType(IntegerType::get(llvmset->getContext(), 32))));
+    MemObj* obj =
+        new MemObj(symId, symInfo->createObjTypeInfo(llvmset->getSVFType(
+                              IntegerType::get(llvmset->getContext(), 32))));
     symInfo->objMap[symId] = obj;
     return obj;
 }
@@ -58,7 +60,9 @@ MemObj* SymbolTableBuilder::createConstantObj(SymID symId)
     assert(symInfo->isConstantObj(symId));
     assert(symInfo->objMap.find(symId)==symInfo->objMap.end());
     LLVMModuleSet* llvmset = LLVMModuleSet::getLLVMModuleSet();
-    MemObj* obj = new MemObj(symId, symInfo->createObjTypeInfo(llvmset->getSVFType(IntegerType::get(llvmset->getContext(), 32))));
+    MemObj* obj =
+        new MemObj(symId, symInfo->createObjTypeInfo(llvmset->getSVFType(
+                              IntegerType::get(llvmset->getContext(), 32))));
     symInfo->objMap[symId] = obj;
     return obj;
 }
@@ -90,64 +94,63 @@ void SymbolTableBuilder::buildMemModel(SVFModule* svfModule)
     for (Module &M : LLVMModuleSet::getLLVMModuleSet()->getLLVMModules())
     {
         // Add symbols for all the globals .
-        for (Module::global_iterator I = M.global_begin(), E = M.global_end(); I != E; ++I)
+        for (const GlobalVariable& gv : M.globals())
         {
-            collectSym(&*I);
+            collectSym(&gv);
         }
 
         // Add symbols for all the global aliases
-        for (Module::alias_iterator I = M.alias_begin(), E = M.alias_end(); I != E; I++)
+        for (const GlobalAlias& ga : M.aliases())
         {
-            collectSym(&*I);
-            collectSym((&*I)->getAliasee());
+            collectSym(&ga);
+            collectSym(ga.getAliasee());
         }
 
         // Add symbols for all of the functions and the instructions in them.
-        for (Module::const_iterator F = M.begin(), E = M.end(); F != E; ++F)
+        for (const Function& fun : M.functions())
         {
-            const Function *fun = &*F;
-            collectSym(fun);
-            collectRet(fun);
-            if (fun->getFunctionType()->isVarArg())
-                collectVararg(fun);
+            collectSym(&fun);
+            collectRet(&fun);
+            if (fun.getFunctionType()->isVarArg())
+                collectVararg(&fun);
 
             // Add symbols for all formal parameters.
-            for (Function::const_arg_iterator I = fun->arg_begin(), E = fun->arg_end();
-                    I != E; ++I)
+            for (const Argument& arg : fun.args())
             {
-                collectSym(&*I);
+                collectSym(&arg);
             }
 
             // collect and create symbols inside the function body
-            for (const_inst_iterator II = inst_begin(*fun), E = inst_end(*fun); II != E; ++II)
+            for (const Instruction& inst : instructions(fun))
             {
-                const Instruction* inst = &*II;
-                collectSym(inst);
+                collectSym(&inst);
 
                 // initialization for some special instructions
                 //{@
-                if (const StoreInst *st = SVFUtil::dyn_cast<StoreInst>(inst))
+                if (const StoreInst* st = SVFUtil::dyn_cast<StoreInst>(&inst))
                 {
                     collectSym(st->getPointerOperand());
                     collectSym(st->getValueOperand());
                 }
-                else if (const LoadInst *ld = SVFUtil::dyn_cast<LoadInst>(inst))
+                else if (const LoadInst* ld =
+                             SVFUtil::dyn_cast<LoadInst>(&inst))
                 {
                     collectSym(ld->getPointerOperand());
                 }
-                else if (const AllocaInst *alloc = SVFUtil::dyn_cast<AllocaInst>(inst))
+                else if (const AllocaInst* alloc =
+                             SVFUtil::dyn_cast<AllocaInst>(&inst))
                 {
                     collectSym(alloc->getArraySize());
                 }
-                else if (const PHINode *phi = SVFUtil::dyn_cast<PHINode>(inst))
+                else if (const PHINode* phi = SVFUtil::dyn_cast<PHINode>(&inst))
                 {
                     for (u32_t i = 0; i < phi->getNumIncomingValues(); ++i)
                     {
                         collectSym(phi->getIncomingValue(i));
                     }
                 }
-                else if (const GetElementPtrInst *gep = SVFUtil::dyn_cast<GetElementPtrInst>(
-                        inst))
+                else if (const GetElementPtrInst* gep =
+                             SVFUtil::dyn_cast<GetElementPtrInst>(&inst))
                 {
                     collectSym(gep->getPointerOperand());
                     for (u32_t i = 0; i < gep->getNumOperands(); ++i)
@@ -155,61 +158,69 @@ void SymbolTableBuilder::buildMemModel(SVFModule* svfModule)
                         collectSym(gep->getOperand(i));
                     }
                 }
-                else if (const SelectInst *sel = SVFUtil::dyn_cast<SelectInst>(inst))
+                else if (const SelectInst* sel =
+                             SVFUtil::dyn_cast<SelectInst>(&inst))
                 {
                     collectSym(sel->getTrueValue());
                     collectSym(sel->getFalseValue());
                     collectSym(sel->getCondition());
                 }
-                else if (const BinaryOperator *binary = SVFUtil::dyn_cast<BinaryOperator>(inst))
+                else if (const BinaryOperator* binary =
+                             SVFUtil::dyn_cast<BinaryOperator>(&inst))
                 {
                     for (u32_t i = 0; i < binary->getNumOperands(); i++)
                         collectSym(binary->getOperand(i));
                 }
-                else if (const UnaryOperator *unary = SVFUtil::dyn_cast<UnaryOperator>(inst))
+                else if (const UnaryOperator* unary =
+                             SVFUtil::dyn_cast<UnaryOperator>(&inst))
                 {
                     for (u32_t i = 0; i < unary->getNumOperands(); i++)
                         collectSym(unary->getOperand(i));
                 }
-                else if (const CmpInst *cmp = SVFUtil::dyn_cast<CmpInst>(inst))
+                else if (const CmpInst* cmp = SVFUtil::dyn_cast<CmpInst>(&inst))
                 {
                     for (u32_t i = 0; i < cmp->getNumOperands(); i++)
                         collectSym(cmp->getOperand(i));
                 }
-                else if (const CastInst *cast = SVFUtil::dyn_cast<CastInst>(inst))
+                else if (const CastInst* cast =
+                             SVFUtil::dyn_cast<CastInst>(&inst))
                 {
                     collectSym(cast->getOperand(0));
                 }
-                else if (const ReturnInst *ret = SVFUtil::dyn_cast<ReturnInst>(inst))
+                else if (const ReturnInst* ret =
+                             SVFUtil::dyn_cast<ReturnInst>(&inst))
                 {
-                    if(ret->getReturnValue())
+                    if (ret->getReturnValue())
                         collectSym(ret->getReturnValue());
                 }
-                else if (const BranchInst *br = SVFUtil::dyn_cast<BranchInst>(inst))
+                else if (const BranchInst* br =
+                             SVFUtil::dyn_cast<BranchInst>(&inst))
                 {
-                    Value* opnd = br->isConditional() ? br->getCondition() : br->getOperand(0);
+                    Value* opnd = br->isConditional() ? br->getCondition()
+                                                      : br->getOperand(0);
                     collectSym(opnd);
                 }
-                else if (const SwitchInst *sw = SVFUtil::dyn_cast<SwitchInst>(inst))
+                else if (const SwitchInst* sw =
+                             SVFUtil::dyn_cast<SwitchInst>(&inst))
                 {
                     collectSym(sw->getCondition());
                 }
-                else if (isNonInstricCallSite(LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(inst)))
+                else if (isNonInstricCallSite(LLVMModuleSet::getLLVMModuleSet()
+                                                  ->getSVFInstruction(&inst)))
                 {
 
-                    const CallBase* cs = LLVMUtil::getLLVMCallSite(inst);
+                    const CallBase* cs = LLVMUtil::getLLVMCallSite(&inst);
                     for (u32_t i = 0; i < cs->arg_size(); i++)
                     {
                         collectSym(cs->getArgOperand(i));
                     }
-                    // Calls to inline asm need to be added as well because the callee isn't
-                    // referenced anywhere else.
-                    const Value *Callee = cs->getCalledOperand();
+                    // Calls to inline asm need to be added as well because the
+                    // callee isn't referenced anywhere else.
+                    const Value* Callee = cs->getCalledOperand();
                     collectSym(Callee);
 
-                    //TODO handle inlineAsm
-                    ///if (SVFUtil::isa<InlineAsm>(Callee))
-
+                    // TODO handle inlineAsm
+                    /// if (SVFUtil::isa<InlineAsm>(Callee))
                 }
                 //@}
             }
@@ -233,8 +244,10 @@ void SymbolTableBuilder::collectSVFTypeInfo(const Value* val)
     }
     if(isGepConstantExpr(val) || SVFUtil::isa<GetElementPtrInst>(val))
     {
-        for (bridge_gep_iterator gi = bridge_gep_begin(SVFUtil::cast<User>(val)), ge = bridge_gep_end(SVFUtil::cast<User>(val));
-                gi != ge; ++gi)
+        for (bridge_gep_iterator
+                 gi = bridge_gep_begin(SVFUtil::cast<User>(val)),
+                 ge = bridge_gep_end(SVFUtil::cast<User>(val));
+             gi != ge; ++gi)
         {
             const Type* gepTy = *gi;
             (void)getOrAddSVFTypeInfo(gepTy);
@@ -245,12 +258,16 @@ void SymbolTableBuilder::collectSVFTypeInfo(const Value* val)
 /*!
  * Collect symbols, including value and object syms
  */
-void SymbolTableBuilder::collectSym(const Value *val)
+void SymbolTableBuilder::collectSym(const Value* val)
 {
 
     //TODO: filter the non-pointer type // if (!SVFUtil::isa<PointerType>(val->getType()))  return;
 
-    DBOUT(DMemModel, outs() << "collect sym from ##" << LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val)->toString() << " \n");
+    DBOUT(DMemModel,
+          outs()
+              << "collect sym from ##"
+              << LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val)->toString()
+              << " \n");
     //TODO handle constant expression value here??
     handleCE(val);
 
@@ -270,14 +287,15 @@ void SymbolTableBuilder::collectSym(const Value *val)
 /*!
  * Get value sym, if not available create a new one
  */
-void SymbolTableBuilder::collectVal(const Value *val)
+void SymbolTableBuilder::collectVal(const Value* val)
 {
     // collect and record special sym here
     if (LLVMUtil::isNullPtrSym(val) || LLVMUtil::isBlackholeSym(val))
     {
         return;
     }
-    SymbolTableInfo::ValueToIDMapTy::iterator iter = symInfo->valSymMap.find(LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
+    SymbolTableInfo::ValueToIDMapTy::iterator iter = symInfo->valSymMap.find(
+        LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
     if (iter == symInfo->valSymMap.end())
     {
         // create val sym and sym type
@@ -298,10 +316,11 @@ void SymbolTableBuilder::collectVal(const Value *val)
 /*!
  * Get memory object sym, if not available create a new one
  */
-void SymbolTableBuilder::collectObj(const Value *val)
+void SymbolTableBuilder::collectObj(const Value* val)
 {
     val = LLVMUtil::getGlobalRep(val);
-    SymbolTableInfo::ValueToIDMapTy::iterator iter = symInfo->objSymMap.find(LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
+    SymbolTableInfo::ValueToIDMapTy::iterator iter = symInfo->objSymMap.find(
+        LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
     if (iter == symInfo->objSymMap.end())
     {
         SVFValue* svfVal = LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val);
@@ -321,7 +340,9 @@ void SymbolTableBuilder::collectObj(const Value *val)
                   outs() << "create a new obj sym " << id << "\n");
 
             // create a memory object
-            MemObj* mem = new MemObj(id, createObjTypeInfo(val), LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
+            MemObj* mem =
+                new MemObj(id, createObjTypeInfo(val),
+                           LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val));
             assert(symInfo->objMap.find(id) == symInfo->objMap.end());
             symInfo->objMap[id] = mem;
         }
@@ -331,47 +352,51 @@ void SymbolTableBuilder::collectObj(const Value *val)
 /*!
  * Create unique return sym, if not available create a new one
  */
-void SymbolTableBuilder::collectRet(const Function *val)
+void SymbolTableBuilder::collectRet(const Function* val)
 {
-    const SVFFunction* svffun = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(val);
-    SymbolTableInfo::FunToIDMapTy::iterator iter = symInfo->returnSymMap.find(svffun);
+    const SVFFunction* svffun =
+        LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(val);
+    SymbolTableInfo::FunToIDMapTy::iterator iter =
+        symInfo->returnSymMap.find(svffun);
     if (iter == symInfo->returnSymMap.end())
     {
         SymID id = NodeIDAllocator::get()->allocateValueId();
         symInfo->returnSymMap.insert(std::make_pair(svffun, id));
-        DBOUT(DMemModel,
-              outs() << "create a return sym " << id << "\n");
+        DBOUT(DMemModel, outs() << "create a return sym " << id << "\n");
     }
 }
 
 /*!
  * Create vararg sym, if not available create a new one
  */
-void SymbolTableBuilder::collectVararg(const Function *val)
+void SymbolTableBuilder::collectVararg(const Function* val)
 {
-    const SVFFunction* svffun = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(val);
-    SymbolTableInfo::FunToIDMapTy::iterator iter = symInfo->varargSymMap.find(svffun);
+    const SVFFunction* svffun =
+        LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(val);
+    SymbolTableInfo::FunToIDMapTy::iterator iter =
+        symInfo->varargSymMap.find(svffun);
     if (iter == symInfo->varargSymMap.end())
     {
         SymID id = NodeIDAllocator::get()->allocateValueId();
         symInfo->varargSymMap.insert(std::make_pair(svffun, id));
-        DBOUT(DMemModel,
-              outs() << "create a vararg sym " << id << "\n");
+        DBOUT(DMemModel, outs() << "create a vararg sym " << id << "\n");
     }
 }
-
 
 /*!
  * Handle constant expression
  */
-void SymbolTableBuilder::handleCE(const Value *val)
+void SymbolTableBuilder::handleCE(const Value* val)
 {
     if (const Constant* ref = SVFUtil::dyn_cast<Constant>(val))
     {
         if (const ConstantExpr* ce = isGepConstantExpr(ref))
         {
-            DBOUT(DMemModelCE,
-                  outs() << "handle constant expression " << LLVMModuleSet::getLLVMModuleSet()->getSVFValue(ref)->toString() << "\n");
+            DBOUT(DMemModelCE, outs() << "handle constant expression "
+                                      << LLVMModuleSet::getLLVMModuleSet()
+                                             ->getSVFValue(ref)
+                                             ->toString()
+                                      << "\n");
             collectVal(ce);
 
             // handle the recursive constant express case
@@ -384,8 +409,11 @@ void SymbolTableBuilder::handleCE(const Value *val)
         }
         else if (const ConstantExpr* ce = isCastConstantExpr(ref))
         {
-            DBOUT(DMemModelCE,
-                  outs() << "handle constant expression " << LLVMModuleSet::getLLVMModuleSet()->getSVFValue(ref)->toString() << "\n");
+            DBOUT(DMemModelCE, outs() << "handle constant expression "
+                                      << LLVMModuleSet::getLLVMModuleSet()
+                                             ->getSVFValue(ref)
+                                             ->toString()
+                                      << "\n");
             collectVal(ce);
             collectVal(ce->getOperand(0));
             // handle the recursive constant express case
@@ -394,8 +422,11 @@ void SymbolTableBuilder::handleCE(const Value *val)
         }
         else if (const ConstantExpr* ce = isSelectConstantExpr(ref))
         {
-            DBOUT(DMemModelCE,
-                  outs() << "handle constant expression " << LLVMModuleSet::getLLVMModuleSet()->getSVFValue(ref)->toString() << "\n");
+            DBOUT(DMemModelCE, outs() << "handle constant expression "
+                                      << LLVMModuleSet::getLLVMModuleSet()
+                                             ->getSVFValue(ref)
+                                             ->toString()
+                                      << "\n");
             collectVal(ce);
             collectVal(ce->getOperand(0));
             collectVal(ce->getOperand(1));
@@ -407,14 +438,14 @@ void SymbolTableBuilder::handleCE(const Value *val)
             handleCE(ce->getOperand(2));
         }
         // if we meet a int2ptr, then it points-to black hole
-        else if (const ConstantExpr *int2Ptrce = isInt2PtrConstantExpr(ref))
+        else if (const ConstantExpr* int2Ptrce = isInt2PtrConstantExpr(ref))
         {
             collectVal(int2Ptrce);
         }
-        else if (const ConstantExpr *ptr2Intce = isPtr2IntConstantExpr(ref))
+        else if (const ConstantExpr* ptr2Intce = isPtr2IntConstantExpr(ref))
         {
             collectVal(ptr2Intce);
-            const Constant *opnd = ptr2Intce->getOperand(0);
+            const Constant* opnd = ptr2Intce->getOperand(0);
             handleCE(opnd);
         }
         else if (isTruncConstantExpr(ref) || isCmpConstantExpr(ref))
@@ -437,8 +468,8 @@ void SymbolTableBuilder::handleCE(const Value *val)
         }
         else
         {
-            if (SVFUtil::isa<ConstantExpr>(val))
-                assert(false && "we don't handle all other constant expression for now!");
+            assert(SVFUtil::isa<ConstantExpr>(val) &&
+                   "we don't handle all other constant expression for now!");
             collectVal(ref);
         }
     }
@@ -447,7 +478,7 @@ void SymbolTableBuilder::handleCE(const Value *val)
 /*!
  * Handle global constant expression
  */
-void SymbolTableBuilder::handleGlobalCE(const GlobalVariable *G)
+void SymbolTableBuilder::handleGlobalCE(const GlobalVariable* G)
 {
     assert(G);
 
@@ -455,30 +486,25 @@ void SymbolTableBuilder::handleGlobalCE(const GlobalVariable *G)
     const Type* T = G->getValueType();
     bool is_array = 0;
     //An array is considered a single variable of its type.
-    while (const ArrayType *AT = SVFUtil::dyn_cast<ArrayType>(T))
+    while (const ArrayType* AT = SVFUtil::dyn_cast<ArrayType>(T))
     {
         T = AT->getElementType();
-        is_array = 1;
+        is_array = true;
     }
 
     if (SVFUtil::isa<StructType>(T))
     {
         //A struct may be used in constant GEP expr.
-        for (Value::const_user_iterator it = G->user_begin(), ie = G->user_end();
-                it != ie; ++it)
+        for (const User* user : G->users())
         {
-            handleCE(*it);
+            handleCE(user);
         }
     }
-    else
+    else if (is_array)
     {
-        if (is_array)
+        for (const User* user : G->users())
         {
-            for (Value::const_user_iterator it = G->user_begin(), ie =
-                        G->user_end(); it != ie; ++it)
-            {
-                handleCE(*it);
-            }
+            handleCE(user);
         }
     }
 
@@ -491,12 +517,12 @@ void SymbolTableBuilder::handleGlobalCE(const GlobalVariable *G)
 /*!
  * Handle global variable initialization
  */
-void SymbolTableBuilder::handleGlobalInitializerCE(const Constant *C)
+void SymbolTableBuilder::handleGlobalInitializerCE(const Constant* C)
 {
 
     if (C->getType()->isSingleValueType())
     {
-        if (const ConstantExpr *E = SVFUtil::dyn_cast<ConstantExpr>(C))
+        if (const ConstantExpr* E = SVFUtil::dyn_cast<ConstantExpr>(C))
         {
             handleCE(E);
         }
@@ -521,9 +547,10 @@ void SymbolTableBuilder::handleGlobalInitializerCE(const Constant *C)
     }
     else if(const ConstantData* data = SVFUtil::dyn_cast<ConstantData>(C))
     {
-        if(Options::ModelConsts())
+        if (Options::ModelConsts())
         {
-            if(const ConstantDataSequential* seq = SVFUtil::dyn_cast<ConstantDataSequential>(data))
+            if (const ConstantDataSequential* seq =
+                    SVFUtil::dyn_cast<ConstantDataSequential>(data))
             {
                 for(u32_t i = 0; i < seq->getNumElements(); i++)
                 {
@@ -533,8 +560,9 @@ void SymbolTableBuilder::handleGlobalInitializerCE(const Constant *C)
             }
             else
             {
-                assert((SVFUtil::isa<ConstantAggregateZero, UndefValue>(data)) &&
-                       "Single value type data should have been handled!");
+                assert(
+                    (SVFUtil::isa<ConstantAggregateZero, UndefValue>(data)) &&
+                    "Single value type data should have been handled!");
             }
         }
     }
@@ -547,9 +575,9 @@ void SymbolTableBuilder::handleGlobalInitializerCE(const Constant *C)
 /*
  * Initial the memory object here
  */
-ObjTypeInfo* SymbolTableBuilder::createObjTypeInfo(const Value *val)
+ObjTypeInfo* SymbolTableBuilder::createObjTypeInfo(const Value* val)
 {
-    const PointerType *refTy = nullptr;
+    const PointerType* refTy = nullptr;
 
     const Instruction* I = SVFUtil::dyn_cast<Instruction>(val);
 
@@ -566,7 +594,9 @@ ObjTypeInfo* SymbolTableBuilder::createObjTypeInfo(const Value *val)
     if (refTy)
     {
         Type* objTy = getPtrElementType(refTy);
-        ObjTypeInfo* typeInfo = new ObjTypeInfo(LLVMModuleSet::getLLVMModuleSet()->getSVFType(objTy), Options::MaxFieldLimit());
+        ObjTypeInfo* typeInfo = new ObjTypeInfo(
+            LLVMModuleSet::getLLVMModuleSet()->getSVFType(objTy),
+            Options::MaxFieldLimit());
         initTypeInfo(typeInfo,val, objTy);
         return typeInfo;
     }
@@ -575,9 +605,11 @@ ObjTypeInfo* SymbolTableBuilder::createObjTypeInfo(const Value *val)
         writeWrnMsg("try to create an object with a non-pointer type.");
         writeWrnMsg(val->getName().str());
         writeWrnMsg("(" + LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val)->getSourceLoc() + ")");
-        if(isConstantObjSym(val))
+        if (isConstantObjSym(val))
         {
-            ObjTypeInfo* typeInfo = new ObjTypeInfo(LLVMModuleSet::getLLVMModuleSet()->getSVFType(val->getType()), 0);
+            ObjTypeInfo* typeInfo = new ObjTypeInfo(
+                LLVMModuleSet::getLLVMModuleSet()->getSVFType(val->getType()),
+                0);
             initTypeInfo(typeInfo,val, val->getType());
             return typeInfo;
         }
@@ -595,33 +627,34 @@ ObjTypeInfo* SymbolTableBuilder::createObjTypeInfo(const Value *val)
 void SymbolTableBuilder::analyzeObjType(ObjTypeInfo* typeinfo, const Value* val)
 {
 
-    const PointerType * refty = SVFUtil::dyn_cast<PointerType>(val->getType());
+    const PointerType* refty = SVFUtil::dyn_cast<PointerType>(val->getType());
     assert(refty && "this value should be a pointer type!");
     Type* elemTy = getPtrElementType(refty);
     bool isPtrObj = false;
     // Find the inter nested array element
-    while (const ArrayType *AT= SVFUtil::dyn_cast<ArrayType>(elemTy))
+    while (const ArrayType* AT = SVFUtil::dyn_cast<ArrayType>(elemTy))
     {
         elemTy = AT->getElementType();
-        if(elemTy->isPointerTy())
+        if (elemTy->isPointerTy())
             isPtrObj = true;
-        if(SVFUtil::isa<GlobalVariable>(val) && SVFUtil::cast<GlobalVariable>(val)->hasInitializer()
-                && SVFUtil::isa<ConstantArray>(SVFUtil::cast<GlobalVariable>(val)->getInitializer()))
+        if (SVFUtil::isa<GlobalVariable>(val) &&
+            SVFUtil::cast<GlobalVariable>(val)->hasInitializer() &&
+            SVFUtil::isa<ConstantArray>(
+                SVFUtil::cast<GlobalVariable>(val)->getInitializer()))
             typeinfo->setFlag(ObjTypeInfo::CONST_ARRAY_OBJ);
         else
             typeinfo->setFlag(ObjTypeInfo::VAR_ARRAY_OBJ);
     }
-    if (const StructType *ST= SVFUtil::dyn_cast<StructType>(elemTy))
+    if (const StructType* ST = SVFUtil::dyn_cast<StructType>(elemTy))
     {
-        const std::vector<const SVFType*>& flattenFields = getOrAddSVFTypeInfo(ST)->getFlattenFieldTypes();
-        for(std::vector<const SVFType*>::const_iterator it = flattenFields.begin(), eit = flattenFields.end();
-                it!=eit; ++it)
-        {
-            if((*it)->isPointerTy())
-                isPtrObj = true;
-        }
-        if(SVFUtil::isa<GlobalVariable>(val) && SVFUtil::cast<GlobalVariable>(val)->hasInitializer()
-                && SVFUtil::isa<ConstantStruct>(SVFUtil::cast<GlobalVariable>(val)->getInitializer()))
+        const std::vector<const SVFType*>& flattenFields =
+            getOrAddSVFTypeInfo(ST)->getFlattenFieldTypes();
+        isPtrObj |= std::any_of(flattenFields.begin(), flattenFields.end(),
+                                SVFType::isPointerTy);
+        if (SVFUtil::isa<GlobalVariable>(val) &&
+            SVFUtil::cast<GlobalVariable>(val)->hasInitializer() &&
+            SVFUtil::isa<ConstantStruct>(
+                SVFUtil::cast<GlobalVariable>(val)->getInitializer()))
             typeinfo->setFlag(ObjTypeInfo::CONST_STRUCT_OBJ);
         else
             typeinfo->setFlag(ObjTypeInfo::VAR_STRUCT_OBJ);
@@ -643,7 +676,8 @@ void SymbolTableBuilder::analyzeHeapObjType(ObjTypeInfo* typeinfo, const Value* 
     if(const Value* castUse = getUniqueUseViaCastInst(val))
     {
         typeinfo->setFlag(ObjTypeInfo::HEAP_OBJ);
-        typeinfo->resetTypeForHeapStaticObj(LLVMModuleSet::getLLVMModuleSet()->getSVFType(castUse->getType()));
+        typeinfo->resetTypeForHeapStaticObj(
+            LLVMModuleSet::getLLVMModuleSet()->getSVFType(castUse->getType()));
         analyzeObjType(typeinfo,castUse);
     }
     else
@@ -661,7 +695,8 @@ void SymbolTableBuilder::analyzeStaticObjType(ObjTypeInfo* typeinfo, const Value
     if(const Value* castUse = getUniqueUseViaCastInst(val))
     {
         typeinfo->setFlag(ObjTypeInfo::STATIC_OBJ);
-        typeinfo->resetTypeForHeapStaticObj(LLVMModuleSet::getLLVMModuleSet()->getSVFType(castUse->getType()));
+        typeinfo->resetTypeForHeapStaticObj(
+            LLVMModuleSet::getLLVMModuleSet()->getSVFType(castUse->getType()));
         analyzeObjType(typeinfo,castUse);
     }
     else
@@ -674,7 +709,8 @@ void SymbolTableBuilder::analyzeStaticObjType(ObjTypeInfo* typeinfo, const Value
 /*!
  * Initialize the type info of an object
  */
-void SymbolTableBuilder::initTypeInfo(ObjTypeInfo* typeinfo, const Value* val, const Type* objTy)
+void SymbolTableBuilder::initTypeInfo(ObjTypeInfo* typeinfo, const Value* val,
+                                      const Type* objTy)
 {
 
     u32_t objSize = 1;
@@ -704,13 +740,19 @@ void SymbolTableBuilder::initTypeInfo(ObjTypeInfo* typeinfo, const Value* val, c
         analyzeObjType(typeinfo,val);
         objSize = getObjSize(objTy);
     }
-    else if (SVFUtil::isa<Instruction>(val) && isHeapAllocExtCall(LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(SVFUtil::cast<Instruction>(val))))
+    else if (SVFUtil::isa<Instruction>(val) &&
+             isHeapAllocExtCall(
+                 LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(
+                     SVFUtil::cast<Instruction>(val))))
     {
         analyzeHeapObjType(typeinfo,val);
         // Heap object, label its field as infinite here
         objSize = typeinfo->getMaxFieldOffsetLimit();
     }
-    else if (SVFUtil::isa<Instruction>(val) && isStaticExtCall(LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(SVFUtil::cast<Instruction>(val))))
+    else if (SVFUtil::isa<Instruction>(val) &&
+             isStaticExtCall(
+                 LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(
+                     SVFUtil::cast<Instruction>(val))))
     {
         analyzeStaticObjType(typeinfo,val);
         // static object allocated before main, label its field as infinite here

--- a/svf/lib/SVFIR/SVFIRRW.cpp
+++ b/svf/lib/SVFIR/SVFIRRW.cpp
@@ -758,6 +758,7 @@ cJSON* jsonCreateString(const char* str)
 cJSON* jsonCreateIndex(size_t index)
 {
     constexpr size_t maxPreciseIntInDouble = (1ull << 53);
+    (void)maxPreciseIntInDouble; // silence unused warning
     assert(index <= maxPreciseIntInDouble);
     return cJSON_CreateNumber(index);
 }
@@ -1099,7 +1100,7 @@ cJSON* SVFIRWriter::toJson(const SVFModule* module)
     cJSON* values = jsonCreateArray();
     for (size_t i = 1; i <= svfModuleWriter.svfValuePool.size(); ++i)
     {
-        cJSON* value = toJson(svfModuleWriter.svfValuePool.getPtr(i));
+        cJSON* value = contentToJson(svfModuleWriter.svfValuePool.getPtr(i));
         jsonAddItemToArray(values, value);
     }
     jsonAddItemToObject(root, "values", values);
@@ -1107,7 +1108,7 @@ cJSON* SVFIRWriter::toJson(const SVFModule* module)
     cJSON* types = jsonCreateArray();
     for (size_t i = 1; i <= svfModuleWriter.svfTypePool.size(); ++i)
     {
-        cJSON* type = toJson(svfModuleWriter.svfTypePool.getPtr(i));
+        cJSON* type = contentToJson(svfModuleWriter.svfTypePool.getPtr(i));
         jsonAddItemToArray(types, type);
     }
     jsonAddItemToObject(root, "types", types);


### PR DESCRIPTION
* Break overly long lines in code
* Rename `build_symbol_table` to `buildSymbolTable` to conform to SVF naming convention
* Replace iterator loop with range-based loop