### PR TITLE
Avoid repetitive checks in `LLVMUtil::isObject()`

### DIFF
--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -53,17 +53,16 @@ const std::string structName = "struct.";
  */
 bool LLVMUtil::isObject(const Value*  ref)
 {
-    bool createobj = false;
     if (SVFUtil::isa<Instruction>(ref) && SVFUtil::isStaticExtCall(LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(SVFUtil::cast<Instruction>(ref))) )
-        createobj = true;
+        return true;
     if (SVFUtil::isa<Instruction>(ref) && SVFUtil::isHeapAllocExtCallViaRet(LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(SVFUtil::cast<Instruction>(ref))))
-        createobj = true;
+        return true;
     if (SVFUtil::isa<GlobalVariable>(ref))
-        createobj = true;
+        return true;
     if (SVFUtil::isa<Function, AllocaInst>(ref))
-        createobj = true;
+        return true;
 
-    return createobj;
+    return false;
 }
 
 /*!
@@ -659,10 +658,7 @@ bool LLVMUtil::isConstantObjSym(const Value* val)
             return false;
         else if (!v->hasInitializer())
         {
-            if(v->isExternalLinkage(v->getLinkage()))
-                return false;
-            else
-                return true;
+            return !v->isExternalLinkage(v->getLinkage());
         }
         else
         {

--- a/svf-llvm/lib/SymbolTableBuilder.cpp
+++ b/svf-llvm/lib/SymbolTableBuilder.cpp
@@ -324,7 +324,7 @@ void SymbolTableBuilder::collectObj(const Value* val)
         SVFValue* svfVal = LLVMModuleSet::getLLVMModuleSet()->getSVFValue(val);
         // if the object pointed by the pointer is a constant data (e.g., i32 0) or a global constant object (e.g. string)
         // then we treat them as one ConstantObj
-        if((isConstantObjSym(val) && !symInfo->getModelConstants()))
+        if (isConstantObjSym(val) && !symInfo->getModelConstants())
         {
             symInfo->objSymMap.insert(std::make_pair(svfVal, symInfo->constantSymID()));
         }


### PR DESCRIPTION
Avoid repetitive checks like
```
bool b = false; 
if (X) b = true; 
if (Y) b = true;
...
return b;
```
Return immediately when any condition is satisfied.