### PR TITLE
cmake: use paths relative to project source, not cmake top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.13.4)
 
 project("SVF")
 
-configure_file(${CMAKE_SOURCE_DIR}/.config.in
-               ${CMAKE_BINARY_DIR}/include/Util/config.h)
+configure_file(${PROJECT_SOURCE_DIR}/.config.in
+               ${PROJECT_BINARY_DIR}/include/Util/config.h)
 
 # We need to match the build environment for LLVM: In particular, we need C++14
 # and the -fno-rtti flag
@@ -14,6 +14,7 @@ set(CMAKE_CXX_EXTENSIONS ON)
 
 add_compile_options("-fno-rtti")
 add_compile_options("-fno-exceptions")
+add_compile_options("-ggdb")
 
 # Treat compiler warnings as errors
 add_compile_options("-Werror" "-Wall")
@@ -65,13 +66,13 @@ endif()
 message(STATUS "Found Z3: ${Z3_LIBRARIES}")
 message(STATUS "Z3 include dir: ${Z3_INCLUDES}")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/svf/include
-                    ${CMAKE_BINARY_DIR}/include ${Z3_INCLUDES})
+include_directories(${PROJECT_SOURCE_DIR}/svf/include
+                    ${PROJECT_BINARY_DIR}/include ${Z3_INCLUDES})
 
 # checks if the test-suite is present, if it is then build bc files and add
 # testing to cmake build
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite")
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/Test-Suite)
+if(EXISTS "${PROJECT_SOURCE_DIR}/Test-Suite")
+  include_directories(${PROJECT_SOURCE_DIR}/Test-Suite)
   enable_testing()
   add_subdirectory(Test-Suite)
   include(CTest)
@@ -81,8 +82,8 @@ add_subdirectory(svf)
 add_subdirectory(svf-llvm)
 
 install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/svf/include/
-            ${CMAKE_CURRENT_SOURCE_DIR}/svf-llvm/include/
+  DIRECTORY ${PROJECT_SOURCE_DIR}/svf/include/
+            ${PROJECT_SOURCE_DIR}/svf-llvm/include/
   COMPONENT devel
   DESTINATION include/svf
   FILES_MATCHING


### PR DESCRIPTION
We use SVF as a submodule and build it as part of a larger CMake project. `CMAKE_SOURCE_DIR` evaluates to the source dir where the top level CMake for the current build was invoked (dir of our top-level CMakeLists.txt). Instead, `PROJECT_SOURCE_DIR` evaluates to the top-level dir of the current (sub-)project. When building SVF normally, this makes no difference, but in our case, it does. 

The same goes for the `*_BINARY_DIR` variables: we ideally want SVF's generated `config.h` to be under it's own subdir in our build folder, not globally (to avoid messing with our own generated include paths, for instance). 

After this change, we're able to continue using SVF as a submodule by simply doing:
```
set(SVF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/SVF/)
set(svf_libs SvfLLVM SvfCore)
include_directories(${SVF_DIR}/svf/include/)
include_directories(${SVF_DIR}/svf-llvm/include/)
include_directories(${PROJECT_BINARY_DIR}/SVF/include/)
add_subdirectory(${SVF_DIR})
```

from a higher-level CMakeLists.txt