### PR TITLE
Make printing `SVFType` independent of LLVM BC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ Release*/
 Debug*/
 build/
 html/
-Test-Suite/
+Test-Suite
 Release+Asserts/
 Debug+Asserts/
 autoconf/
@@ -21,3 +21,4 @@ doxygen/
 *.obj
 *.svf
 cmake-build-debug/
+compile_commands.json

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -1003,12 +1003,25 @@ SVFType* LLVMModuleSet::addSVFTypeInfo(const Type* T)
         svftype = new SVFIntegerType();
     else if (const FunctionType* ft = SVFUtil::dyn_cast<FunctionType>(T))
         svftype = new SVFFunctionType(getSVFType(ft->getReturnType()));
-    else if (SVFUtil::isa<StructType>(T))
-        svftype = new SVFStructType();
-    else if (SVFUtil::isa<ArrayType>(T))
-        svftype = new SVFArrayType();
+    else if (const StructType* st = SVFUtil::dyn_cast<StructType>(T))
+    {
+        auto svfst = new SVFStructType;
+        svfst->getName() = st->getName().str();
+        svftype = svfst;
+    }
+    else if (const auto at = SVFUtil::dyn_cast<ArrayType>(T))
+    {
+        auto svfat = new SVFArrayType();
+        svfat->setNumOfElement(at->getNumElements());
+        svfat->setTypeOfElement(getSVFType(at->getElementType()));
+        svftype = svfat;
+    }
     else
-        svftype = new SVFOtherType(T->isSingleValueType());
+    {
+        auto ot = new SVFOtherType(T->isSingleValueType());
+        llvm::raw_string_ostream(ot->getRepr()) << *T;
+        svftype = ot;
+    }
 
     symInfo->addTypeInfo(svftype);
     LLVMType2SVFType[T] = svftype;

--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -1048,12 +1048,4 @@ const std::string SVFValue::toString() const
     return rawstr.str();
 }
 
-const std::string SVFType::toString() const
-{
-    std::string str;
-    llvm::raw_string_ostream rawstr(str);
-    const Type* ty = LLVMModuleSet::getLLVMModuleSet()->getLLVMType(this);
-    rawstr << *ty;
-    return rawstr.str();
-}
 }

--- a/svf/include/SVFIR/SVFType.h
+++ b/svf/include/SVFIR/SVFType.h
@@ -264,6 +264,7 @@ private:
     StInfo* typeinfo;   ///< SVF's TypeInfo
     bool isSingleValTy; ///< The type represents a single value, not struct or
     ///< array
+
 protected:
     SVFType(bool svt, SVFTyKind k)
         : kind(k), getPointerToTy(nullptr), typeinfo(nullptr),
@@ -280,9 +281,7 @@ public:
         return kind;
     }
 
-    /// Needs to be implemented by a specific SVF front end (e.g., the
-    /// implementation in LLVMUtil)
-    virtual const std::string toString() const;
+    virtual void print(std::ostream& OS) const = 0;
 
     inline void setPointerTo(const SVFPointerType* ty)
     {
@@ -323,6 +322,8 @@ public:
     }
 };
 
+std::ostream& operator<<(std::ostream& OS, const SVFType& type);
+
 class SVFPointerType : public SVFType
 {
     friend class SVFIRWriter;
@@ -344,6 +345,8 @@ public:
     {
         return ptrElementType;
     }
+
+    void print(std::ostream& OS) const override;
 };
 
 class SVFIntegerType : public SVFType
@@ -354,6 +357,8 @@ public:
     {
         return node->getKind() == SVFIntegerTy;
     }
+
+    void print(std::ostream& OS) const override;
 };
 
 class SVFFunctionType : public SVFType
@@ -377,36 +382,89 @@ public:
     {
         return retTy;
     }
