### PR TITLE
Refactoring redundant code in `LLVMModule.cpp`

### DIFF
--- a/svf/include/AbstractExecution/BoundedZ3Expr.h
+++ b/svf/include/AbstractExecution/BoundedZ3Expr.h
@@ -179,6 +179,7 @@ public:
             return lhs;
         else
             assert(false && "undefined operation +oo + -oo");
+        abort();
     }
 
     friend BoundedZ3Expr operator-(const BoundedZ3Expr &lhs)
@@ -198,6 +199,7 @@ public:
             return lhs;
         else
             assert(false && "undefined operation +oo - +oo");
+        abort();
     }
 
     friend BoundedZ3Expr operator*(const BoundedZ3Expr &lhs, const BoundedZ3Expr &rhs)
@@ -225,7 +227,7 @@ public:
         else
             // TODO: +oo/-oo L'Hôpital's rule?
             return eq(lhs, rhs) ? plus_infinity() : minus_infinity();
-
+        abort();
     }
 
     friend BoundedZ3Expr operator%(const BoundedZ3Expr &lhs, const BoundedZ3Expr &rhs)
@@ -241,6 +243,7 @@ public:
         else
             // TODO: +oo/-oo L'Hôpital's rule?
             return eq(lhs, rhs) ? plus_infinity() : minus_infinity();
+        abort();
     }
 
     friend BoundedZ3Expr operator^(const BoundedZ3Expr &lhs, const BoundedZ3Expr &rhs)

--- a/svf/include/AbstractExecution/NumericLiteral.h
+++ b/svf/include/AbstractExecution/NumericLiteral.h
@@ -140,6 +140,7 @@ public:
         else
         {
             assert(false && "other literal?");
+            abort();
         }
     }
 

--- a/svf/include/SVFIR/SVFIRRW.h
+++ b/svf/include/SVFIR/SVFIRRW.h
@@ -408,7 +408,7 @@ private:
     cJSON* toJson(const LocationSet& ls);
     cJSON* toJson(const SVFLoop* loop);
     cJSON* toJson(const MemObj* memObj);
-    cJSON* toJson(const ObjTypeInfo* objTypeInfo); // Ensures ownership
+    cJSON* toJson(const ObjTypeInfo* objTypeInfo); // Only owned by MemObj
     cJSON* toJson(const SVFLoopAndDomInfo* ldInfo); // Only owned by SVFFunction
     cJSON* toJson(const StInfo* type); // Ensure Only owned by SVFType
 


### PR DESCRIPTION
* When using expression `m[k]`, map's `operator[]` will construct a value for the key `k` that doesn't exist, so we don't have to handle the code in two ways;
* Removed some unnecessary `static_cast` from `const T*` to `T*`;
* Added some `const` qualifiers to some references and pointers.