### PR TITLE
Update LLVMModuleSet::createSVFDataStructure()

### DIFF
--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -151,6 +151,7 @@ void LLVMModuleSet::build()
 
 void LLVMModuleSet::createSVFDataStructure()
 {
+    getSVFType(IntegerType::getInt8Ty(getContext()));
 
     for (const Module& mod : modules)
     {
@@ -1009,18 +1010,9 @@ SVFType* LLVMModuleSet::addSVFTypeInfo(const Type* T)
     else
         svftype = new SVFOtherType(T->isSingleValueType());
 
-    LLVMType2SVFTypeMap::const_iterator it = LLVMType2SVFType.find(T);
-    if (it != LLVMType2SVFType.end())
-    {
-        delete svftype;
-        return it->second;
-    }
-    else
-    {
-        symInfo->addTypeInfo(svftype);
-        LLVMType2SVFType[T] = svftype;
-        return svftype;
-    }
+    symInfo->addTypeInfo(svftype);
+    LLVMType2SVFType[T] = svftype;
+    return svftype;
 }
 
 /*!

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -953,8 +953,7 @@ SVFType* LLVMModuleSet::getSVFType(const Type* T)
     /// [getPointerTo(): char   ----> i8*]
     /// [getPointerTo(): int    ----> i8*]
     /// [getPointerTo(): struct ----> i8*]
-    PointerType* ptrTy =
-        PointerType::getInt8PtrTy(getContext())->getPointerTo();
+    PointerType* ptrTy = PointerType::getInt8PtrTy(getContext());
     svfType->setPointerTo(SVFUtil::cast<SVFPointerType>(getSVFType(ptrTy)));
     return svfType;
 }
@@ -1010,9 +1009,18 @@ SVFType* LLVMModuleSet::addSVFTypeInfo(const Type* T)
     else
         svftype = new SVFOtherType(T->isSingleValueType());
 
-    symInfo->addTypeInfo(svftype);
-    LLVMType2SVFType[T] = svftype;
-    return svftype;
+    LLVMType2SVFTypeMap::const_iterator it = LLVMType2SVFType.find(T);
+    if (it != LLVMType2SVFType.end())
+    {
+        delete svftype;
+        return it->second;
+    }
+    else
+    {
+        symInfo->addTypeInfo(svftype);
+        LLVMType2SVFType[T] = svftype;
+        return svftype;
+    }
 }
 
 /*!

--- a/svf/lib/SVFIR/SymbolTableInfo.cpp
+++ b/svf/lib/SVFIR/SymbolTableInfo.cpp
@@ -282,6 +282,13 @@ void SymbolTableInfo::printFlattenFields(const SVFType* type)
         outs() << "(Function)}\n\n";
     }
 
+    else if ( const SVFOtherType* ot= SVFUtil::dyn_cast<SVFOtherType> (type))
+    {
+        outs() << "  {Type: ";
+        outs() << ot->toString();
+        outs() << "(SVFOtherType)}\n\n";
+    }
+
     else
     {
         assert(type->isSingleValueType() && "not a single value type, then what else!!");


### PR DESCRIPTION
/// Due to recursion, a TOCTTOU (Time-of-Check to Time-of-Use) bug might happen here.
/// ................................................................................................................
///   Time 0:  the check on LLVMType2SVFType in the calling function 
///          Time 1:  the change on LLVMType2SVFType in the called function 
///          Time 2:  the called function returns to the calling function
///   Time 3:  the use of LLVMType2SVFType in the calling function (TOCTTOU bug)
/// ................................................................................................................
/// Test case:
///         char **ptr;
///
/// (0) In LLVMModuleSet::getSVFType(const Type* T), "char *" will be created.
/// (1) If "new SVFPointerType(char *)" is called twice, we will get two SVFPointerType objects.
///     The LLVM type "char *" will incorrectly corresponds to two different SVFPointerType objects.
/// (2) call "getSVFType(IntegerType::getInt8Ty(getContext()));" in createSVFDataStructure() such that 
///      the char * in getSVFType() is initialised in advance.
///
/// In this way, -print-type will be happy.