+
+    void print(std::ostream& OS) const override;
 };
 
 class SVFStructType : public SVFType
 {
+    friend class SVFIRWriter;
+    friend class SVFIRReader;
+
+private:
+    std::string name;
+
 public:
     SVFStructType() : SVFType(false, SVFStructTy) {}
+
     static inline bool classof(const SVFType* node)
     {
         return node->getKind() == SVFStructTy;
+    }
+
+    void print(std::ostream& OS) const override;
+
+    std::string& getName()
+    {
+        return name;
     }
 };
 
 class SVFArrayType : public SVFType
 {
+    friend class SVFIRWriter;
+    friend class SVFIRReader;
+
+private:
+    unsigned numOfElement; /// For printing
+    SVFType* typeOfElement; /// For printing
+
 public:
-    SVFArrayType() : SVFType(false, SVFArrayTy) {}
+    SVFArrayType()
+        : SVFType(false, SVFArrayTy), numOfElement(0), typeOfElement(nullptr)
+    {
+    }
+
     static inline bool classof(const SVFType* node)
     {
         return node->getKind() == SVFArrayTy;
+    }
+
+    void print(std::ostream& OS) const override;
+
+    void setTypeOfElement(SVFType* elemType)
+    {
+        typeOfElement = elemType;
+    }
+
+    void setNumOfElement(unsigned elemNum)
+    {
+        numOfElement = elemNum;
     }
 };
 
 class SVFOtherType : public SVFType
 {
+    friend class SVFIRWriter;
+    friend class SVFIRReader;
+
+private:
+    std::string repr; /// Field representation for printing
+
 public:
     SVFOtherType(bool isSingleValueTy) : SVFType(isSingleValueTy, SVFOtherTy) {}
+
     static inline bool classof(const SVFType* node)
     {
         return node->getKind() == SVFOtherTy;
     }
+
+    std::string& getRepr()
+    {
+        return repr;
+    }
+
+    void print(std::ostream& OS) const override;
 };
 
 // TODO: be explicit that this is a pair of 32-bit unsigneds?

--- a/svf/include/SVFIR/SVFType.h
+++ b/svf/include/SVFIR/SVFType.h
@@ -281,6 +281,10 @@ public:
         return kind;
     }
 
+    /// Note: Use `os<<svfType` or `svfType.print(os)` when possible to avoid
+    /// string concatenation.
+    std::string toString() const;
+
     virtual void print(std::ostream& OS) const = 0;
 
     inline void setPointerTo(const SVFPointerType* ty)

--- a/svf/lib/AbstractExecution/SVFIR2ItvExeState.cpp
+++ b/svf/lib/AbstractExecution/SVFIR2ItvExeState.cpp
@@ -300,7 +300,7 @@ void SVFIR2ItvExeState::initValVar(const ValVar *valVar, u32_t varId)
         else
         {
 
-            SVFUtil::errs() << valVar->getValue()->toString() << "\n" << " type: " << type->toString() << "\n";
+            SVFUtil::errs() << valVar->getValue()->toString() << "\n" << " type: " << *type << "\n";
             assert(false && "what other types we have");
         }
     }

--- a/svf/lib/MemoryModel/LocationSet.cpp
+++ b/svf/lib/MemoryModel/LocationSet.cpp
@@ -81,7 +81,7 @@ u32_t LocationSet::getElementNum(const SVFType* type) const
     }
     else
     {
-        SVFUtil::outs() << "GepIter Type" << type->toString() << "\n";
+        SVFUtil::outs() << "GepIter Type" << *type << "\n";
         assert(false && "What other types for this gep?");
         abort();
     }
@@ -228,7 +228,8 @@ std::string LocationSet::dump() const
     OffsetVarAndGepTypePairs::const_iterator eit = vec.end();
     for (; it != eit; ++it)
     {
-        rawstr << " (Svf var: " << it->first->toString() << ", Iter type: " << it->second->toString() << ")";
+        const SVFType* ty = it->second;
+        rawstr << " (Svf var: " << it->first->toString() << ", Iter type: " << *ty << ")";
     }
     rawstr << " }\n";
     return rawstr.str();

