### PR TITLE
Update extensible ExtAPI functionality to match new JSON spec

### DIFF
--- a/svf/include/Util/ExtAPI.h
+++ b/svf/include/Util/ExtAPI.h
@@ -261,7 +261,9 @@ public:
     static void destory();
 
     // Add an entry with the specified fields to the ExtAPI, which will be reflected immediately by further ExtAPI queries
-    void add_entry(const char* funName, extType type, bool overwrite_app_function);
+    void add_entry(const char* funName, const char* returnType, 
+                        std::vector<const char*> argTypes, extType type, 
+                        bool overwrite_app_function);
 
     // Get numeric index of the argument in external function
     u32_t getArgPos(const std::string& s);

--- a/svf/include/Util/ExtAPI.h
+++ b/svf/include/Util/ExtAPI.h
@@ -31,8 +31,8 @@
 #define __ExtAPI_H
 
 #include "SVFIR/SVFValue.h"
-#include "Util/cJSON.h"
-#include "Util/config.h"
+#include <Util/cJSON.h>
+#include <Util/config.h>
 #include <string>
 #include <map>
 
@@ -299,6 +299,9 @@ public:
     // 0: Apply user-defined functions
     // 1: Apply function specification in ExtAPI.json
     u32_t isOverwrittenAppFunction(const SVF::SVFFunction *callee);
+    u32_t isOverwrittenAppFunction(const std::string& funcName);
+    // set priority of the function
+    void setOverWrittenAppFunction(const std::string& funcName, u32_t overwrite_app_function);
 
     // Does (F) have a static var X (unavailable to us) that its return points to?
     bool has_static(const SVFFunction *F);

--- a/svf/lib/Util/ExtAPI.cpp
+++ b/svf/lib/Util/ExtAPI.cpp
@@ -416,6 +416,11 @@ ExtAPI::extType ExtAPI::get_type(const SVF::SVFFunction* F)
 u32_t ExtAPI::isOverwrittenAppFunction(const SVF::SVFFunction* callee)
 {
     std::string funName = get_name(callee);
+    return isOverwrittenAppFunction(funName);
+}
+
+u32_t ExtAPI::isOverwrittenAppFunction(const std::string& funName)
+{
     cJSON* item = get_FunJson(funName);
     if (item != nullptr)
     {
@@ -427,6 +432,16 @@ u32_t ExtAPI::isOverwrittenAppFunction(const SVF::SVFFunction* callee)
             assert(false && "The function operation format is illegal!");
     }
     return 0;
+}
+
+void ExtAPI::setOverWrittenAppFunction(const std::string& funcName, u32_t overwrite_app_function)
+{
+    auto item = get_FunJson(funcName);
+    assert(item && "Do not set fields for ExtAPI funcs that don't exist!");
+    auto overwrite_obj = item->child->next->next->next;
+    assert(overwrite_obj);
+    assert(strcmp(overwrite_obj->string, JSON_OPT_OVERWRITE) == 0);
+    cJSON_SetIntValue(overwrite_obj, overwrite_app_function);
 }
 
 // Does (F) have a static var X (unavailable to us) that its return points to?


### PR DESCRIPTION
Since changing the specification language in the 2.6 release, the `add_entry` functionality of the ExtAPI has been silently broken. This patch fixes it to match the current spec again.

Also added some helper functions to query and set the `overwritten_app_function` field.