### PR TITLE
fix 2 bug

### DIFF
--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -1253,8 +1253,9 @@ SVFType* LLVMModuleSet::addSVFTypeInfo(const Type* T)
            "SVFType has been added before");
 
     SVFType* svftype;
-    if (const PointerType* pt = SVFUtil::dyn_cast<PointerType>(T))
-        svftype = new SVFPointerType(getSVFType(LLVMUtil::getPtrElementType(pt)));
+    if (const PointerType* pt = SVFUtil::dyn_cast<PointerType>(T)) {
+        svftype = new SVFPointerType();
+    }
     else if (const IntegerType* intT = SVFUtil::dyn_cast<IntegerType>(T))
     {
         auto svfIntT = new SVFIntegerType();
@@ -1290,6 +1291,12 @@ SVFType* LLVMModuleSet::addSVFTypeInfo(const Type* T)
 
     symInfo->addTypeInfo(svftype);
     LLVMType2SVFType[T] = svftype;
+    if (const PointerType* pt = SVFUtil::dyn_cast<PointerType>(T)) {
+        //cast svftype to SVFPointerType
+        SVFPointerType* svfPtrType = SVFUtil::dyn_cast<SVFPointerType>(svftype);
+        assert(svfPtrType && "this is not SVFPointerType");
+        svfPtrType->setPtrElementType(getSVFType(LLVMUtil::getPtrElementType(pt)));
+    }
     return svftype;
 }
 

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -1253,7 +1253,7 @@ SVFType* LLVMModuleSet::addSVFTypeInfo(const Type* T)
            "SVFType has been added before");
 
     SVFType* svftype;
-    if (const PointerType* pt = SVFUtil::dyn_cast<PointerType>(T)) {
+    if (SVFUtil::isa<PointerType>(T)) {
         svftype = new SVFPointerType();
     }
     else if (const IntegerType* intT = SVFUtil::dyn_cast<IntegerType>(T))

--- a/svf/include/SVFIR/SVFType.h
+++ b/svf/include/SVFIR/SVFType.h
@@ -350,17 +350,23 @@ private:
     const SVFType* ptrElementType;
 
 public:
-    SVFPointerType(const SVFType* pty)
-        : SVFType(true, SVFPointerTy), ptrElementType(pty)
+    SVFPointerType()
+        : SVFType(true, SVFPointerTy), ptrElementType(nullptr)
     {
     }
+
     static inline bool classof(const SVFType* node)
     {
         return node->getKind() == SVFPointerTy;
     }
     inline const SVFType* getPtrElementType() const
     {
+        assert(ptrElementType && "ptrElementType is nullptr");
         return ptrElementType;
+    }
+
+    inline void setPtrElementType(SVFType* _ptrElementType)  {
+        ptrElementType = _ptrElementType;
     }
 
     void print(std::ostream& os) const override;

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -128,11 +128,12 @@ APOffset AccessPath::computeConstantByteOffset() const
         const SVFConstantInt* op = SVFUtil::dyn_cast<SVFConstantInt>(value);
         if (const SVFStructType* structType = SVFUtil::dyn_cast<SVFStructType>(type)) {
             /// for (1) structType: %struct.DEST
-            ///   structField = 0, type2: int
-            ///   structField = 1, type2: char[10]
-            ///   structField = 2, type2: int[5]
+            ///   structField = 0, flattenIdx = 0, type2: int
+            ///   structField = 1, flattenIdx = 1, type2: char[10]
+            ///   structField = 2, flattenIdx = 11, type2: int[5]
             for (u32_t structField = 0; structField < (u32_t)op->getSExtValue(); ++structField) {
-                type2 = structType->getTypeInfo()->getOriginalElemType(structField);
+                u32_t flattenIdx = structType->getTypeInfo()->getFlattenedFieldIdxVec()[structField];
+                type2 = structType->getTypeInfo()->getOriginalElemType(flattenIdx);
                 totalConstOffset += type2->getLLVMByteSize();
             }
         } else {

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -101,25 +101,43 @@ APOffset AccessPath::computeConstantByteOffset() const
     APOffset totalConstOffset = 0;
     for(int i = offsetVarAndGepTypePairs.size() - 1; i >= 0; i--)
     {
+        /// For example, there is struct DEST{int a, char b[10], int c[5]}
+        /// (1) %c = getelementptr inbounds %struct.DEST, %struct.DEST* %arr, i32 0, i32 2
+        //  (2) %arrayidx = getelementptr inbounds [10 x i8], [10 x i8]* %b, i64 0, i64 8
         const SVFValue* value = offsetVarAndGepTypePairs[i].first->getValue();
+        /// for (1) offsetVarAndGepTypePairs.size()  = 2
+        ///     i = 0, type: %struct.DEST*, PtrType, op = 0
+        ///     i = 1, type: %struct.DEST, StructType, op = 2
+        /// for (2) offsetVarAndGepTypePairs.size()  = 2
+        ///     i = 0, type: [10 x i8]*, PtrType, op = 0
+        ///     i = 1, type: [10 x i8], ArrType, op = 8
         const SVFType* type = offsetVarAndGepTypePairs[i].second;
         const SVFType* type2 = type;
         if (const SVFArrayType* arrType = SVFUtil::dyn_cast<SVFArrayType>(type))
         {
+            /// for (2) i = 1, arrType: [10 x i8], type2 = i8
             type2 = arrType->getTypeOfElement();
         }
         else if (const SVFPointerType* ptrType = SVFUtil::dyn_cast<SVFPointerType>(type))
         {
+            /// for (1) i = 0, ptrType: %struct.DEST*, type2: %struct.DEST
+            /// for (2) i = 0, ptrType: [10 x i8]*, type2 = [10 x i8]
             type2 = ptrType->getPtrElementType();
         }
 
         const SVFConstantInt* op = SVFUtil::dyn_cast<SVFConstantInt>(value);
         if (const SVFStructType* structType = SVFUtil::dyn_cast<SVFStructType>(type)) {
+            /// for (1) structType: %struct.DEST
+            ///   structField = 0, type2: int
+            ///   structField = 1, type2: char[10]
+            ///   structField = 2, type2: int[5]
             for (u32_t structField = 0; structField < (u32_t)op->getSExtValue(); ++structField) {
                 type2 = structType->getTypeInfo()->getOriginalElemType(structField);
                 totalConstOffset += type2->getLLVMByteSize();
             }
         } else {
+            /// for (2) i = 0, op: 0, type: [10 x i8]*(Ptr), type2: [10 x i8](Arr)
+            ///         i = 1, op: 8, type: [10 x i8](Arr), type2: i8
             totalConstOffset += op->getSExtValue() * type2->getLLVMByteSize();
         }
     }

--- a/svf/lib/SVFIR/SVFFileSystem.cpp
+++ b/svf/lib/SVFIR/SVFFileSystem.cpp
@@ -24,7 +24,7 @@ SVFType* createSVFType(SVFType::GNodeK kind, bool isSingleValTy)
         ABORT_MSG("Creation of RAW SVFType isn't allowed");
     case SVFType::SVFPointerTy:
         ABORT_IFNOT(isSingleValTy, "Pointer type must be single-valued");
-        return new SVFPointerType(nullptr);
+        return new SVFPointerType();
     case SVFType::SVFIntegerTy:
         ABORT_IFNOT(isSingleValTy, "Integer type must be single-valued");
         return new SVFIntegerType();


### PR DESCRIPTION
### 1 when creating SVFType, to avoid duplicated creations when it comes to struct nested pointer type. 
### 2 when call accumulatedByteOffset in GepStmt, call getOriginalElemType() with flatten index