### PR TITLE
fix a bug that leads to get many incorrect switch target case value -1

### DIFF
--- a/svf-llvm/include/SVF-LLVM/BasicTypes.h
+++ b/svf-llvm/include/SVF-LLVM/BasicTypes.h
@@ -178,6 +178,10 @@ typedef llvm::BinaryOperator BinaryOperator;
 typedef llvm::UnaryOperator UnaryOperator;
 typedef llvm::UndefValue UndefValue;
 
+// Related to Switch Case
+typedef std::pair<const BasicBlock*, const ConstantInt*> SuccBBAndCondValPair;
+typedef std::vector<SuccBBAndCondValPair> SuccBBAndCondValPairVec;
+
 // LLVM Intrinsic Instructions
 #if LLVM_VERSION_MAJOR >= 13
 typedef llvm::IntrinsicInst IntrinsicInst;

--- a/svf-llvm/include/SVF-LLVM/LLVMUtil.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMUtil.h
@@ -519,6 +519,55 @@ std::string llvmToString(const T& val)
     llvm::raw_string_ostream(str) << val;
     return str;
 }
+
+/**
+ * See more: https://github.com/SVF-tools/SVF/pull/1191
+ *
+ * Given the code:
+ *
+ * switch (a) {
+ *   case 0: printf("0\n"); break;
+ *   case 1:
+ *   case 2:
+ *   case 3: printf("a >=1 && a <= 3\n"); break;
+ *   case 4:
+ *   case 6:
+ *   case 7:  printf("a >= 4 && a <=7\n"); break;
+ *   default: printf("a < 0 || a > 7"); break;
+ * }
+ *
+ * Generate the IR:
+ *
+ * switch i32 %0, label %sw.default [
+ *  i32 0, label %sw.bb
+ *  i32 1, label %sw.bb1
+ *  i32 2, label %sw.bb1
+ *  i32 3, label %sw.bb1
+ *  i32 4, label %sw.bb3
+ *  i32 6, label %sw.bb3
+ *  i32 7, label %sw.bb3
+ * ]
+ *
+ * We can get every case basic block and related case value:
+ * [
+ *   {%sw.default, -1},
+ *   {%sw.bb, 0},
+ *   {%sw.bb1, 1},
+ *   {%sw.bb1, 2},
+ *   {%sw.bb1, 3},
+ *   {%sw.bb3, 4},
+ *   {%sw.bb3, 6},
+ *   {%sw.bb3, 7},
+ * ]
+ * Note: default case value is nullptr
+ */
+void getSuccBBandCondValPairVec(const SwitchInst &switchInst, SuccBBAndCondValPairVec &vec);
+
+/**
+ * Note: default case value is nullptr
+ */
+s64_t getCaseValue(const SwitchInst &switchInst, SuccBBAndCondValPair &succBB2CondVal);
+
 } // End namespace LLVMUtil
 
 } // End namespace SVF

--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -1154,6 +1154,43 @@ s32_t LLVMUtil::getVCallIdx(const CallBase* cs)
     return idx_value;
 }
 
+void LLVMUtil::getSuccBBandCondValPairVec(const SwitchInst &switchInst, SuccBBAndCondValPairVec &vec)
+{
+    // get default successor basic block and default case value (nullptr)
+    vec.push_back({switchInst.getDefaultDest(), nullptr});
+
+    // get normal case value and it's successor basic block
+    for (const auto& cs : switchInst.cases())
+        vec.push_back({cs.getCaseSuccessor(), cs.getCaseValue()});
+}
+
+s64_t LLVMUtil::getCaseValue(const SwitchInst &switchInst, SuccBBAndCondValPair &succBB2CondVal)
+{
+    const BasicBlock* succBB = succBB2CondVal.first;
+    const ConstantInt* caseValue = succBB2CondVal.second;
+    s64_t val;
+    if (caseValue == nullptr || succBB == switchInst.getDefaultDest())
+    {
+        /// default case value is set to -1
+        val = -1;
+    }
+    else
+    {
+        /// get normal case value
+        if (caseValue->getBitWidth() <= 64)
+        {
+            val = caseValue->getSExtValue();
+        }
+        else
+        {
+            /// For larger number, we preserve case value just -1 now
+            /// see more: https://github.com/SVF-tools/SVF/pull/992
+            val = -1;
+        }
+    }
+    return val;
+}
+
 namespace SVF
 {
 std::string SVFValue::toString() const

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -946,29 +946,20 @@ void SVFIRBuilder::visitSwitchInst(SwitchInst &inst)
     NodeID cond = getValueNode(inst.getCondition());
 
     BranchStmt::SuccAndCondPairVec successors;
-    for (u32_t i = 0; i < inst.getNumSuccessors(); ++i)
+
+    // get case successor basic block and related case value
+    SuccBBAndCondValPairVec succBB2CondValPairVec;
+    LLVMUtil::getSuccBBandCondValPairVec(inst, succBB2CondValPairVec);
+    for (auto &succBB2CaseValue : succBB2CondValPairVec)
     {
-        BasicBlock *succBB = inst.getSuccessor(i);
-        /// default case is set to -1;
-        s64_t val = -1;
-        /// Equivalent to: succBB != inst.getDefaultDest()
-        if (i != 0)
-        {
-            // According to llvm::SwitchInst class comments:
-            // Operand[0]    = Value to switch on
-            // Operand[1]    = Default basic block destination
-            // Operand[2n  ] = Value to match
-            // Operand[2n+1] = BasicBlock to go to on match
-            ConstantInt *condVal = SVFUtil::dyn_cast<ConstantInt>(inst.getOperand(i * 2));
-            if (condVal && condVal->getBitWidth() <= 64)
-                val = condVal->getSExtValue();
-        }
+        s64_t val = LLVMUtil::getCaseValue(inst, succBB2CaseValue);
+        const BasicBlock *succBB = succBB2CaseValue.first;
         const Instruction* succInst = &succBB->front();
         const SVFInstruction* svfSuccInst = LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(succInst);
         const ICFGNode* icfgNode = pag->getICFG()->getICFGNode(svfSuccInst);
-        successors.push_back(std::make_pair(icfgNode,val));
+        successors.push_back(std::make_pair(icfgNode, val));
     }
-    addBranchStmt(brinst, cond,successors);
+    addBranchStmt(brinst, cond, successors);
 }
 
 ///   %ap = alloca %struct.va_list


### PR DESCRIPTION
When I use SVF to do some research on static (sparse) symbolic execution, e.g., translate SVFG/VFGNode to Z3 Formula. I think the the following code will lead to some incorrect formulas.
 
Given the code:
```c
#include <stdio.h>


void test(int a) {
    switch (a)
    {
        case 0: printf("0\n"); break;
        case 1:
        case 2:
        case 3: printf("a >=1 && a <= 3\n"); break;
        case 4:
        case 6:
        case 7:  printf("a >= 4 && a <=7\n"); break;
        default: printf("a < 0 || a > 7"); break;
    }
}
```
SVF will get many incorrect target case value -1 `due to use of API SwitchInst::findCaseDest`. Here is comments about SwitchInst::findCaseDest:
```c
/// Finds the unique case value for a given successor. Returns null if the
/// successor is not found, not unique, or is the default case.
ConstantInt *findCaseDest(BasicBlock *BB) {
  // ...
}
```
Find the `unique` case value .... .`Return null if ... , not unique ` ...