### PR TITLE
fix LLVM_DIR rewrite by LLVMConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,10 @@ install(
   PATTERN "**/*.h")
 
 # Compile extapi.c to extapi.bc
-find_path(LLVM_CLANG_DIR NAMES clang PATH_SUFFIXES bin)
+find_path(LLVM_CLANG_DIR
+        NAMES clang llvm
+        HINTS ${LLVM_DIR} ENV LLVM_DIR
+        PATH_SUFFIXES bin)
 add_custom_target(extapi_ir ALL
     COMMAND ${LLVM_CLANG_DIR}/clang -w -S -c -Xclang -disable-O0-optnone -fno-discard-value-names -emit-llvm ${PROJECT_SOURCE_DIR}/svf-llvm/lib/extapi.c -o ${PROJECT_BINARY_DIR}/svf-llvm/extapi.bc
     DEPENDS ${PROJECT_SOURCE_DIR}/svf-llvm/lib/extapi.c

--- a/svf-llvm/CMakeLists.txt
+++ b/svf-llvm/CMakeLists.txt
@@ -3,6 +3,7 @@
 # building out-of-source
 if(NOT COMMAND add_llvm_library)
   find_package(LLVM REQUIRED CONFIG HINTS "${LLVM_DIR}")
+  set(LLVM_DIR ${LLVM_BINARY_DIR} PARENT_SCOPE)
 
   message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
   message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")


### PR DESCRIPTION
- LLVM_DIR is overridden as LLVM_DIR/lib/cmake due to the configuration in LLVMConfig.cmake. We should reset LLVM_DIR as the root directory of LLVM if we want to use LLVM_DIR as before.
- Use LLVM_DIR as a hint to find the path of Clang. This can ensure that the clang version used to build extapi.bc is consistent with the llvm library used in SVF.