### PR TITLE
Allow building of shared libraries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -221,9 +221,11 @@ BUILD_DIR="./${BUILD_TYPE}-build"
 
 rm -rf "${BUILD_DIR}"
 mkdir "${BUILD_DIR}"
+# If you need shared libs, turn BUILD_SHARED_LIBS on
 cmake -D CMAKE_BUILD_TYPE:STRING="${BUILD_TYPE}" \
     -DSVF_ENABLE_ASSERTIONS:BOOL=true            \
     -DSVF_SANITIZE="${SVF_SANITIZER}"            \
+    -DBUILD_SHARED_LIBS=off                      \
     -S "${SVFHOME}" -B "${BUILD_DIR}"
 cmake --build "${BUILD_DIR}" -j ${jobs}
 

--- a/svf-llvm/CMakeLists.txt
+++ b/svf-llvm/CMakeLists.txt
@@ -48,10 +48,10 @@ endif()
 # SVF-LLVM contains LLVM Libs
 file(GLOB SVFLLVM_SOURCES lib/*.cpp)
 
-add_llvm_library(SvfLLVM STATIC ${SVFLLVM_SOURCES})
+add_llvm_library(SvfLLVM ${SVFLLVM_SOURCES})
 target_include_directories(SvfLLVM SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})
 target_include_directories(SvfLLVM PUBLIC include)
-target_link_libraries(SvfLLVM PUBLIC ${Z3_LIBRARIES} SvfCoreObj)
+target_link_libraries(SvfLLVM PUBLIC ${Z3_LIBRARIES} SvfCore)
 
 if(DEFINED IN_SOURCE_BUILD)
   add_dependencies(SvfLLVM intrinsics_gen)

--- a/svf/CMakeLists.txt
+++ b/svf/CMakeLists.txt
@@ -19,8 +19,5 @@ file(
   lib/Util/*.cpp
   lib/WPA/*.cpp)
 
-# Refer to this link for detail:
-# https://stackoverflow.com/questions/68864536/cmake-linking-static-libraries-in-different-subdirectories-into-one-single-stati
-add_library(SvfCoreObj OBJECT ${SVF_CORE_SOURCES})
-add_library(SvfCore STATIC)
-target_link_libraries(SvfCore PUBLIC ${Z3_LIBRARIES} SvfCoreObj)
+add_library(SvfCore ${SVF_CORE_SOURCES})
+target_link_libraries(SvfCore PUBLIC ${Z3_LIBRARIES})

--- a/svf/lib/AbstractExecution/SVFIR2ItvExeState.cpp
+++ b/svf/lib/AbstractExecution/SVFIR2ItvExeState.cpp
@@ -33,6 +33,9 @@
 using namespace SVF;
 using namespace SVFUtil;
 
+SVF::SVFIR2ItvExeState::VAddrs SVF::SVFIR2ItvExeState::globalNullVaddrs =
+    AddressValue();
+
 void SVFIR2ItvExeState::applySummary(IntervalExeState &es)
 {
     for (const auto &item: es._varToItvVal)


### PR DESCRIPTION
In previous versions, we specified "STATIC" when using `add_library`, which enforced the result to be a static library. This pull request eliminates this constraint.