### PR TITLE
Making naming consistent with type

### DIFF
--- a/svf-llvm/include/SVF-LLVM/SVFIRBuilder.h
+++ b/svf-llvm/include/SVF-LLVM/SVFIRBuilder.h
@@ -216,10 +216,10 @@ protected:
     void processCE(const Value* val);
 
     /// Infer field index from byteoffset.
-    u32_t inferFieldIdxFromByteOffset(const llvm::GEPOperator* gepOp, DataLayout *dl, AccessPath& ls, APOffset idx);
+    u32_t inferFieldIdxFromByteOffset(const llvm::GEPOperator* gepOp, DataLayout *dl, AccessPath& ap, APOffset idx);
 
     /// Compute offset of a gep instruction or gep constant expression
-    bool computeGepOffset(const User *V, AccessPath& ls);
+    bool computeGepOffset(const User *V, AccessPath& ap);
 
     /// Get the base value of (i8* src and i8* dst) for external argument (e.g. memcpy(i8* dst, i8* src, int size))
     const Value* getBaseValueForExtArg(const Value* V);
@@ -287,7 +287,7 @@ protected:
         return nullPtr;
     }
 
-    NodeID getGepValVar(const SVFValue* val, const AccessPath& ls, const SVFType* baseType);
+    NodeID getGepValVar(const SVFValue* val, const AccessPath& ap, const SVFType* baseType);
 
     void setCurrentBBAndValueForPAGEdge(PAGEdge* edge);
 
@@ -364,53 +364,53 @@ protected:
     inline void addStoreEdge(NodeID src, NodeID dst)
     {
         IntraICFGNode* node;
-        if(const SVFInstruction* inst = SVFUtil::dyn_cast<SVFInstruction>(curVal))
+        if (const SVFInstruction* inst = SVFUtil::dyn_cast<SVFInstruction>(curVal))
             node = pag->getICFG()->getIntraICFGNode(inst);
         else
             node = nullptr;
-        if(StoreStmt *edge = pag->addStoreStmt(src, dst, node))
+        if (StoreStmt* edge = pag->addStoreStmt(src, dst, node))
             setCurrentBBAndValueForPAGEdge(edge);
     }
     /// Add Call edge
     inline void addCallEdge(NodeID src, NodeID dst, const CallICFGNode* cs, const FunEntryICFGNode* entry)
     {
-        if(CallPE *edge = pag->addCallPE(src, dst, cs, entry))
+        if (CallPE* edge = pag->addCallPE(src, dst, cs, entry))
             setCurrentBBAndValueForPAGEdge(edge);
     }
     /// Add Return edge
     inline void addRetEdge(NodeID src, NodeID dst, const CallICFGNode* cs, const FunExitICFGNode* exit)
     {
-        if(RetPE *edge = pag->addRetPE(src, dst, cs, exit))
+        if (RetPE* edge = pag->addRetPE(src, dst, cs, exit))
             setCurrentBBAndValueForPAGEdge(edge);
     }
     /// Add Gep edge
-    inline void addGepEdge(NodeID src, NodeID dst, const AccessPath& ls, bool constGep)
+    inline void addGepEdge(NodeID src, NodeID dst, const AccessPath& ap, bool constGep)
     {
-        if(GepStmt *edge = pag->addGepStmt(src, dst, ls, constGep))
+        if (GepStmt* edge = pag->addGepStmt(src, dst, ap, constGep))
             setCurrentBBAndValueForPAGEdge(edge);
     }
     /// Add Offset(Gep) edge
-    inline void addNormalGepEdge(NodeID src, NodeID dst, const AccessPath& ls)
+    inline void addNormalGepEdge(NodeID src, NodeID dst, const AccessPath& ap)
     {
-        if(GepStmt *edge = pag->addNormalGepStmt(src, dst, ls))
+        if (GepStmt* edge = pag->addNormalGepStmt(src, dst, ap))
             setCurrentBBAndValueForPAGEdge(edge);
     }
     /// Add Variant(Gep) edge
-    inline void addVariantGepEdge(NodeID src, NodeID dst, const AccessPath& ls)
+    inline void addVariantGepEdge(NodeID src, NodeID dst, const AccessPath& ap)
     {
-        if(GepStmt *edge = pag->addVariantGepStmt(src, dst, ls))
+        if (GepStmt* edge = pag->addVariantGepStmt(src, dst, ap))
             setCurrentBBAndValueForPAGEdge(edge);
     }
     /// Add Thread fork edge for parameter passing
     inline void addThreadForkEdge(NodeID src, NodeID dst, const CallICFGNode* cs, const FunEntryICFGNode* entry)
     {
-        if(TDForkPE *edge = pag->addThreadForkPE(src, dst, cs, entry))
+        if (TDForkPE* edge = pag->addThreadForkPE(src, dst, cs, entry))
             setCurrentBBAndValueForPAGEdge(edge);
     }
     /// Add Thread join edge for parameter passing
     inline void addThreadJoinEdge(NodeID src, NodeID dst, const CallICFGNode* cs, const FunExitICFGNode* exit)
     {
-        if(TDJoinPE *edge = pag->addThreadJoinPE(src, dst, cs, exit))
+        if (TDJoinPE* edge = pag->addThreadJoinPE(src, dst, cs, exit))
             setCurrentBBAndValueForPAGEdge(edge);
     }
     //@}

