### PR TITLE
fix getByteOffsets in GepStmt and SVFIR2ItvExeState

### DIFF
--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -1268,6 +1268,15 @@ s64_t LLVMUtil::getCaseValue(const SwitchInst &switchInst, SuccBBAndCondValPair 
 
 namespace SVF
 {
+// getLLVMByteSize
+u32_t SVFType::getLLVMByteSize() const {
+    const llvm::DataLayout &DL = LLVMModuleSet::getLLVMModuleSet()->
+                                 getMainLLVMModule()->getDataLayout();
+    const Type* T = LLVMModuleSet::getLLVMModuleSet()->getLLVMType(this);
+    Type* mut_T = const_cast<Type*>(T);
+    return  DL.getTypeAllocSize(mut_T);
+}
+
 std::string SVFValue::toString() const
 {
     std::string str;

--- a/svf-llvm/tools/Example/svf-ex.cpp
+++ b/svf-llvm/tools/Example/svf-ex.cpp
@@ -83,10 +83,7 @@ void traverseOnSVFStmt(const ICFGNode* node) {
             svfir2ExeState->translateBinary(binary);
         } else if (const CmpStmt *cmp = SVFUtil::dyn_cast<CmpStmt>(stmt)) {
             svfir2ExeState->translateCmp(cmp);
-        } else if (const UnaryOPStmt *unary = SVFUtil::dyn_cast<UnaryOPStmt>(stmt)) {
-        } else if (const BranchStmt *br = SVFUtil::dyn_cast<BranchStmt>(stmt)) {
-            
-        } else if (const LoadStmt *load = SVFUtil::dyn_cast<LoadStmt>(stmt)) {
+        }  else if (const LoadStmt *load = SVFUtil::dyn_cast<LoadStmt>(stmt)) {
             svfir2ExeState->translateLoad(load);
         } else if (const StoreStmt *store = SVFUtil::dyn_cast<StoreStmt>(stmt)) {
             svfir2ExeState->translateStore(store);

--- a/svf-llvm/tools/Example/svf-ex.cpp
+++ b/svf-llvm/tools/Example/svf-ex.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "SVF-LLVM/LLVMUtil.h"
+#include "AbstractExecution/SVFIR2ItvExeState.h"
 #include "Graphs/SVFG.h"
 #include "WPA/Andersen.h"
 #include "SVF-LLVM/SVFIRBuilder.h"
@@ -70,6 +71,47 @@ std::string printPts(PointerAnalysis* pta, SVFValue* val)
 
 }
 
+/*!
+ * An example to query/collect all SVFStmt from a ICFGNode (iNode)
+ */
+void traverseOnSVFStmt(const ICFGNode* node) {
+    SVFIR2ItvExeState* svfir2ExeState = new SVFIR2ItvExeState(SVFIR::getPAG());
+    for (const SVFStmt* stmt: node->getSVFStmts()) {
+        if (const AddrStmt *addr = SVFUtil::dyn_cast<AddrStmt>(stmt)) {
+            svfir2ExeState->translateAddr(addr);
+        } else if (const BinaryOPStmt *binary = SVFUtil::dyn_cast<BinaryOPStmt>(stmt)) {
+            svfir2ExeState->translateBinary(binary);
+        } else if (const CmpStmt *cmp = SVFUtil::dyn_cast<CmpStmt>(stmt)) {
+            svfir2ExeState->translateCmp(cmp);
+        } else if (const UnaryOPStmt *unary = SVFUtil::dyn_cast<UnaryOPStmt>(stmt)) {
+        } else if (const BranchStmt *br = SVFUtil::dyn_cast<BranchStmt>(stmt)) {
+            
+        } else if (const LoadStmt *load = SVFUtil::dyn_cast<LoadStmt>(stmt)) {
+            svfir2ExeState->translateLoad(load);
+        } else if (const StoreStmt *store = SVFUtil::dyn_cast<StoreStmt>(stmt)) {
+            svfir2ExeState->translateStore(store);
+        } else if (const CopyStmt *copy = SVFUtil::dyn_cast<CopyStmt>(stmt)) {
+            svfir2ExeState->translateCopy(copy);
+        } else if (const GepStmt *gep = SVFUtil::dyn_cast<GepStmt>(stmt)) {
+            if (gep->isConstantOffset()) {
+                gep->accumulateConstantByteOffset();
+                gep->accumulateConstantOffset();
+            }
+            svfir2ExeState->translateGep(gep);
+        } else if (const SelectStmt *select = SVFUtil::dyn_cast<SelectStmt>(stmt)) {
+            svfir2ExeState->translateSelect(select);
+        } else if (const PhiStmt *phi = SVFUtil::dyn_cast<PhiStmt>(stmt)) {
+            svfir2ExeState->translatePhi(phi);
+        } else if (const CallPE *callPE = SVFUtil::dyn_cast<CallPE>(stmt)) {
+            // To handle Call Edge
+            svfir2ExeState->translateCall(callPE);
+        } else if (const RetPE *retPE = SVFUtil::dyn_cast<RetPE>(stmt)) {
+            svfir2ExeState->translateRet(retPE);
+        } else
+            assert(false && "implement this part");
+    }
+}
+
 
 /*!
  * An example to query/collect all successor nodes from a ICFGNode (iNode) along control-flow graph (ICFG)
@@ -90,6 +132,7 @@ void traverseOnICFG(ICFG* icfg, const SVFInstruction* svfInst)
         {
             ICFGEdge* edge = *it;
             ICFGNode* succNode = edge->getDstNode();
+            traverseOnSVFStmt(succNode);
             if (visited.find(succNode) == visited.end())
             {
                 visited.insert(succNode);

--- a/svf/include/AbstractExecution/SVFIR2ItvExeState.h
+++ b/svf/include/AbstractExecution/SVFIR2ItvExeState.h
@@ -74,17 +74,17 @@ public:
     VAddrs getGepObjAddress(u32_t pointer, APOffset offset);
 
     /// Return the byte offset from one gep param offset
-    std::pair<APOffset, APOffset> getBytefromGepTypePair(const AccessPath::VarAndGepTypePair& gep_pair, const GepStmt *gep, APOffset elem_bytesize);
+    std::pair<APOffset, APOffset> getBytefromGepTypePair(const AccessPath::VarAndGepTypePair& gep_pair, const GepStmt *gep);
 
     /// Return the Index offset from one gep param offset
     std::pair<APOffset, APOffset> getIndexfromGepTypePair(const AccessPath::VarAndGepTypePair& gep_pair, const GepStmt *gep);
 
     /// Return the byte offset expression of a GepStmt
     /// elemBytesize is the element byte size of an static alloc or heap alloc array
-    /// e.g. GepStmt* gep = **,
-    /// s32_t elemBytesize = LLVMUtil::SVFType2ByteSize(gep->getRHSVar()->getValue()->getType());
-    /// std::pair<s32_t, s32_t> byteOffset = getGepByteOffset(gep, elemBytesize);
-    std::pair<APOffset, APOffset> getGepByteOffset(const GepStmt *gep, APOffset elemBytesize);
+    /// e.g. GepStmt* gep = [i32*10], x, and x is [0,3]
+    /// std::pair<s32_t, s32_t> byteOffset = getGepByteOffset(gep);
+    /// byteOffset should be [0, 12] since i32 is 4 bytes.
+    std::pair<APOffset, APOffset> getGepByteOffset(const GepStmt *gep);
 
     /// Return the offset expression of a GepStmt
     std::pair<APOffset, APOffset> getGepOffset(const GepStmt *gep);

--- a/svf/include/MemoryModel/AccessPath.h
+++ b/svf/include/MemoryModel/AccessPath.h
@@ -109,12 +109,31 @@ public:
     }
     //@}
 
-    /// Return accumulated constant byte offset given OffsetVarVec
-    /// e.g. GepStmt* gep = [i32*4]*, 2
+    /**
+     * Computes the total constant byte offset of an access path.
+     * This function iterates over the offset-variable-type pairs in reverse order,
+     * accumulating the total byte offset for constant offsets. For each pair,
+     * it retrieves the corresponding SVFValue and determines the type of offset
+     * (whether it's an array, pointer, or structure). If the offset corresponds
+     * to a structure, it further resolves the actual element type based on the
+     * offset value. It then multiplies the offset value by the size of the type
+     * to compute the byte offset. This is used to handle composite types where
+     * offsets are derived from the type's internal structure, such as arrays
+     * or structures with fields of various types and sizes. The function asserts
+     * that the access path must have a constant offset, and it is intended to be
+     * used when the offset is known to be constant at compile time.
+     *
+     * @return APOffset representing the computed total constant byte offset.
+     */
+    /// e.g. GepStmt* gep = [i32*4], 2
     /// APOffset byteOffset = gep->accumulateConstantByteOffset();
     /// byteOffset should be 8 since i32 is 4 bytes and index is 2.
     APOffset computeConstantByteOffset() const;
     /// Return accumulated constant offset given OffsetVarVec
+    /// compard to computeConstantByteOffset, it is field offset rather than byte offset
+    /// e.g. GepStmt* gep = [i32*4], 2
+    /// APOffset byteOffset = gep->computeConstantOffset();
+    /// byteOffset should be 2 since it is field offset.
     APOffset computeConstantOffset() const;
 
     /// Return element number of a type.

--- a/svf/include/MemoryModel/AccessPath.h
+++ b/svf/include/MemoryModel/AccessPath.h
@@ -109,12 +109,11 @@ public:
     }
     //@}
 
-    /// Return accumulated constant byte offset given OffsetVarVec and elemByteSize
-    /// elemBytesize is the element byte size of an static alloc or heap alloc array
-    /// e.g. GepStmt* gep = **,
-    /// s32_t elemBytesize = LLVMUtil::SVFType2ByteSize(gep->getRHSVar()->getValue()->getType());
-    /// APOffset byteOffset = gep->accumulateConstantByteOffset(elemBytesize);
-    APOffset computeConstantByteOffset(u32_t elemBytesize) const;
+    /// Return accumulated constant byte offset given OffsetVarVec
+    /// e.g. GepStmt* gep = [i32*4]*, 2
+    /// APOffset byteOffset = gep->accumulateConstantByteOffset();
+    /// byteOffset should be 8 since i32 is 4 bytes and index is 2.
+    APOffset computeConstantByteOffset() const;
     /// Return accumulated constant offset given OffsetVarVec
     APOffset computeConstantOffset() const;
 

--- a/svf/include/SVFIR/SVFStatements.h
+++ b/svf/include/SVFIR/SVFStatements.h
@@ -505,9 +505,9 @@ public:
     /// e.g. GepStmt* gep = **,
     /// s32_t elemBytesize = LLVMUtil::SVFType2ByteSize(gep->getRHSVar()->getValue()->getType());
     /// APOffset byteOffset = gep->accumulateConstantByteOffset(elemBytesize);
-    inline APOffset accumulateConstantByteOffset(u32_t elemBytesize) const
+    inline APOffset accumulateConstantByteOffset() const
     {
-        return getAccessPath().computeConstantByteOffset(elemBytesize);
+        return getAccessPath().computeConstantByteOffset();
     }
 
     /// Return accumulated constant offset (when accessing array or struct) if this offset is a constant.

--- a/svf/include/SVFIR/SVFType.h
+++ b/svf/include/SVFIR/SVFType.h
@@ -299,6 +299,8 @@ public:
         return getPointerToTy;
     }
 
+    u32_t getLLVMByteSize() const;
+
     inline void setTypeInfo(StInfo* ti)
     {
         typeinfo = ti;
@@ -319,6 +321,16 @@ public:
     inline bool isPointerTy() const
     {
         return kind == SVFPointerTy;
+    }
+
+    inline bool isArrayTy() const
+    {
+        return kind == SVFArrayTy;
+    }
+
+    inline bool isStructTy() const
+    {
+        return kind == SVFStructTy;
     }
 
     inline bool isSingleValueType() const
@@ -462,6 +474,10 @@ public:
 
     void print(std::ostream& os) const override;
 
+    const SVFType* getTypeOfElement() const {
+        return typeOfElement;
+    }
+
     void setTypeOfElement(const SVFType* elemType)
     {
         typeOfElement = elemType;
@@ -471,6 +487,8 @@ public:
     {
         numOfElement = elemNum;
     }
+
+
 };
 
 class SVFOtherType : public SVFType

--- a/svf/lib/SVFIR/SVFType.cpp
+++ b/svf/lib/SVFIR/SVFType.cpp
@@ -5,6 +5,11 @@ namespace SVF
 {
 
 __attribute__((weak))
+u32_t SVFType::getLLVMByteSize() const {
+    return 0;
+}
+
+__attribute__((weak))
 std::string SVFType::toString() const
 {
     std::ostringstream os;

--- a/svf/lib/SVFIR/SVFType.cpp
+++ b/svf/lib/SVFIR/SVFType.cpp
@@ -6,7 +6,8 @@ namespace SVF
 
 __attribute__((weak))
 u32_t SVFType::getLLVMByteSize() const {
-    return 0;
+    assert("SVFType::getLLVMByteSize should be implemented or supported by fronted" && false);
+    abort();
 }
 
 __attribute__((weak))


### PR DESCRIPTION
- add getLLVMByteSize in SVFType
- fix getByteOffset in SVFIR2ExeState and GepStmt 