### PR TITLE
fix a nullptr dereference error

### DIFF
--- a/svf/include/WPA/AndersenPWC.h
+++ b/svf/include/WPA/AndersenPWC.h
@@ -62,7 +62,7 @@ public:
     {
         if (scdAndersen == nullptr)
         {
-            new AndersenSCD(_pag);
+            scdAndersen = new AndersenSCD(_pag);
             scdAndersen->analyze();
             return scdAndersen;
         }


### PR DESCRIPTION
fix a nullptr dereference when creating AndersenSCD singleton instance