### PR TITLE
fix typo

### DIFF
--- a/svf/include/Graphs/IRGraph.h
+++ b/svf/include/Graphs/IRGraph.h
@@ -62,7 +62,7 @@ protected:
     bool fromFile; ///< Whether the SVFIR is built according to user specified data from a txt file
     NodeID nodeNumAfterPAGBuild; ///< initial node number after building SVFIR, excluding later added nodes, e.g., gepobj nodes
     u32_t totalPTAPAGEdge;
-    ValueToEdgeMap valueToEdgeMap; ///< Map llvm::Values to all corresponding PAGEdges
+    ValueToEdgeMap valueToEdgeMap; ///< Map SVFValues (e.g., SVFInstruction) to all corresponding PAGEdges
     SymbolTableInfo* symInfo;
 
     /// Add a node into the graph


### PR DESCRIPTION
Not llvm::values, but SVFValues (e.g., SVFInstruction)