--- a/svf/lib/SVFIR/SVFFileSystem.cpp
+++ b/svf/lib/SVFIR/SVFFileSystem.cpp
@@ -498,17 +498,24 @@ cJSON* SVFIRWriter::contentToJson(const SVFFunctionType* type)
 
 cJSON* SVFIRWriter::contentToJson(const SVFStructType* type)
 {
-    return contentToJson(static_cast<const SVFType*>(type));
+    cJSON* root = contentToJson(static_cast<const SVFType*>(type));
+    JSON_WRITE_FIELD(root, type, name);
+    return root;
 }
 
 cJSON* SVFIRWriter::contentToJson(const SVFArrayType* type)
 {
-    return contentToJson(static_cast<const SVFType*>(type));
+    cJSON* root = contentToJson(static_cast<const SVFType*>(type));
+    JSON_WRITE_FIELD(root, type, numOfElement);
+    JSON_WRITE_FIELD(root, type, typeOfElement);
+    return root;
 }
 
 cJSON* SVFIRWriter::contentToJson(const SVFOtherType* type)
 {
-    return contentToJson(static_cast<const SVFType*>(type));
+    cJSON* root = contentToJson(static_cast<const SVFType*>(type));
+    JSON_WRITE_FIELD(root, type, repr);
+    return root;
 }
 
 cJSON* SVFIRWriter::contentToJson(const SVFValue* value)
@@ -2492,16 +2499,20 @@ void SVFIRReader::fill(const cJSON*& fieldJson, SVFFunctionType* type)
 void SVFIRReader::fill(const cJSON*& fieldJson, SVFStructType* type)
 {
     fill(fieldJson, static_cast<SVFType*>(type));
+    JSON_READ_FIELD_FWD(fieldJson, type, name);
 }
 
 void SVFIRReader::fill(const cJSON*& fieldJson, SVFArrayType* type)
 {
     fill(fieldJson, static_cast<SVFType*>(type));
+    JSON_READ_FIELD_FWD(fieldJson, type, numOfElement);
+    JSON_READ_FIELD_FWD(fieldJson, type, typeOfElement);
 }
 
 void SVFIRReader::fill(const cJSON*& fieldJson, SVFOtherType* type)
 {
     fill(fieldJson, static_cast<SVFType*>(type));
+    JSON_READ_FIELD_FWD(fieldJson, type, repr);
 }
 
 SVFIR* SVFIRReader::read(const std::string& path)

--- a/svf/lib/SVFIR/SVFType.cpp
+++ b/svf/lib/SVFIR/SVFType.cpp
@@ -1,0 +1,44 @@
+#include "SVFIR/SVFType.h"
+
+namespace SVF
+{
+
+std::ostream& operator<<(std::ostream& OS, const SVFType& type)
+{
+    type.print(OS);
+    return OS;
+}
+
+void SVFPointerType::print(std::ostream& OS) const
+{
+    getPtrElementType()->print(OS);
+    OS << "*";
+}
+
+void SVFIntegerType::print(std::ostream& OS) const
+{
+    // Making it more informative?
+    OS << "I";
+}
+
+void SVFFunctionType::print(std::ostream& OS) const
+{
+    OS << *getReturnType() << "()";
+}
+
+void SVFStructType::print(std::ostream& OS) const
+{
+    OS << "S." << name;
+}
+
+void SVFArrayType::print(std::ostream& OS) const
+{
+    OS << "[" << numOfElement << "x" << *typeOfElement << "]";
+}
+
+void SVFOtherType::print(std::ostream& OS) const
+{
+    OS << repr;
+}
+
+} // namespace SVF

--- a/svf/lib/SVFIR/SVFType.cpp
+++ b/svf/lib/SVFIR/SVFType.cpp
@@ -1,7 +1,14 @@
 #include "SVFIR/SVFType.h"
