### PR TITLE
Update the callgraph in Steensgaard pointer analysis

### DIFF
--- a/svf/include/WPA/Steensgaard.h
+++ b/svf/include/WPA/Steensgaard.h
@@ -17,24 +17,21 @@ namespace SVF
  */
 typedef WPASolver<ConstraintGraph*> WPAConstraintSolver;
 
-class Steensgaard:  public AndersenBase
+class Steensgaard : public AndersenBase
 {
 
 public:
-
     typedef Map<NodeID, NodeID> NodeToEquivClassMap;
     typedef Map<NodeID, Set<NodeID>> NodeToSubsMap;
+    typedef OrderedMap<CallSite, NodeID> CallSite2DummyValPN;
 
     /// Constructor
-    Steensgaard(SVFIR* _pag)
-        :  AndersenBase(_pag, Steensgaard_WPA, true)
-    {
-    }
+    Steensgaard(SVFIR* _pag) : AndersenBase(_pag, Steensgaard_WPA, true) {}
 
     /// Create an singleton instance
     static Steensgaard* createSteensgaard(SVFIR* _pag)
     {
-        if(steens==nullptr)
+        if (steens == nullptr)
         {
             steens = new Steensgaard(_pag);
             steens->analyze();
@@ -57,15 +54,15 @@ public:
 
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
     //@{
-    static inline bool classof(const Steensgaard *)
+    static inline bool classof(const Steensgaard*)
     {
         return true;
     }
-    static inline bool classof(const AndersenBase *pta)
+    static inline bool classof(const AndersenBase* pta)
     {
         return (pta->getAnalysisTy() == Steensgaard_WPA);
     }
-    static inline bool classof(const PointerAnalysis *pta)
+    static inline bool classof(const PointerAnalysis* pta)
     {
         return (pta->getAnalysisTy() == Steensgaard_WPA);
     }
@@ -87,7 +84,7 @@ public:
     {
         id = getEC(id);
         ptd = getEC(ptd);
-        return getPTDataTy()->unionPts(id,ptd);
+        return getPTDataTy()->unionPts(id, ptd);
     }
 
     /// API for equivalence class operations
@@ -96,7 +93,7 @@ public:
     inline NodeID getEC(NodeID id) const
     {
         NodeToEquivClassMap::const_iterator it = nodeToECMap.find(id);
-        if(it==nodeToECMap.end())
+        if (it == nodeToECMap.end())
             return id;
         else
             return it->second;
@@ -113,14 +110,32 @@ public:
         nodeToSubsMap[node].insert(sub);
     }
 
-private:
+    /// Add copy edge on constraint graph
+    virtual inline bool addCopyEdge(NodeID src, NodeID dst)
+    {
+        return consCG->addCopyCGEdge(src, dst);
+    }
 
+protected:
+    CallSite2DummyValPN
+        callsite2DummyValPN; ///< Map an instruction to a dummy obj which
+                             ///< created at an indirect callsite, which invokes
+                             ///< a heap allocator
+    void heapAllocatorViaIndCall(CallSite cs, NodePairSet& cpySrcNodes);
+
+    /// Update call graph for the input indirect callsites
+    virtual bool updateCallGraph(const CallSiteToFunPtrMap& callsites);
+
+    /// Connect formal and actual parameters for indirect callsites
+    void connectCaller2CalleeParams(CallSite cs, const SVFFunction* F,
+                                    NodePairSet& cpySrcNodes);
+
+private:
     static Steensgaard* steens; // static instance
     NodeToEquivClassMap nodeToECMap;
     NodeToSubsMap nodeToSubsMap;
 };
 
-} /// end of the namespace
-
+} // namespace SVF
 
 #endif /* INCLUDE_WPA_STEENSGAARD_H_ */

--- a/svf/lib/WPA/Steensgaard.cpp
+++ b/svf/lib/WPA/Steensgaard.cpp
@@ -1,4 +1,5 @@
-//===- Steensgaard.cpp -- Steensgaard's field-insensitive analysis--------------//
+//===- Steensgaard.cpp -- Steensgaard's field-insensitive
+// analysis--------------//
 //
 //                     SVF: Static Value-Flow Analysis
 //
@@ -32,7 +33,7 @@
 using namespace SVF;
 using namespace SVFUtil;
 
