### PR TITLE
fix shared library builds (experimental)

### DIFF
--- a/svf-llvm/CMakeLists.txt
+++ b/svf-llvm/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT COMMAND add_llvm_library)
   include(AddLLVM)
 
   add_definitions(${LLVM_DEFINITIONS})
-  # include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+  include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 
   if(LLVM_LINK_LLVM_DYLIB)
     set(llvm_libs LLVM)
@@ -50,8 +50,9 @@ file(GLOB SVFLLVM_SOURCES lib/*.cpp)
 
 add_llvm_library(SvfLLVM STATIC ${SVFLLVM_SOURCES})
 target_include_directories(SvfLLVM SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})
+include_directories(SvfLLVM PUBLIC include)
 target_include_directories(SvfLLVM PUBLIC include)
-target_link_libraries(SvfLLVM PUBLIC ${Z3_LIBRARIES} SvfCoreObj)
+target_link_libraries(SvfLLVM PUBLIC ${Z3_LIBRARIES} SvfCoreObj  ${llvm_libs})
 
 if(DEFINED IN_SOURCE_BUILD)
   add_dependencies(SvfLLVM intrinsics_gen)

--- a/svf/lib/AbstractExecution/SVFIR2ItvExeState.cpp
+++ b/svf/lib/AbstractExecution/SVFIR2ItvExeState.cpp
@@ -33,6 +33,8 @@
 using namespace SVF;
 using namespace SVFUtil;
 
+SVF::SVFIR2ItvExeState::VAddrs SVF::SVFIR2ItvExeState::globalNullVaddrs = AddressValue();
+
 void SVFIR2ItvExeState::applySummary(IntervalExeState &es)
 {
     for (const auto &item: es._varToItvVal)


### PR DESCRIPTION
this patch fixes undefined symbol errors when building with -DBUILD_SHARED_LIBS=on.
building without the flag works too. only tested on macos.