### PR TITLE
add getSVFBugReport for SrcSnkDDA

### DIFF
--- a/svf/include/SABER/SrcSnkDDA.h
+++ b/svf/include/SABER/SrcSnkDDA.h
@@ -243,6 +243,10 @@ public:
         return saberCondAllocator.get();
     }
 
+    inline const SVFBugReport& getBugReport() const {
+        return report;
+    }
+
 protected:
     /// Forward traverse
     inline void FWProcessCurNode(const DPIm& item) override

--- a/svf/include/Util/SVFBugReport.h
+++ b/svf/include/Util/SVFBugReport.h
@@ -356,7 +356,7 @@ public:
      * function: pass file path, open the file and dump bug report as JSON format
      * usage: dumpToFile("/path/to/file")
      */
-    void dumpToJsonFile(const std::string& filePath);
+    void dumpToJsonFile(const std::string& filePath) const;
 
     /*
      * function: get underlying bugset

--- a/svf/include/Util/SVFBugReport.h
+++ b/svf/include/Util/SVFBugReport.h
@@ -84,7 +84,7 @@ public:
 
 public:
     enum BugType {FULLBUFOVERFLOW, PARTIALBUFOVERFLOW, NEVERFREE, PARTIALLEAK, DOUBLEFREE, FILENEVERCLOSE, FILEPARTIALCLOSE};
-    static const std::string BugTypeName[7];
+    static const std::map<GenericBug::BugType, std::string> BugType2Str;
 
 protected:
     BugType bugType;

--- a/svf/include/Util/SVFBugReport.h
+++ b/svf/include/Util/SVFBugReport.h
@@ -84,6 +84,7 @@ public:
 
 public:
     enum BugType {FULLBUFOVERFLOW, PARTIALBUFOVERFLOW, NEVERFREE, PARTIALLEAK, DOUBLEFREE, FILENEVERCLOSE, FILEPARTIALCLOSE};
+    static const std::string BugTypeName[7];
 
 protected:
     BugType bugType;
@@ -356,6 +357,15 @@ public:
      * usage: dumpToFile("/path/to/file")
      */
     void dumpToJsonFile(const std::string& filePath);
+
+    /*
+     * function: get underlying bugset
+     * usage: getBugSet()
+     */
+    const BugSet &getBugSet() const{
+        return bugSet;
+    }
+
 };
 }
 

--- a/svf/lib/Util/SVFBugReport.cpp
+++ b/svf/lib/Util/SVFBugReport.cpp
@@ -35,6 +35,11 @@
 using namespace std;
 using namespace SVF;
 
+
+const std::string GenericBug::BugTypeName[7] = {
+    "FULLBUFOVERFLOW", "PARTIALBUFOVERFLOW", "NEVERFREE",
+    "PARTIALLEAK", "DOUBLEFREE", "FILENEVERCLOSE", "FILEPARTIALCLOSE"};
+
 const std::string GenericBug::getLoc() const
 {
     const SVFBugEvent&sourceInstEvent = bugEventStack.at(bugEventStack.size() -1);

--- a/svf/lib/Util/SVFBugReport.cpp
+++ b/svf/lib/Util/SVFBugReport.cpp
@@ -310,7 +310,7 @@ SVFBugReport::~SVFBugReport()
     }
 }
 
-void SVFBugReport::dumpToJsonFile(const std::string& filePath)
+void SVFBugReport::dumpToJsonFile(const std::string& filePath) const
 {
     std::map<u32_t, std::string> eventType2Str =
     {

--- a/svf/lib/Util/SVFBugReport.cpp
+++ b/svf/lib/Util/SVFBugReport.cpp
@@ -35,10 +35,16 @@
 using namespace std;
 using namespace SVF;
 
-
-const std::string GenericBug::BugTypeName[7] = {
-    "FULLBUFOVERFLOW", "PARTIALBUFOVERFLOW", "NEVERFREE",
-    "PARTIALLEAK", "DOUBLEFREE", "FILENEVERCLOSE", "FILEPARTIALCLOSE"};
+const std::map<GenericBug::BugType, std::string> GenericBug::BugType2Str =
+    {
+        {GenericBug::FULLBUFOVERFLOW, "Full Buffer Overflow"},
+        {GenericBug::PARTIALBUFOVERFLOW, "Partial Buffer Overflow"},
+        {GenericBug::NEVERFREE, "Never Free"},
+        {GenericBug::PARTIALLEAK, "Partial Leak"},
+        {GenericBug::FILENEVERCLOSE, "File Never Close"},
+        {GenericBug::FILEPARTIALCLOSE, "File Partial Close"},
+        {GenericBug::DOUBLEFREE, "Double Free"}
+};
 
 const std::string GenericBug::getLoc() const
 {
@@ -314,17 +320,6 @@ void SVFBugReport::dumpToJsonFile(const std::string& filePath)
         {SVFBugEvent::Branch, "branch"}
     };
 
-    std::map<GenericBug::BugType, std::string> bugType2Str =
-    {
-        {GenericBug::FULLBUFOVERFLOW, "Full Buffer Overflow"},
-        {GenericBug::PARTIALBUFOVERFLOW, "Partial Buffer Overflow"},
-        {GenericBug::NEVERFREE, "Never Free"},
-        {GenericBug::PARTIALLEAK, "Partial Leak"},
-        {GenericBug::FILENEVERCLOSE, "File Never Close"},
-        {GenericBug::FILEPARTIALCLOSE, "File Partial Close"},
-        {GenericBug::DOUBLEFREE, "Double Free"}
-    };
-
     ofstream jsonFile(filePath, ios::out);
 
     jsonFile << "[";
@@ -335,7 +330,7 @@ void SVFBugReport::dumpToJsonFile(const std::string& filePath)
         cJSON *singleBug = cJSON_CreateObject();
 
         /// add bug information to json
-        cJSON *bugType = cJSON_CreateString(bugType2Str[bugPtr->getBugType()].c_str());
+        cJSON *bugType = cJSON_CreateString(GenericBug::BugType2Str.at(bugPtr->getBugType()).c_str());
         cJSON_AddItemToObject(singleBug, "DefectType", bugType);
 
         cJSON *bugLoc = cJSON_Parse(bugPtr->getLoc().c_str());


### PR DESCRIPTION
This PR enables various checkers (leak checker, free checker, etc) to have access to bug reports after running on modules. 

It also adds literal strings for `GenericBug::BugType`.

Please refer to issue #1104 . Close #1104 after PR.