### PR TITLE
fix if offsetVarAndGepTypePair.second is nullptr 

### DIFF
--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -112,6 +112,9 @@ APOffset AccessPath::computeConstantByteOffset() const
         ///     i = 0, type: [10 x i8]*, PtrType, op = 0
         ///     i = 1, type: [10 x i8], ArrType, op = 8
         const SVFType* type = offsetVarAndGepTypePairs[i].second;
+        /// if offsetVarAndGepTypePairs[i].second is nullptr, it means
+        /// this GepStmt comes from external API, assert
+        assert(type && "this GepStmt comes from ExternalAPI cannot call this api");
         const SVFType* type2 = type;
         if (const SVFArrayType* arrType = SVFUtil::dyn_cast<SVFArrayType>(type))
         {

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -113,7 +113,8 @@ APOffset AccessPath::computeConstantByteOffset() const
         ///     i = 1, type: [10 x i8], ArrType, op = 8
         const SVFType* type = offsetVarAndGepTypePairs[i].second;
         /// if offsetVarAndGepTypePairs[i].second is nullptr, it means
-        /// this GepStmt comes from external API, assert
+        ///   GepStmt comes from external API, this GepStmt is assigned in SVFIRExtAPI.cpp
+        ///   at SVFIRBuilder::getBaseTypeAndFlattenedFields ls.addOffsetVarAndGepTypePair()
         assert(type && "this GepStmt comes from ExternalAPI cannot call this api");
         const SVFType* type2 = type;
         if (const SVFArrayType* arrType = SVFUtil::dyn_cast<SVFArrayType>(type))


### PR DESCRIPTION
since it is from External API like memcpy
```
"GepStmt: [Var96744 <-- Var4683]\t\n   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %13, i8* align 1 %15, i64 8, i1 false), !dbg !26775 { \"ln\": 162, \"cl\": 2, \"fl\": \"/devcloud/ws/sQEab/workspace/j_gIcjhi8u/code/tests/allocator.cpp\" }"

```
this GepStmt comes from memcpy, which offsetVarAndGepTypePair[i].second  is always nullptr