-Steensgaard *Steensgaard::steens = nullptr;
+Steensgaard* Steensgaard::steens = nullptr;
 
 /*!
  * Steensgaard analysis
@@ -50,7 +51,7 @@ void Steensgaard::solveWorklist()
         ConstraintNode* node = consCG->getConstraintNode(nodeId);
 
         /// foreach o \in pts(p)
-        for(NodeID o : getPts(nodeId))
+        for (NodeID o : getPts(nodeId))
         {
 
             /// *p = q : EC(o) == EC(q)
@@ -68,36 +69,34 @@ void Steensgaard::solveWorklist()
         /// q = p : EC(q) == EC(p)
         for (ConstraintEdge* edge : node->getCopyOutEdges())
         {
-            ecUnion(edge->getSrcID(),edge->getDstID());
+            ecUnion(edge->getSrcID(), edge->getDstID());
         }
         /// q = &p->f : EC(q) == EC(p)
         for (ConstraintEdge* edge : node->getGepOutEdges())
         {
-            ecUnion(edge->getSrcID(),edge->getDstID());
+            ecUnion(edge->getSrcID(), edge->getDstID());
         }
     }
 }
-
 
 void Steensgaard::setEC(NodeID node, NodeID rep)
 {
     rep = getEC(rep);
     Set<NodeID>& subNodes = getSubNodes(node);
-    for(NodeID sub : subNodes)
+    for (NodeID sub : subNodes)
     {
         nodeToECMap[sub] = rep;
-        addSubNode(rep,sub);
+        addSubNode(rep, sub);
     }
     subNodes.clear();
 }
 
-
 /// merge node into equiv class and merge node's pts into ec's pts
 void Steensgaard::ecUnion(NodeID node, NodeID ec)
 {
-    if(unionPts(ec, node))
+    if (unionPts(ec, node))
         pushIntoWorklist(ec);
-    setEC(node,ec);
+    setEC(node, ec);
 }
 
 /*!
@@ -105,20 +104,188 @@ void Steensgaard::ecUnion(NodeID node, NodeID ec)
  */
 void Steensgaard::processAllAddr()
 {
-    for (ConstraintGraph::const_iterator nodeIt = consCG->begin(), nodeEit = consCG->end(); nodeIt != nodeEit; nodeIt++)
+    for (ConstraintGraph::const_iterator nodeIt = consCG->begin(),
+                                         nodeEit = consCG->end();
+         nodeIt != nodeEit; nodeIt++)
     {
-        ConstraintNode * cgNode = nodeIt->second;
-        for (ConstraintNode::const_iterator it = cgNode->incomingAddrsBegin(), eit = cgNode->incomingAddrsEnd();
-                it != eit; ++it)
+        ConstraintNode* cgNode = nodeIt->second;
+        for (ConstraintNode::const_iterator it = cgNode->incomingAddrsBegin(),
+                                            eit = cgNode->incomingAddrsEnd();
+             it != eit; ++it)
         {
             numOfProcessedAddr++;
 
             const AddrCGEdge* addr = cast<AddrCGEdge>(*it);
             NodeID dst = addr->getDstID();
             NodeID src = addr->getSrcID();
-            if(addPts(dst,src))
+            if (addPts(dst, src))
                 pushIntoWorklist(dst);
         }
     }
 }
 
