### PR TITLE
Suppress warnings for unused variables when SVF_ENABLE_ASSERTIONS is …

### DIFF
--- a/svf/include/Graphs/CDG.h
+++ b/svf/include/Graphs/CDG.h
@@ -266,7 +266,7 @@ public:
         bool added1 = edge->getDstNode()->addIncomingEdge(edge);
         bool added2 = edge->getSrcNode()->addOutgoingEdge(edge);
         assert(added1 && added2 && "edge not added??");
-        return true;
+        return added1 && added2;
     }
 
     /// Add a CDG node
@@ -438,8 +438,7 @@ struct DOTGraphTraits<SVF::CDG *> : public DOTGraphTraits<SVF::PAG *>
     template<class EdgeIter>
     static std::string getEdgeAttributes(NodeType *, EdgeIter EI, SVF::CDG *)
     {
-        SVF::CDGEdge *edge = *(EI.getCurrent());
-        assert(edge && "No edge found!!");
+        assert(*(EI.getCurrent()) && "No edge found!!");
         return "style=solid";
     }
 

--- a/svf/include/Graphs/CFBasicBlockG.h
+++ b/svf/include/Graphs/CFBasicBlockG.h
@@ -312,15 +312,13 @@ public:
     ///@{
     inline u32_t removeIncomingEdge(CFBasicBlockEdge *edge)
     {
-        iterator it = InEdges.find(edge);
-        assert(it != InEdges.end() && "can not find in edge in SVFG node");
+        assert(InEdges.find(edge) != InEdges.end() && "can not find in edge in SVFG node");
         return InEdges.erase(edge);
     }
 
     inline u32_t removeOutgoingEdge(CFBasicBlockEdge *edge)
     {
-        iterator it = OutEdges.find(edge);
-        assert(it != OutEdges.end() && "can not find out edge in SVFG node");
+        assert(OutEdges.find(edge) != OutEdges.end() && "can not find out edge in SVFG node");
         return OutEdges.erase(edge);
     }
     ///@}
@@ -457,7 +455,7 @@ public:
         bool added2 = edge->getSrcNode()->addOutgoingEdge(edge);
         assert(added1 && added2 && "edge not added??");
         _totalCFBasicBlockEdge++;
-        return true;
+        return added1 && added2;
     }
 
     /// Add a ICFGNodeWrapper


### PR DESCRIPTION
…not defined.

When SVF_ENABLE_ASSERTIONS is not defined when running cmake, assert in two .h files will be removed, causing unused variable warning. It then leads to compilation errors due to "-Werror -Wunused-variable".

Fixing it by replacing variables in assert with the target expressions. For two functions that cannot be fixed in this way, i.e., CFBasicBlockG.h/add CFBBEdge() and CDG.h/addCDGEDge(), put the two variables in the return statements.