### PR TITLE
Update collectArrayInfo() and collectStructInfo()

### DIFF
--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -1057,8 +1057,9 @@ StInfo* LLVMModuleSet::collectArrayInfo(const ArrayType* ty)
     /// Array's flatten field infor is the same as its element's
     /// flatten infor.
     StInfo* elemStInfo = collectTypeInfo(elemTy);
-    u32_t nfE = elemStInfo->getNumOfFlattenFields();
-    for (u32_t j = 0; j < nfE; j++)
+    u32_t nfF = elemStInfo->getNumOfFlattenFields();
+    u32_t nfE = elemStInfo->getNumOfFlattenElements();
+    for (u32_t j = 0; j < nfF; j++)
     {
         const SVFType* fieldTy = elemStInfo->getFlattenFieldTypes()[j];
         stInfo->getFlattenFieldTypes().push_back(fieldTy);
@@ -1077,14 +1078,14 @@ StInfo* LLVMModuleSet::collectArrayInfo(const ArrayType* ty)
     {
         for (u32_t j = 0; j < nfE; ++j)
         {
-            const SVFType* et = elemStInfo->getFlattenFieldTypes()[j];
+            const SVFType* et = elemStInfo->getFlattenElementTypes()[j];
             stInfo->getFlattenElementTypes().push_back(et);
         }
     }
 
     assert(stInfo->getFlattenElementTypes().size() == nfE * totalElemNum &&
            "typeForArray size incorrect!!!");
-    stInfo->setNumOfFieldsAndElems(nfE, nfE * totalElemNum);
+    stInfo->setNumOfFieldsAndElems(nfF, nfE * totalElemNum);
 
     return stInfo;
 }
@@ -1112,23 +1113,22 @@ StInfo* LLVMModuleSet::collectStructInfo(const StructType* structTy,
         if (SVFUtil::isa<StructType, ArrayType>(elemTy))
         {
             StInfo* subStInfo = collectTypeInfo(elemTy);
-            u32_t nfE = subStInfo->getNumOfFlattenFields();
+            u32_t nfF = subStInfo->getNumOfFlattenFields();
+            u32_t nfE = subStInfo->getNumOfFlattenElements();
             // Copy ST's info, whose element 0 is the size of ST itself.
-            for (u32_t j = 0; j < nfE; ++j)
+            for (u32_t j = 0; j < nfF; ++j)
             {
                 const SVFType* elemTy = subStInfo->getFlattenFieldTypes()[j];
                 stInfo->getFlattenFieldTypes().push_back(elemTy);
             }
-            numFields += nfE;
-            strideOffset += nfE * subStInfo->getStride();
-            for (u32_t tpi = 0; tpi < subStInfo->getStride(); ++tpi)
+            numFields += nfF;
+            strideOffset += nfE;
+            for (u32_t tpj = 0; tpj < nfE; ++tpj)
             {
-                for (u32_t tpj = 0; tpj < nfE; ++tpj)
-                {
-                    const SVFType* ty = subStInfo->getFlattenFieldTypes()[tpj];
-                    stInfo->getFlattenElementTypes().push_back(ty);
-                }
+                const SVFType* ty = subStInfo->getFlattenElementTypes()[tpj];
+                stInfo->getFlattenElementTypes().push_back(ty);
             }
+
         }
         else
         {


### PR DESCRIPTION
## Test Case
```sh
typedef struct Data
{
	float a;
	int b;
	char c;
	char cc[3];
	short d;
	void *ptr;
} Data;

Data arr[2][5];
```
##  Before Update
```sh
  {SVFArrayType: [2 x [5 x %struct.Data]]}
      fldIdxVec
         0
         0
      elemIdxVec
         0
         30
      fldIdx2TypeMap
         0 ==> SVFStructTy %struct.Data = type { float, i32, i8, [3 x i8], i16, i8* }
      finfo
         SVFOtherTy float
         SVFIntegerTy i32
         SVFIntegerTy i8
         SVFIntegerTy i8
         SVFIntegerTy i16
         SVFPointerTy i8*
      stride
         10
      numOfFlattenElements
         60
      numOfFlattenFields
         6

  {SVFStructType: %struct.Data = type { float, i32, i8, [3 x i8], i16, i8* }}
      fldIdxVec
         0
         1
         2
         3
         4
         5
      elemIdxVec
         0
         1
         2
         3
         6
         7
      fldIdx2TypeMap
         5 ==> SVFPointerTy i8*
         4 ==> SVFIntegerTy i16
         3 ==> SVFArrayTy [3 x i8]
         2 ==> SVFIntegerTy i8
         1 ==> SVFIntegerTy i32
         0 ==> SVFOtherTy float
      finfo
         SVFOtherTy float
         SVFIntegerTy i32
         SVFIntegerTy i8
         SVFIntegerTy i8
         SVFIntegerTy i16
         SVFPointerTy i8*
      stride
         1
      numOfFlattenElements
         8
      numOfFlattenFields
         6
```
## After Update

### Without  -model-arrays 
```sh
  {SVFArrayType: [2 x [5 x %struct.Data]]}
	array type 	 [element size = 6]

      fldIdxVec
         0
         0
      elemIdxVec
         0
         40
      fldIdx2TypeMap
         0 ==> SVFStructTy %struct.Data = type { float, i32, i8, [3 x i8], i16, i8* }
      finfo
         SVFOtherTy float
         SVFIntegerTy i32
         SVFIntegerTy i8
         SVFIntegerTy i8
         SVFIntegerTy i16
         SVFPointerTy i8*
      stride
         10
      numOfFlattenElements
         80
      numOfFlattenFields
         6

```

### With  -model-arrays 
```sh
  {SVFArrayType: [2 x [5 x %struct.Data]]}
	array type 	 [element size = 80]

      fldIdxVec
         0
         0
      elemIdxVec
         0
         40
      fldIdx2TypeMap
         0 ==> SVFStructTy %struct.Data = type { float, i32, i8, [3 x i8], i16, i8* }
      finfo
         SVFOtherTy float
         SVFIntegerTy i32
         SVFIntegerTy i8
         SVFIntegerTy i8
         SVFIntegerTy i16
         SVFPointerTy i8*
      stride
         10
      numOfFlattenElements
         80
      numOfFlattenFields
         6
```