### PR TITLE
Do small crux bc tests even if ASan is used

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -88,11 +88,17 @@ jobs:
         run:
           ctest -R cfl_tests -VV
 
-      - name: ctest performance tests on cruxbc & File system diff tests
+      - name: ctest performance tests on big cruxbc with file system diff tests
         working-directory: ${{github.workspace}}/Release-build
         if: runner.os == 'Linux' && matrix.sanitizer != 'address'
         run:
-          ctest -R diff-perf-cruxbc -VV
+          ctest -R diff-perf-cruxbc-big -VV
+
+      - name: ctest performance tests on small cruxbc with file system diff tests
+        working-directory: ${{github.workspace}}/Release-build
+        if: runner.os == 'Linux'
+        run:
+          ctest -R diff-perf-cruxbc-small -VV
 
       - name: create-coverage-report-and-remove-system-files
         working-directory: ${{github.workspace}}/Release-build


### PR DESCRIPTION
To find memory usage bugs, turn on small crux bc tests if AddrSanitizer is used.