+bool Steensgaard::updateCallGraph(const CallSiteToFunPtrMap& callsites)
+{
+
+    double cgUpdateStart = stat->getClk();
+
+    CallEdgeMap newEdges;
+    onTheFlyCallGraphSolve(callsites, newEdges);
+    NodePairSet cpySrcNodes; /// nodes as a src of a generated new copy edge
+    for (CallEdgeMap::iterator it = newEdges.begin(), eit = newEdges.end();
+         it != eit; ++it)
+    {
+        CallSite cs = SVFUtil::getSVFCallSite(it->first->getCallSite());
+        for (FunctionSet::iterator cit = it->second.begin(),
+                                   ecit = it->second.end();
+             cit != ecit; ++cit)
+        {
+            connectCaller2CalleeParams(cs, *cit, cpySrcNodes);
+        }
+    }
+    for (NodePairSet::iterator it = cpySrcNodes.begin(),
+                               eit = cpySrcNodes.end();
+         it != eit; ++it)
+    {
+        pushIntoWorklist(it->first);
+    }
+
+    double cgUpdateEnd = stat->getClk();
+    timeOfUpdateCallGraph += (cgUpdateEnd - cgUpdateStart) / TIMEINTERVAL;
+
+    return (!newEdges.empty());
+}
+
+void Steensgaard::heapAllocatorViaIndCall(CallSite cs, NodePairSet& cpySrcNodes)
+{
+    assert(SVFUtil::getCallee(cs) == nullptr && "not an indirect callsite?");
+    RetICFGNode* retBlockNode =
+        pag->getICFG()->getRetICFGNode(cs.getInstruction());
+    const PAGNode* cs_return = pag->getCallSiteRet(retBlockNode);
+    NodeID srcret;
+    CallSite2DummyValPN::const_iterator it = callsite2DummyValPN.find(cs);
+    if (it != callsite2DummyValPN.end())
+    {
+        srcret = getEC(it->second);
+    }
+    else
+    {
+        NodeID valNode = pag->addDummyValNode();
+        NodeID objNode = pag->addDummyObjNode(cs.getType());
+        addPts(valNode, objNode);
+        callsite2DummyValPN.insert(std::make_pair(cs, valNode));
+        consCG->addConstraintNode(new ConstraintNode(valNode), valNode);
+        consCG->addConstraintNode(new ConstraintNode(objNode), objNode);
+        srcret = valNode;
+    }
+
+    NodeID dstrec = getEC(cs_return->getId());
+    if (addCopyEdge(srcret, dstrec))
+        cpySrcNodes.insert(std::make_pair(srcret, dstrec));
+}
+
+/*!
+ * Connect formal and actual parameters for indirect callsites
+ */
+void Steensgaard::connectCaller2CalleeParams(CallSite cs, const SVFFunction* F,
+                                             NodePairSet& cpySrcNodes)
+{
+    assert(F);
+
+    DBOUT(DAndersen, outs() << "connect parameters from indirect callsite "
+                            << cs.getInstruction()->toString() << " to callee "
+                            << *F << "\n");
+
+    CallICFGNode* callBlockNode =
+        pag->getICFG()->getCallICFGNode(cs.getInstruction());
+    RetICFGNode* retBlockNode =
+        pag->getICFG()->getRetICFGNode(cs.getInstruction());
+
+    if (SVFUtil::isHeapAllocExtFunViaRet(F) &&
+        pag->callsiteHasRet(retBlockNode))
+    {
+        heapAllocatorViaIndCall(cs, cpySrcNodes);
+    }
+
+    if (pag->funHasRet(F) && pag->callsiteHasRet(retBlockNode))
+    {
+        const PAGNode* cs_return = pag->getCallSiteRet(retBlockNode);
+        const PAGNode* fun_return = pag->getFunRet(F);
+        if (cs_return->isPointer() && fun_return->isPointer())
+        {
+            NodeID dstrec = getEC(cs_return->getId());
+            NodeID srcret = getEC(fun_return->getId());
+            if (addCopyEdge(srcret, dstrec))
+            {
+                cpySrcNodes.insert(std::make_pair(srcret, dstrec));
+            }
+        }
+        else
+        {
+            DBOUT(DAndersen, outs() << "not a pointer ignored\n");
+        }
+    }
+
+    if (pag->hasCallSiteArgsMap(callBlockNode) && pag->hasFunArgsList(F))
+    {
+
+        // connect actual and formal param
+        const SVFIR::SVFVarList& csArgList =
+            pag->getCallSiteArgsList(callBlockNode);
+        const SVFIR::SVFVarList& funArgList = pag->getFunArgsList(F);
+        // Go through the fixed parameters.
+        DBOUT(DPAGBuild, outs() << "      args:");
+        SVFIR::SVFVarList::const_iterator funArgIt = funArgList.begin(),
+                                          funArgEit = funArgList.end();
+        SVFIR::SVFVarList::const_iterator csArgIt = csArgList.begin(),
+                                          csArgEit = csArgList.end();
+        for (; funArgIt != funArgEit; ++csArgIt, ++funArgIt)
+        {
+            // Some programs (e.g. Linux kernel) leave unneeded parameters
+            // empty.
+            if (csArgIt == csArgEit)
+            {
+                DBOUT(DAndersen, outs() << " !! not enough args\n");
+                break;
+            }
+            const PAGNode* cs_arg = *csArgIt;
+            const PAGNode* fun_arg = *funArgIt;
+
+            if (cs_arg->isPointer() && fun_arg->isPointer())
+            {
+                DBOUT(DAndersen, outs() << "process actual parm  "
+                                        << cs_arg->toString() << " \n");
+                NodeID srcAA = getEC(cs_arg->getId());
+                NodeID dstFA = getEC(fun_arg->getId());
+                if (addCopyEdge(srcAA, dstFA))
+                {
+                    cpySrcNodes.insert(std::make_pair(srcAA, dstFA));
+                }
+            }
+        }
+
+        // Any remaining actual args must be varargs.
+        if (F->isVarArg())
+        {
+            NodeID vaF = getEC(pag->getVarargNode(F));
+            DBOUT(DPAGBuild, outs() << "\n      varargs:");
+            for (; csArgIt != csArgEit; ++csArgIt)
+            {
+                const PAGNode* cs_arg = *csArgIt;
+                if (cs_arg->isPointer())
+                {
+                    NodeID vnAA = getEC(cs_arg->getId());
+                    if (addCopyEdge(vnAA, vaF))
+                    {
+                        cpySrcNodes.insert(std::make_pair(vnAA, vaF));
+                    }
+                }
+            }
+        }
+        if (csArgIt != csArgEit)
+        {
+            writeWrnMsg("too many args to non-vararg func.");
+            writeWrnMsg("(" + cs.getInstruction()->getSourceLoc() + ")");
+        }
+    }
+}


### PR DESCRIPTION
Currently Steensgaard pointer analysis can't update points-to set along indirect calls. This patch is tried to address this gap.