+#include <sstream>
 
 namespace SVF
 {
+std::string SVFType::toString() const
+{
+    std::ostringstream os;
+    print(os);
+    return os.str();
+}
 
 std::ostream& operator<<(std::ostream& OS, const SVFType& type)
 {

--- a/svf/lib/SVFIR/SymbolTableInfo.cpp
+++ b/svf/lib/SVFIR/SymbolTableInfo.cpp
@@ -237,61 +237,45 @@ const std::vector<const SVFType*>& SymbolTableInfo::getFlattenFieldTypes(const S
 void SymbolTableInfo::printFlattenFields(const SVFType* type)
 {
 
-    if(const SVFArrayType *at = SVFUtil::dyn_cast<SVFArrayType> (type))
+    if (const SVFArrayType* at = SVFUtil::dyn_cast<SVFArrayType>(type))
     {
-        outs() <<"  {Type: ";
-        outs() << at->toString();
-        outs() << "}\n";
-        outs() << "\tarray type ";
-        outs() << "\t [element size = " << getNumOfFlattenElements(at) << "]\n";
-        outs() << "\n";
+        outs() << "  {Type: " << *at << "}\n"
+               << "\tarray type "
+               << "\t [element size = " << getNumOfFlattenElements(at) << "]\n"
+               << "\n";
     }
-
     else if(const SVFStructType *st = SVFUtil::dyn_cast<SVFStructType> (type))
     {
-        outs() <<"  {Type: ";
-        outs() << st->toString();
-        outs() << "}\n";
+        outs() <<"  {Type: " << *st << "}\n";
         const std::vector<const SVFType*>& finfo = getTypeInfo(st)->getFlattenFieldTypes();
         int field_idx = 0;
-        for(std::vector<const SVFType*>::const_iterator it = finfo.begin(), eit = finfo.end();
-                it!=eit; ++it, field_idx++)
+        for(const SVFType* type : finfo)
         {
-            outs() << " \tField_idx = " << field_idx;
-            outs() << ", field type: ";
-            outs() << (*it)->toString();
-            outs() << "\n";
+            outs() << " \tField_idx = " << ++field_idx
+                   << ", field type: " << *type << "\n";
         }
         outs() << "\n";
     }
-
     else if (const SVFPointerType* pt= SVFUtil::dyn_cast<SVFPointerType> (type))
     {
         u32_t eSize = getNumOfFlattenElements(pt->getPtrElementType());
-        outs() << "  {Type: ";
-        outs() << pt->toString();
-        outs() << "}\n";
-        outs() <<"\t [target size = " << eSize << "]\n";
-        outs() << "\n";
+        outs() << "  {Type: " << *pt << "}\n"
+               << "\t [target size = " << eSize << "]\n"
+               << "\n";
     }
-
-    else if ( const SVFFunctionType* fu= SVFUtil::dyn_cast<SVFFunctionType> (type))
+    else if (const SVFFunctionType* fu =
+                 SVFUtil::dyn_cast<SVFFunctionType>(type))
     {
-        outs() << "  {Type: ";
-        outs() << fu->getReturnType()->toString();
-        outs() << "(Function)}\n\n";
+        outs() << "  {Type: " << *fu << "}\n\n";
     }
-
     else
     {
         assert(type->isSingleValueType() && "not a single value type, then what else!!");
         /// All rest types are scalar type?
         u32_t eSize = getNumOfFlattenElements(type);
-        outs() <<"  {Type: ";
-        outs() << type->toString();
-        outs() << "}\n";
-        outs() <<"\t [object size = " << eSize << "]\n";
-        outs() << "\n";
+        outs() << "  {Type: " << *type << "}\n"
+               << "\t [object size = " << eSize << "]\n"
+               << "\n";
     }
 }
 
@@ -586,4 +570,3 @@ bool SymbolTableInfo::hasValSym(const SVFValue* val)
     else
         return (valSymMap.find(val) != valSymMap.end());
 }
-


### PR DESCRIPTION
To make string representation of SVF data structure independent of LLVM BC, we need to remove both
- `SVFType::toString()`
- `SVFValue::toString()`
and store necessary information in SVF IR.

This is the part 1 of it.