### PR TITLE
fix compiler err in gcc13.2

### DIFF
--- a/svf/include/AbstractExecution/ConsExeState.h
+++ b/svf/include/AbstractExecution/ConsExeState.h
@@ -99,6 +99,8 @@ public:
         return "ConstantExpr";
     }
 
+    using ExeState::operator==;
+    using ExeState::operator!=; 
     /// Exposed APIs
     //{%
     bool operator==(const ConsExeState &rhs) const;

--- a/svf/include/AbstractExecution/IntervalExeState.h
+++ b/svf/include/AbstractExecution/IntervalExeState.h
@@ -418,6 +418,8 @@ public:
         return true;
     }
 
+    using ExeState::operator==;
+    using ExeState::operator!=;
     bool operator==(const IntervalExeState &rhs) const
     {
         return ExeState::operator==(rhs) && eqVarToValMap(_varToItvVal, rhs.getVarToVal()) &&

--- a/svf/include/Graphs/ICFGWrapper.h
+++ b/svf/include/Graphs/ICFGWrapper.h
@@ -88,6 +88,7 @@ public:
         _icfgEdge = edge;
     }
 
+    using SVF::GenericEdge<NodeType>::operator==;
     /// Add the hash function for std::set (we also can overload operator< to implement this)
     //  and duplicated elements in the set are not inserted (binary tree comparison)
     //@{

--- a/svf/include/SVFIR/SVFType.h
+++ b/svf/include/SVFIR/SVFType.h
@@ -31,7 +31,7 @@
 #define INCLUDE_SVFIR_SVFTYPE_H_
 
 #include "Util/SparseBitVector.h"
-
+#include <cstdint>
 #include <deque>
 #include <iostream>
 #include <list>


### PR DESCRIPTION
- add include cstdint
- add using Base::Func to avoid compiler err in GCC 13.2