--- a/svf-llvm/lib/SVFIRExtAPI.cpp
+++ b/svf-llvm/lib/SVFIRExtAPI.cpp
@@ -471,8 +471,8 @@ void SVFIRBuilder::extFuncAtomaticOperation(ExtAPI::Operand& atomicOp, const SVF
     {
         if (!atomicOp.getSrcValue().empty() && !atomicOp.getDstValue().empty() && !atomicOp.getOffsetOrSizeStr().empty())
         {
-            AccessPath ls(atomicOp.getOffsetOrSize());
-            addNormalGepEdge(atomicOp.getSrcID(), atomicOp.getDstID(), ls);
+            AccessPath ap(atomicOp.getOffsetOrSize());
+            addNormalGepEdge(atomicOp.getSrcID(), atomicOp.getDstID(), ap);
         }
         else
             writeWrnMsg("We need two valid NodeIDs and an offset to add a Gep edge");

--- a/svf-llvm/tools/MTA/LockResultValidator.cpp
+++ b/svf-llvm/tools/MTA/LockResultValidator.cpp
@@ -20,7 +20,7 @@ namespace SVF
 class RaceValidator : public RaceResultValidator
 {
 public:
-    RaceValidator(LockAnalysis* ls) :lsa(ls)
+    RaceValidator(LockAnalysis* lockAnalysis) :lsa(lockAnalysis)
     {
     }
     bool protectedByCommonLocks(const Instruction* I1, const Instruction* I2)

--- a/svf/include/Graphs/ConsG.h
+++ b/svf/include/Graphs/ConsG.h
@@ -52,7 +52,7 @@ public:
     typedef FIFOWorkList<NodeID> WorkList;
 
 protected:
-    SVFIR*pag;
+    SVFIR* pag;
     NodeToRepMap nodeToRepMap;
     NodeToSubsMap nodeToSubsMap;
     WorkList nodesToBeCollapsed;
@@ -180,7 +180,7 @@ public:
     /// Add Copy edge
     CopyCGEdge* addCopyCGEdge(NodeID src, NodeID dst);
     /// Add Gep edge
-    NormalGepCGEdge*  addNormalGepCGEdge(NodeID src, NodeID dst, const AccessPath& ls);
+    NormalGepCGEdge* addNormalGepCGEdge(NodeID src, NodeID dst, const AccessPath& ap);
     VariantGepCGEdge* addVariantGepCGEdge(NodeID src, NodeID dst);
     /// Add Load edge
     LoadCGEdge* addLoadCGEdge(NodeID src, NodeID dst);
@@ -325,9 +325,9 @@ public:
         return (mem->getMaxFieldOffsetLimit() == 1);
     }
     /// Get a field of a memory object
-    inline NodeID getGepObjVar(NodeID id, const APOffset& ls)
+    inline NodeID getGepObjVar(NodeID id, const APOffset& apOffset)
     {
-        NodeID gep =  pag->getGepObjVar(id,ls);
+        NodeID gep =  pag->getGepObjVar(id, apOffset);
         /// Create a node when it is (1) not exist on graph and (2) not merged
         if(sccRepNode(gep)==gep && hasConstraintNode(gep)==false)
             addConstraintNode(new ConstraintNode(gep),gep);

--- a/svf/include/Graphs/ConsGEdge.h
+++ b/svf/include/Graphs/ConsGEdge.h
@@ -269,7 +269,7 @@ private:
     NormalGepCGEdge(const NormalGepCGEdge &);  ///< place holder
     void operator=(const NormalGepCGEdge &); ///< place holder
 
-    AccessPath ls;	///< location set of the gep edge
+    AccessPath ap;	///< Access path of the gep edge
 
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -293,20 +293,22 @@ public:
     //@}
 
     /// Constructor
-    NormalGepCGEdge(ConstraintNode* s, ConstraintNode* d, const AccessPath& l, EdgeID id)
-        : GepCGEdge(s,d,NormalGep,id), ls(l)
-    {}
+    NormalGepCGEdge(ConstraintNode* s, ConstraintNode* d, const AccessPath& ap,
+                    EdgeID id)
+        : GepCGEdge(s, d, NormalGep, id), ap(ap)
+    {
+    }
 
     /// Get location set of the gep edge
     inline const AccessPath& getAccessPath() const
     {
-        return ls;
+        return ap;
     }
 
     /// Get location set of the gep edge
     inline APOffset getConstantFieldIdx() const
     {
-        return ls.getConstantFieldIdx();
+        return ap.getConstantFieldIdx();
     }
 
 };

--- a/svf/include/MemoryModel/AccessPath.h
+++ b/svf/include/MemoryModel/AccessPath.h
@@ -68,9 +68,9 @@ public:
     AccessPath(APOffset o = 0) : fldIdx(o) {}
 
     /// Copy Constructor
-    AccessPath(const AccessPath& ls)
-        : fldIdx(ls.fldIdx),
-          offsetVarAndGepTypePairs(ls.getOffsetVarAndGepTypePairVec())
+    AccessPath(const AccessPath& ap)
+        : fldIdx(ap.fldIdx),
+          offsetVarAndGepTypePairs(ap.getOffsetVarAndGepTypePairVec())
     {
     }
 
@@ -146,11 +146,12 @@ private:
 
 template <> struct std::hash<SVF::AccessPath>
 {
-    size_t operator()(const SVF::AccessPath &ls) const
+    size_t operator()(const SVF::AccessPath &ap) const
     {
         SVF::Hash<std::pair<SVF::NodeID, SVF::NodeID>> h;
         std::hash<SVF::AccessPath::OffsetVarAndGepTypePairs> v;
-        return h(std::make_pair(ls.getConstantFieldIdx(), v(ls.getOffsetVarAndGepTypePairVec())));
+        return h(std::make_pair(ap.getConstantFieldIdx(),
+                                v(ap.getOffsetVarAndGepTypePairVec())));
     }
 };
 

--- a/svf/include/MemoryModel/PointerAnalysis.h
+++ b/svf/include/MemoryModel/PointerAnalysis.h
@@ -338,9 +338,9 @@ public:
     {
         return pag->getFIObjVar(id);
     }
-    inline NodeID getGepObjVar(NodeID id, const APOffset& ls)
+    inline NodeID getGepObjVar(NodeID id, const APOffset& ap)
     {
-        return pag->getGepObjVar(id,ls);
+        return pag->getGepObjVar(id, ap);
     }
     virtual inline const NodeBS& getAllFieldsObjVars(NodeID id)
     {

--- a/svf/include/SVFIR/SVFFileSystem.h
+++ b/svf/include/SVFIR/SVFFileSystem.h
@@ -422,7 +422,7 @@ private:
     cJSON* toJson(const CHEdge* edge);         // CHGraph Edge
 
     cJSON* toJson(const CallSite& cs);
-    cJSON* toJson(const AccessPath& ls);
+    cJSON* toJson(const AccessPath& ap);
     cJSON* toJson(const SVFLoop* loop);
     cJSON* toJson(const MemObj* memObj);
     cJSON* toJson(const ObjTypeInfo* objTypeInfo);  // Only owned by MemObj
@@ -1104,7 +1104,7 @@ private:
     void readJson(const cJSON* obj, CHEdge*& edge); // CHGraph Edge
     void readJson(const cJSON* obj, CallSite& cs); // CHGraph's csToClassMap
 
-    void readJson(const cJSON* obj, AccessPath& ls);
+    void readJson(const cJSON* obj, AccessPath& ap);
     void readJson(const cJSON* obj, SVFLoop*& loop);
     void readJson(const cJSON* obj, MemObj*& memObj);
     void readJson(const cJSON* obj,

--- a/svf/include/SVFIR/SVFIR.h
+++ b/svf/include/SVFIR/SVFIR.h
@@ -328,7 +328,8 @@ public:
     //@}
 
     /// Due to constaint expression, curInst is used to distinguish different instructions (e.g., memorycpy) when creating GepValVar.
-    NodeID getGepValVar(const SVFValue* curInst, NodeID base, const AccessPath& ls) const;
+    NodeID getGepValVar(const SVFValue* curInst, NodeID base,
+                        const AccessPath& ap) const;
 
     /// Add/get indirect callsites
     //@{
@@ -392,9 +393,9 @@ public:
     //@}
 
     /// Get a field SVFIR Object node according to base mem obj and offset
-    NodeID getGepObjVar(const MemObj* obj, const APOffset& ls);
+    NodeID getGepObjVar(const MemObj* obj, const APOffset& ap);
     /// Get a field obj SVFIR node according to a mem obj and a given offset
-    NodeID getGepObjVar(NodeID id, const APOffset& ls) ;
+    NodeID getGepObjVar(NodeID id, const APOffset& ap) ;
     /// Get a field-insensitive obj SVFIR node according to a mem obj
     //@{
     inline NodeID getFIObjVar(const MemObj* obj) const
@@ -557,9 +558,9 @@ private:
     }
 
     /// Add a temp field value node, this method can only invoked by getGepValVar
-    NodeID addGepValNode(const SVFValue* curInst,const SVFValue* val, const AccessPath& ls, NodeID i, const SVFType* type);
+    NodeID addGepValNode(const SVFValue* curInst,const SVFValue* val, const AccessPath& ap, NodeID i, const SVFType* type);
     /// Add a field obj node, this method can only invoked by getGepObjVar
-    NodeID addGepObjNode(const MemObj* obj, const APOffset& ls);
+    NodeID addGepObjNode(const MemObj* obj, const APOffset& apOffset);
     /// Add a field-insensitive node, this method can only invoked by getFIGepObjNode
     NodeID addFIObjNode(const MemObj* obj);
     //@}
@@ -665,12 +666,12 @@ private:
     RetPE* addRetPE(NodeID src, NodeID dst, const CallICFGNode* cs,
                     const FunExitICFGNode* exit);
     /// Add Gep edge
-    GepStmt* addGepStmt(NodeID src, NodeID dst, const AccessPath& ls,
+    GepStmt* addGepStmt(NodeID src, NodeID dst, const AccessPath& ap,
                         bool constGep);
     /// Add Offset(Gep) edge
-    GepStmt* addNormalGepStmt(NodeID src, NodeID dst, const AccessPath& ls);
+    GepStmt* addNormalGepStmt(NodeID src, NodeID dst, const AccessPath& ap);
     /// Add Variant(Gep) edge
-    GepStmt* addVariantGepStmt(NodeID src, NodeID dst, const AccessPath& ls);
+    GepStmt* addVariantGepStmt(NodeID src, NodeID dst, const AccessPath& ap);
     /// Add Thread fork edge for parameter passing
     TDForkPE* addThreadForkPE(NodeID src, NodeID dst, const CallICFGNode* cs,
                               const FunEntryICFGNode* entry);

--- a/svf/include/SVFIR/SVFStatements.h
+++ b/svf/include/SVFIR/SVFStatements.h
@@ -465,7 +465,7 @@ private:
     GepStmt(const GepStmt &);  ///< place holder
     void operator=(const GepStmt &); ///< place holder
 
-    AccessPath ls;	///< location set of the gep edge
+    AccessPath ap;	///< Access path of the GEP edge
     bool variantField;  ///< Gep statement with a variant field index (pointer arithmetic) for struct field access (e.g., p = &(q + f), where f is a variable)
 public:
     /// Methods for support type inquiry through isa, cast, and dyn_cast:
@@ -486,7 +486,7 @@ public:
 
     inline const AccessPath& getAccessPath() const
     {
-        return ls;
+        return ap;
     }
     inline const AccessPath::OffsetVarAndGepTypePairs getOffsetVarAndGepTypePairVec() const
     {
@@ -515,8 +515,8 @@ public:
     }
 
     /// constructor
-    GepStmt(SVFVar* s, SVFVar* d, const AccessPath& l, bool varfld = false)
-        : AssignStmt(s, d, SVFStmt::Gep), ls(l), variantField(varfld)
+    GepStmt(SVFVar* s, SVFVar* d, const AccessPath& ap, bool varfld = false)
+        : AssignStmt(s, d, SVFStmt::Gep), ap(ap), variantField(varfld)
     {
     }
 

--- a/svf/include/SVFIR/SVFVariables.h
+++ b/svf/include/SVFIR/SVFVariables.h
@@ -383,7 +383,7 @@ class GepValVar: public ValVar
     friend class SVFIRReader;
 
 private:
-    AccessPath ls;	// AccessPath
+    AccessPath ap;	// AccessPath
     const SVFType* gepValType;
 
     /// Constructor to create empty GeValVar (for SVFIRReader/deserialization)
@@ -411,16 +411,16 @@ public:
     //@}
 
     /// Constructor
-    GepValVar(const SVFValue* val, NodeID i, const AccessPath& l,
+    GepValVar(const SVFValue* val, NodeID i, const AccessPath& ap,
               const SVFType* ty)
-        : ValVar(val, i, GepValNode), ls(l), gepValType(ty)
+        : ValVar(val, i, GepValNode), ap(ap), gepValType(ty)
     {
     }
 
     /// offset of the base value variable
     inline APOffset getConstantFieldIdx() const
     {
-        return ls.getConstantFieldIdx();
+        return ap.getConstantFieldIdx();
     }
 
     /// Return name of a LLVM value
@@ -451,7 +451,7 @@ class GepObjVar: public ObjVar
     friend class SVFIRReader;
 
 private:
-    APOffset ls = 0;
+    APOffset apOffset = 0;
     NodeID base = 0;
 
     /// Constructor to create empty GepObjVar (for SVFIRReader/deserialization)
@@ -480,9 +480,9 @@ public:
     //@}
 
     /// Constructor
-    GepObjVar(const MemObj* mem, NodeID i, const APOffset& l,
+    GepObjVar(const MemObj* mem, NodeID i, const APOffset& apOffset,
               PNODEK ty = GepObjNode)
-        : ObjVar(mem->getValue(), i, mem, ty), ls(l)
+        : ObjVar(mem->getValue(), i, mem, ty), apOffset(apOffset)
     {
         base = mem->getId();
     }
@@ -490,7 +490,7 @@ public:
     /// offset of the mem object
     inline APOffset getConstantFieldIdx() const
     {
-        return ls;
+        return apOffset;
     }
 
     /// Set the base object from which this GEP node came from.
@@ -508,15 +508,15 @@ public:
     /// Return the type of this gep object
     inline virtual const SVFType* getType() const
     {
-        return SymbolTableInfo::SymbolInfo()->getFlatternedElemType(mem->getType(), ls);
+        return SymbolTableInfo::SymbolInfo()->getFlatternedElemType(mem->getType(), apOffset);
     }
 
     /// Return name of a LLVM value
     inline const std::string getValueName() const
     {
         if (value)
-            return value->getName() + "_" + std::to_string(ls);
-        return "offset_" + std::to_string(ls);
+            return value->getName() + "_" + std::to_string(apOffset);
+        return "offset_" + std::to_string(apOffset);
     }
 
     virtual const std::string toString() const;

--- a/svf/include/SVFIR/SymbolTableInfo.h
+++ b/svf/include/SVFIR/SymbolTableInfo.h
@@ -333,7 +333,8 @@ public:
     virtual void dump();
 
     /// Given an offset from a Gep Instruction, return it modulus offset by considering memory layout
-    virtual APOffset getModulusOffset(const MemObj* obj, const APOffset& ls);
+    virtual APOffset getModulusOffset(const MemObj* obj,
+                                      const APOffset& apOffset);
 
     ///The struct type with the most fields
     const SVFType* maxStruct;
@@ -453,7 +454,7 @@ public:
     bool isConstDataOrConstGlobal() const;
     bool isConstDataOrAggData() const;
     bool hasPtrObj() const;
-    bool isNonPtrFieldObj(const APOffset& ls) const;
+    bool isNonPtrFieldObj(const APOffset& apOffset) const;
     //@}
 
     /// Operator overloading
@@ -621,7 +622,7 @@ public:
     {
         return hasFlag(HASPTR_OBJ);
     }
-    virtual bool isNonPtrFieldObj(const APOffset& ls);
+    virtual bool isNonPtrFieldObj(const APOffset& apOffset);
     //@}
 };
 

--- a/svf/lib/Graphs/ConsG.cpp
+++ b/svf/lib/Graphs/ConsG.cpp
@@ -210,14 +210,15 @@ CopyCGEdge* ConstraintGraph::addCopyCGEdge(NodeID src, NodeID dst)
 /*!
  * Add Gep edge
  */
-NormalGepCGEdge*  ConstraintGraph::addNormalGepCGEdge(NodeID src, NodeID dst, const AccessPath& ls)
+NormalGepCGEdge*  ConstraintGraph::addNormalGepCGEdge(NodeID src, NodeID dst, const AccessPath& ap)
 {
     ConstraintNode* srcNode = getConstraintNode(src);
     ConstraintNode* dstNode = getConstraintNode(dst);
     if (hasEdge(srcNode, dstNode, ConstraintEdge::NormalGep))
         return nullptr;
 
-    NormalGepCGEdge* edge = new NormalGepCGEdge(srcNode, dstNode,ls, edgeIndex++);
+    NormalGepCGEdge* edge =
+        new NormalGepCGEdge(srcNode, dstNode, ap, edgeIndex++);
 
     bool inserted = directEdgeSet.insert(edge).second;
     (void)inserted; // Suppress warning of unused variable under release build
@@ -320,9 +321,9 @@ void ConstraintGraph::reTargetDstOfEdge(ConstraintEdge* edge, ConstraintNode* ne
     }
     else if(NormalGepCGEdge* gep = SVFUtil::dyn_cast<NormalGepCGEdge>(edge))
     {
-        const AccessPath ls = gep->getAccessPath();
+        const AccessPath ap = gep->getAccessPath();
         removeDirectEdge(gep);
-        addNormalGepCGEdge(srcId,newDstNodeID,ls);
+        addNormalGepCGEdge(srcId,newDstNodeID, ap);
     }
     else if(VariantGepCGEdge* gep = SVFUtil::dyn_cast<VariantGepCGEdge>(edge))
     {
@@ -364,9 +365,9 @@ void ConstraintGraph::reTargetSrcOfEdge(ConstraintEdge* edge, ConstraintNode* ne
     }
     else if(NormalGepCGEdge* gep = SVFUtil::dyn_cast<NormalGepCGEdge>(edge))
     {
-        const AccessPath ls = gep->getAccessPath();
+        const AccessPath ap = gep->getAccessPath();
         removeDirectEdge(gep);
-        addNormalGepCGEdge(newSrcNodeID,dstId,ls);
+        addNormalGepCGEdge(newSrcNodeID, dstId, ap);
     }
     else if(VariantGepCGEdge* gep = SVFUtil::dyn_cast<VariantGepCGEdge>(edge))
     {

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -157,18 +157,15 @@ NodeBS AccessPath::computeAllLocations() const
     return result;
 }
 
-AccessPath AccessPath::operator+ (const AccessPath& rhs) const
+AccessPath AccessPath::operator+(const AccessPath& rhs) const
 {
-    AccessPath ls(rhs);
-    ls.fldIdx += getConstantFieldIdx();
-    OffsetVarAndGepTypePairs::const_iterator it = getOffsetVarAndGepTypePairVec().begin();
-    OffsetVarAndGepTypePairs::const_iterator eit = getOffsetVarAndGepTypePairVec().end();
-    for (; it != eit; ++it)
-        ls.addOffsetVarAndGepTypePair(it->first, it->second);
+    AccessPath ap(rhs);
+    ap.fldIdx += getConstantFieldIdx();
+    for (auto &p : ap.getOffsetVarAndGepTypePairVec())
+        ap.addOffsetVarAndGepTypePair(p.first, p.second);
 
-    return ls;
+    return ap;
 }
-
 
 bool AccessPath::operator< (const AccessPath& rhs) const
 {

--- a/svf/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/svf/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -525,8 +525,8 @@ void BVDataPTAImpl::normalizePointsTo()
     {
         NodeID base = pag->getBaseObjVar(n);
         GepObjVar *gepNode = SVFUtil::dyn_cast<GepObjVar>(pag->getGNode(n));
-        const APOffset ls = gepNode->getConstantFieldIdx();
-        GepObjVarMap.erase(std::make_pair(base, ls));
+        const APOffset apOffset = gepNode->getConstantFieldIdx();
+        GepObjVarMap.erase(std::make_pair(base, apOffset));
         memToFieldsMap[base].reset(n);
 
         pag->removeGNode(gepNode);

--- a/svf/lib/SVFIR/SVFFileSystem.cpp
+++ b/svf/lib/SVFIR/SVFFileSystem.cpp
@@ -323,7 +323,7 @@ cJSON* SVFIRWriter::contentToJson(const ObjVar* var)
 cJSON* SVFIRWriter::contentToJson(const GepValVar* var)
 {
     cJSON* root = contentToJson(static_cast<const ValVar*>(var));
-    JSON_WRITE_FIELD(root, var, ls);
+    JSON_WRITE_FIELD(root, var, ap);
     JSON_WRITE_FIELD(root, var, gepValType);
     return root;
 }
@@ -331,7 +331,7 @@ cJSON* SVFIRWriter::contentToJson(const GepValVar* var)
 cJSON* SVFIRWriter::contentToJson(const GepObjVar* var)
 {
     cJSON* root = contentToJson(static_cast<const ObjVar*>(var));
-    JSON_WRITE_FIELD(root, var, ls);
+    JSON_WRITE_FIELD(root, var, apOffset);
     JSON_WRITE_FIELD(root, var, base);
     return root;
 }
@@ -701,7 +701,7 @@ cJSON* SVFIRWriter::contentToJson(const LoadStmt* edge)
 cJSON* SVFIRWriter::contentToJson(const GepStmt* edge)
 {
     cJSON* root = contentToJson(static_cast<const AssignStmt*>(edge));
-    JSON_WRITE_FIELD(root, edge, ls);
+    JSON_WRITE_FIELD(root, edge, ap);
     JSON_WRITE_FIELD(root, edge, variantField);
     return root;
 }
@@ -1240,11 +1240,11 @@ cJSON* SVFIRWriter::toJson(const StInfo* stInfo)
     return jsonCreateIndex(svfModuleWriter.getStInfoID(stInfo));
 }
 
-cJSON* SVFIRWriter::toJson(const AccessPath& ls)
+cJSON* SVFIRWriter::toJson(const AccessPath& ap)
 {
     cJSON* root = jsonCreateObject();
-    JSON_WRITE_FIELD(root, &ls, fldIdx);
-    JSON_WRITE_FIELD(root, &ls, offsetVarAndGepTypePairs);
+    JSON_WRITE_FIELD(root, &ap, fldIdx);
+    JSON_WRITE_FIELD(root, &ap, offsetVarAndGepTypePairs);
     return root;
 }
 
@@ -1844,12 +1844,12 @@ void SVFIRReader::readJson(const cJSON* obj, CallSite& cs)
     readJson(obj, cs.CB);
 }
 
-void SVFIRReader::readJson(const cJSON* obj, AccessPath& ls)
+void SVFIRReader::readJson(const cJSON* obj, AccessPath& ap)
 {
     ABORT_IFNOT(jsonIsObject(obj), "Expected obj for AccessPath");
     obj = obj->child;
-    JSON_READ_FIELD_FWD(obj, &ls, fldIdx);
-    JSON_READ_FIELD_FWD(obj, &ls, offsetVarAndGepTypePairs);
+    JSON_READ_FIELD_FWD(obj, &ap, fldIdx);
+    JSON_READ_FIELD_FWD(obj, &ap, offsetVarAndGepTypePairs);
     ABORT_IFNOT(!obj, "Extra field " << JSON_KEY(obj) << " in AccessPath");
 }
 
@@ -1948,14 +1948,14 @@ void SVFIRReader::fill(const cJSON*& fieldJson, ObjVar* var)
 void SVFIRReader::fill(const cJSON*& fieldJson, GepValVar* var)
 {
     fill(fieldJson, static_cast<ValVar*>(var));
-    JSON_READ_FIELD_FWD(fieldJson, var, ls);
+    JSON_READ_FIELD_FWD(fieldJson, var, ap);
     JSON_READ_FIELD_FWD(fieldJson, var, gepValType);
 }
 
 void SVFIRReader::fill(const cJSON*& fieldJson, GepObjVar* var)
 {
     fill(fieldJson, static_cast<ObjVar*>(var));
-    JSON_READ_FIELD_FWD(fieldJson, var, ls);
+    JSON_READ_FIELD_FWD(fieldJson, var, apOffset);
     JSON_READ_FIELD_FWD(fieldJson, var, base);
 }
 
@@ -2053,7 +2053,7 @@ void SVFIRReader::fill(const cJSON*& fieldJson, LoadStmt* stmt)
 void SVFIRReader::fill(const cJSON*& fieldJson, GepStmt* stmt)
 {
     fill(fieldJson, static_cast<AssignStmt*>(stmt));
-    JSON_READ_FIELD_FWD(fieldJson, stmt, ls);
+    JSON_READ_FIELD_FWD(fieldJson, stmt, ap);
     JSON_READ_FIELD_FWD(fieldJson, stmt, variantField);
 }
 

--- a/svf/lib/SVFIR/SVFIR.cpp
+++ b/svf/lib/SVFIR/SVFIR.cpp
@@ -324,7 +324,7 @@ TDJoinPE* SVFIR::addThreadJoinPE(NodeID src, NodeID dst, const CallICFGNode* cs,
  * Find the base node id of src and connect base node to dst node
  * Create gep offset:  (offset + baseOff <nested struct gep size>)
  */
-GepStmt* SVFIR::addGepStmt(NodeID src, NodeID dst, const AccessPath& ls, bool constGep)
+GepStmt* SVFIR::addGepStmt(NodeID src, NodeID dst, const AccessPath& ap, bool constGep)
 {
 
     SVFVar* node = getGNode(src);
@@ -332,18 +332,18 @@ GepStmt* SVFIR::addGepStmt(NodeID src, NodeID dst, const AccessPath& ls, bool co
     {
         /// Since the offset from base to src is variant,
         /// the new gep edge being created is also a Variant GepStmt edge.
-        return addVariantGepStmt(src, dst, ls);
+        return addVariantGepStmt(src, dst, ap);
     }
     else
     {
-        return addNormalGepStmt(src, dst, ls);
+        return addNormalGepStmt(src, dst, ap);
     }
 }
 
 /*!
  * Add normal (Gep) edge
  */
-GepStmt* SVFIR::addNormalGepStmt(NodeID src, NodeID dst, const AccessPath& ls)
+GepStmt* SVFIR::addNormalGepStmt(NodeID src, NodeID dst, const AccessPath& ap)
 {
     SVFVar* baseNode = getGNode(src);
     SVFVar* dstNode = getGNode(dst);
@@ -351,7 +351,7 @@ GepStmt* SVFIR::addNormalGepStmt(NodeID src, NodeID dst, const AccessPath& ls)
         return nullptr;
     else
     {
-        GepStmt* gepPE = new GepStmt(baseNode, dstNode, ls);
+        GepStmt* gepPE = new GepStmt(baseNode, dstNode, ap);
         addToStmt2TypeMap(gepPE);
         addEdge(baseNode, dstNode, gepPE);
         return gepPE;
@@ -362,7 +362,7 @@ GepStmt* SVFIR::addNormalGepStmt(NodeID src, NodeID dst, const AccessPath& ls)
  * Add variant(Gep) edge
  * Find the base node id of src and connect base node to dst node
  */
-GepStmt* SVFIR::addVariantGepStmt(NodeID src, NodeID dst, const AccessPath& ls)
+GepStmt* SVFIR::addVariantGepStmt(NodeID src, NodeID dst, const AccessPath& ap)
 {
     SVFVar* baseNode = getGNode(src);
     SVFVar* dstNode = getGNode(dst);
@@ -370,7 +370,7 @@ GepStmt* SVFIR::addVariantGepStmt(NodeID src, NodeID dst, const AccessPath& ls)
         return nullptr;
     else
     {
-        GepStmt* gepPE = new GepStmt(baseNode, dstNode,ls, true);
+        GepStmt* gepPE = new GepStmt(baseNode, dstNode, ap, true);
         addToStmt2TypeMap(gepPE);
         addEdge(baseNode, dstNode, gepPE);
         return gepPE;
@@ -383,29 +383,29 @@ GepStmt* SVFIR::addVariantGepStmt(NodeID src, NodeID dst, const AccessPath& ls)
  * Add a temp field value node, this method can only invoked by getGepValVar
  * due to constaint expression, curInst is used to distinguish different instructions (e.g., memorycpy) when creating GepValVar.
  */
-NodeID SVFIR::addGepValNode(const SVFValue* curInst,const SVFValue* gepVal, const AccessPath& ls, NodeID i, const SVFType* type)
+NodeID SVFIR::addGepValNode(const SVFValue* curInst,const SVFValue* gepVal, const AccessPath& ap, NodeID i, const SVFType* type)
 {
     NodeID base = getBaseValVar(getValueNode(gepVal));
     //assert(findPAGNode(i) == false && "this node should not be created before");
-    assert(0==GepValObjMap[curInst].count(std::make_pair(base, ls))
+    assert(0==GepValObjMap[curInst].count(std::make_pair(base, ap))
            && "this node should not be created before");
-    GepValObjMap[curInst][std::make_pair(base, ls)] = i;
-    GepValVar *node = new GepValVar(gepVal, i, ls, type);
+    GepValObjMap[curInst][std::make_pair(base, ap)] = i;
+    GepValVar *node = new GepValVar(gepVal, i, ap, type);
     return addValNode(gepVal, node, i);
 }
 
 /*!
  * Given an object node, find its field object node
  */
-NodeID SVFIR::getGepObjVar(NodeID id, const APOffset& ls)
+NodeID SVFIR::getGepObjVar(NodeID id, const APOffset& apOffset)
 {
     SVFVar* node = pag->getGNode(id);
     if (GepObjVar* gepNode = SVFUtil::dyn_cast<GepObjVar>(node))
-        return getGepObjVar(gepNode->getMemObj(), gepNode->getConstantFieldIdx() + ls);
+        return getGepObjVar(gepNode->getMemObj(), gepNode->getConstantFieldIdx() + apOffset);
     else if (FIObjVar* baseNode = SVFUtil::dyn_cast<FIObjVar>(node))
-        return getGepObjVar(baseNode->getMemObj(), ls);
+        return getGepObjVar(baseNode->getMemObj(), apOffset);
     else if (DummyObjVar* baseNode = SVFUtil::dyn_cast<DummyObjVar>(node))
-        return getGepObjVar(baseNode->getMemObj(), ls);
+        return getGepObjVar(baseNode->getMemObj(), apOffset);
     else
     {
         assert(false && "new gep obj node kind?");
@@ -419,7 +419,7 @@ NodeID SVFIR::getGepObjVar(NodeID id, const APOffset& ls)
  * offset = offset % obj->getMaxFieldOffsetLimit() to create limited number of mem objects
  * maximum number of field object creation is obj->getMaxFieldOffsetLimit()
  */
-NodeID SVFIR::getGepObjVar(const MemObj* obj, const APOffset& ls)
+NodeID SVFIR::getGepObjVar(const MemObj* obj, const APOffset& apOffset)
 {
     NodeID base = obj->getId();
 
@@ -427,7 +427,7 @@ NodeID SVFIR::getGepObjVar(const MemObj* obj, const APOffset& ls)
     if (obj->isFieldInsensitive())
         return getFIObjVar(obj);
 
-    APOffset newLS = pag->getSymbolInfo()->getModulusOffset(obj,ls);
+    APOffset newLS = pag->getSymbolInfo()->getModulusOffset(obj, apOffset);
 
     // Base and first field are the same memory location.
     if (Options::FirstFieldEqBase() && newLS == 0) return base;
@@ -443,16 +443,16 @@ NodeID SVFIR::getGepObjVar(const MemObj* obj, const APOffset& ls)
 /*!
  * Add a field obj node, this method can only invoked by getGepObjVar
  */
-NodeID SVFIR::addGepObjNode(const MemObj* obj, const APOffset& ls)
+NodeID SVFIR::addGepObjNode(const MemObj* obj, const APOffset& apOffset)
 {
     //assert(findPAGNode(i) == false && "this node should not be created before");
     NodeID base = obj->getId();
-    assert(0==GepObjVarMap.count(std::make_pair(base, ls))
+    assert(0==GepObjVarMap.count(std::make_pair(base, apOffset))
            && "this node should not be created before");
 
-    NodeID gepId = NodeIDAllocator::get()->allocateGepObjectId(base, ls, Options::MaxFieldLimit());
-    GepObjVarMap[std::make_pair(base, ls)] = gepId;
-    GepObjVar *node = new GepObjVar(obj, gepId, ls);
+    NodeID gepId = NodeIDAllocator::get()->allocateGepObjectId(base, apOffset, Options::MaxFieldLimit());
+    GepObjVarMap[std::make_pair(base, apOffset)] = gepId;
+    GepObjVar *node = new GepObjVar(obj, gepId, apOffset);
     memToFieldsMap[base].set(gepId);
     return addObjNode(obj->getValue(), node, gepId);
 }
@@ -535,7 +535,7 @@ NodeID SVFIR::getBaseValVar(NodeID nodeId)
 /*!
  * It is used to create a dummy GepValVar during global initiailzation.
  */
-NodeID SVFIR::getGepValVar(const SVFValue* curInst, NodeID base, const AccessPath& ls) const
+NodeID SVFIR::getGepValVar(const SVFValue* curInst, NodeID base, const AccessPath& ap) const
 {
     GepValueVarMap::const_iterator iter = GepValObjMap.find(curInst);
     if(iter==GepValObjMap.end())
@@ -544,8 +544,9 @@ NodeID SVFIR::getGepValVar(const SVFValue* curInst, NodeID base, const AccessPat
     }
     else
     {
-        NodeAccessPathMap::const_iterator lit = iter->second.find(std::make_pair(base, ls));
-        if(lit==iter->second.end())
+        NodeAccessPathMap::const_iterator lit =
+            iter->second.find(std::make_pair(base, ap));
+        if (lit == iter->second.end())
             return UINT_MAX;
         else
             return lit->second;

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -145,7 +145,7 @@ const std::string GepObjVar::toString() const
 {
     std::string str;
     std::stringstream rawstr(str);
-    rawstr << "GepObjVar ID: " << getId() << " with offset_" + std::to_string(ls);
+    rawstr << "GepObjVar ID: " << getId() << " with offset_" + std::to_string(apOffset);
     if (Options::ShowSVFIRValue())
     {
         rawstr << "\n";

--- a/svf/lib/SVFIR/SymbolTableInfo.cpp
+++ b/svf/lib/SVFIR/SymbolTableInfo.cpp
@@ -91,14 +91,14 @@ SymbolTableInfo* SymbolTableInfo::SymbolInfo()
 /*!
  * Get modulus offset given the type information
  */
-APOffset SymbolTableInfo::getModulusOffset(const MemObj* obj, const APOffset& ls)
+APOffset SymbolTableInfo::getModulusOffset(const MemObj* obj, const APOffset& apOffset)
 {
 
     /// if the offset is negative, it's possible that we're looking for an obj node out of range
     /// of current struct. Make the offset positive so we can still get a node within current
     /// struct to represent this obj.
 
-    APOffset offset = ls;
+    APOffset offset = apOffset;
     if(offset < 0)
     {
         writeWrnMsg("try to create a gep node with negative offset.");
@@ -368,7 +368,7 @@ void SymbolTableInfo::dump()
 /*!
  * Whether a location set is a pointer type or not
  */
-bool ObjTypeInfo::isNonPtrFieldObj(const APOffset& ls)
+bool ObjTypeInfo::isNonPtrFieldObj(const APOffset& apOffset)
 {
     if (hasPtrObj() == false)
         return true;
@@ -383,13 +383,13 @@ bool ObjTypeInfo::isNonPtrFieldObj(const APOffset& ls)
         else
             sz = SymbolTableInfo::SymbolInfo()->getTypeInfo(ety)->getFlattenFieldTypes().size();
 
-        if(sz <= (u32_t) ls)
+        if(sz <= (u32_t) apOffset)
         {
             writeWrnMsg("out of bound error when accessing the struct/array");
             return false;
         }
 
-        const SVFType* elemTy = SymbolTableInfo::SymbolInfo()->getFlatternedElemType(ety, ls);
+        const SVFType* elemTy = SymbolTableInfo::SymbolInfo()->getFlatternedElemType(ety, apOffset);
         return (elemTy->isPointerTy() == false);
     }
     else
@@ -537,9 +537,9 @@ bool MemObj::hasPtrObj() const
     return typeInfo->hasPtrObj();
 }
 
-bool MemObj::isNonPtrFieldObj(const APOffset& ls) const
+bool MemObj::isNonPtrFieldObj(const APOffset& apOffset) const
 {
-    return typeInfo->isNonPtrFieldObj(ls);
+    return typeInfo->isNonPtrFieldObj(apOffset);
 }
 
 const std::string MemObj::toString() const

--- a/svf/lib/WPA/Andersen.cpp
+++ b/svf/lib/WPA/Andersen.cpp
@@ -179,8 +179,8 @@ void AndersenBase::normalizePointsTo()
         NodeID base = pag->getBaseObjVar(n);
         GepObjVar *gepNode = SVFUtil::dyn_cast<GepObjVar>(pag->getGNode(n));
         assert(gepNode && "Not a gep node in redundantGepNodes set");
-        const APOffset ls = gepNode->getConstantFieldIdx();
-        GepObjVarMap.erase(std::make_pair(base, ls));
+        const APOffset apOffset = gepNode->getConstantFieldIdx();
+        GepObjVarMap.erase(std::make_pair(base, apOffset));
         memToFieldsMap[base].reset(n);
         cleanConsCG(n);
 


### PR DESCRIPTION
Rename variables with name legacy name `ls`(locationSet) to `ap`(accessPath) or `apOffset`(access path offset) to make naming consistent with type