### PR TITLE
1st PR of more precise ObjTypeInfo

### DIFF
--- a/svf-llvm/include/SVF-LLVM/SymbolTableBuilder.h
+++ b/svf-llvm/include/SVF-LLVM/SymbolTableBuilder.h
@@ -55,7 +55,8 @@ public:
     void buildMemModel(SVFModule* svfModule);
 
     /// Return size of this object based on LLVM value
-    u32_t getObjSize(const Type* type);
+    u32_t getNumOfElements(const Type* ety);
+
 
 protected:
 
@@ -92,6 +93,9 @@ protected:
     void analyzeHeapObjType(ObjTypeInfo* typeinfo, const Value* val);
     /// Analyse types of heap and static objects
     void analyzeStaticObjType(ObjTypeInfo* typeinfo, const Value* val);
+
+    /// Analyze byte size of heap alloc function (e.g. malloc/calloc/...)
+    u32_t analyzeHeapAllocByteSize(const Value* val);
 
     ///Get a reference to the components of struct_info.
     /// Number of flattened elements of an array or struct

--- a/svf-llvm/lib/extapi.c
+++ b/svf-llvm/lib/extapi.c
@@ -14,541 +14,541 @@
         MEMCPY,       // memset() operations
         OVERWRITE,    // svf function overwrite app function
 */
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *malloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *fopen(const char *voidname, const char *mode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *fopen64(const char *voidname, const char *mode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *fdopen(int fd, const char *mode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 struct dirent64 *readdir64(void *dirp)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *tmpvoid64(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0*Arg1")))
 void *calloc(unsigned long nitems, unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *zmalloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *gzdopen(int fd, const char *mode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *iconv_open(const char *tocode, const char *fromcode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *lalloc(unsigned long size, int a)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *lalloc_clear(unsigned long size, int a)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 long *nhalloc(unsigned int a, const char *b, int c)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *oballoc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *popen(const char *command, const char *type)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *pthread_getspecific(const char *a, const char *b)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 struct dirent *readdir(void *dirp)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0*Arg1")))
 void* safe_calloc(unsigned nelem, unsigned elsize)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void* safe_malloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0*Arg1")))
 char* safecalloc(int a, int b)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 char* safemalloc(int a, int b)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *setmntent(const char *voidname, const char *type)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *shmat(int shmid, const void *shmaddr, int shmflg)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void* __sysv_signal(int a, void *b)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void (*signal(int sig, void (*func)(int)))(int)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *tempnam(const char *dir, const char *pfx)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *tmpvoid(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void* xcalloc(unsigned long size1, unsigned long size2)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void* xmalloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *_Znam(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *_Znaj(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *_Znwj(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *__cxa_allocate_exception(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg1")))
 void* aligned_alloc(unsigned long size1, unsigned long size2)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg1")))
 void* memalign(unsigned long size1, unsigned long size2)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *valloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg1")))
 void *mmap64(void *addr, unsigned long len, int prot, int flags, int fildes, long off)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *XSetLocaleModifiers(char *a)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char * __strdup(const char * string)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *crypt(const char *key, const char *salt)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *ctime(const void *timer)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *dlerror(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *dlopen(const char *voidname, int flags)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 const char *gai_strerror(int errcode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 const char *gcry_cipher_algo_name(int errcode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 const char *svfgcry_md_algo_name_(int errcode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *getenv(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *getlogin(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *getpass(const char *prompt)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 const char * gnutls_strerror(int error)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 const char *gpg_strerror(unsigned int a)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 const char * gzerror(void* file, int * errnum)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *inet_ntoa(unsigned int in)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *initscr(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void* llvm_stacksave()
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg1")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg1")))
 void *mmap(void *addr, unsigned long len, int prot, int flags, int fildes, long off)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *newwin(int nlines, int ncols, int begin_y, int begin_x)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *nl_langinfo(int item)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *opendir(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void *sbrk(long increment)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *strdup(const char *s)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *strerror(int errnum)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *strsignal(int errnum)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *textdomain(const char * domainname)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *tgetstr(char *id, char **area)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *tigetstr(char *capname)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *tmpnam(char *s)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *ttyname(int fd)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *getcwd(char *buf, unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("Arg1")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:Arg1")))
 char *mem_realloc(void *ptr, unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("Arg1")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:Arg1")))
 char *realloc(void *ptr, unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("Arg1")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:Arg1")))
 void* safe_realloc(void *p, unsigned long n)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("Arg1"), annotate("Arg2")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:Arg1*Arg2")))
 void* saferealloc(void *p, unsigned long n1, unsigned long n2)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 void* safexrealloc()
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *strtok(char *str, const char *delim)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("UNKNOWN")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:UNKNOWN")))
 char *strtok_r(char *str, const char *delim, char **saveptr)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET"), annotate("Arg1")))
+__attribute__((annotate("REALLOC_RET"), annotate("AllocSize:Arg1")))
 void *xrealloc(void *ptr, unsigned long bytes)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *_Znwm(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *_ZnwmRKSt9nothrow_t(unsigned long size, void *)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 void *_ZnamRKSt9nothrow_t(unsigned long size, void *)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("AllocSize:UNKNOWN")))
 int asprintf(char **restrict strp, const char *restrict fmt, ...)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("AllocSize:UNKNOWN")))
 int vasprintf(char **strp, const char *fmt, void* ap)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("AllocSize:UNKNOWN")))
 int db_create(void **dbp, void *dbenv, unsigned int flags)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("AllocSize:UNKNOWN")))
 int gnutls_pkcs12_bag_init(void *a)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("AllocSize:UNKNOWN")))
 int gnutls_pkcs12_init(void *a)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("AllocSize:UNKNOWN")))
 int gnutls_x509_crt_init(void *a)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("AllocSize:UNKNOWN")))
 int gnutls_x509_privkey_init(void *a)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0"), annotate("Arg2")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("AllocSize:Arg2")))
 int posix_memalign(void **a, unsigned long b, unsigned long c)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG1"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG1"), annotate("AllocSize:UNKNOWN")))
 int scandir(const char *restrict dirp, struct dirent ***restrict namelist, int (*filter)(const struct dirent *), int (*compar)(const struct dirent **, const struct dirent **))
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG2"), annotate("UNKNOWN")))
+__attribute__((annotate("ALLOC_ARG2"), annotate("AllocSize:UNKNOWN")))
 int XmbTextPropertyToTextList(void *a, void *b, char ***c, int *d)
 {
     return 0;
@@ -664,7 +664,7 @@ void* _ZNSt5arrayIPK1ALm2EE4backEv(void *arg)
     return ptr2;
 }
 
-__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
+__attribute__((annotate("ALLOC_RET"), annotate("AllocSize:Arg0")))
 __attribute__((annotate("OVERWRITE")))
 void *SyGetmem(unsigned long size)
 {

--- a/svf-llvm/lib/extapi.c
+++ b/svf-llvm/lib/extapi.c
@@ -14,541 +14,541 @@
         MEMCPY,       // memset() operations
         OVERWRITE,    // svf function overwrite app function
 */
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
 void *malloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *fopen(const char *voidname, const char *mode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *fopen64(const char *voidname, const char *mode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *fdopen(int fd, const char *mode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 struct dirent64 *readdir64(void *dirp)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *tmpvoid64(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
 void *calloc(unsigned long nitems, unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *zmalloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *gzdopen(int fd, const char *mode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *iconv_open(const char *tocode, const char *fromcode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *lalloc(unsigned long size, int a)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *lalloc_clear(unsigned long size, int a)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 long *nhalloc(unsigned int a, const char *b, int c)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *oballoc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *popen(const char *command, const char *type)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *pthread_getspecific(const char *a, const char *b)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 struct dirent *readdir(void *dirp)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
 void* safe_calloc(unsigned nelem, unsigned elsize)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void* safe_malloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
 char* safecalloc(int a, int b)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 char* safemalloc(int a, int b)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *setmntent(const char *voidname, const char *type)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *shmat(int shmid, const void *shmaddr, int shmflg)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void* __sysv_signal(int a, void *b)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void (*signal(int sig, void (*func)(int)))(int)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *tempnam(const char *dir, const char *pfx)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *tmpvoid(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0"), annotate("Arg1")))
 void* xcalloc(unsigned long size1, unsigned long size2)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void* xmalloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *_Znam(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *_Znaj(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *_Znwj(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *__cxa_allocate_exception(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg1")))
 void* aligned_alloc(unsigned long size1, unsigned long size2)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg1")))
 void* memalign(unsigned long size1, unsigned long size2)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *valloc(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg1")))
 void *mmap64(void *addr, unsigned long len, int prot, int flags, int fildes, long off)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *XSetLocaleModifiers(char *a)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char * __strdup(const char * string)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *crypt(const char *key, const char *salt)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *ctime(const void *timer)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *dlerror(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *dlopen(const char *voidname, int flags)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 const char *gai_strerror(int errcode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 const char *gcry_cipher_algo_name(int errcode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 const char *svfgcry_md_algo_name_(int errcode)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *getenv(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *getlogin(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *getpass(const char *prompt)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 const char * gnutls_strerror(int error)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 const char *gpg_strerror(unsigned int a)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 const char * gzerror(void* file, int * errnum)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *inet_ntoa(unsigned int in)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *initscr(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void* llvm_stacksave()
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg1")))
 void *mmap(void *addr, unsigned long len, int prot, int flags, int fildes, long off)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *newwin(int nlines, int ncols, int begin_y, int begin_x)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *nl_langinfo(int item)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *opendir(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 void *sbrk(long increment)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *strdup(const char *s)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *strerror(int errnum)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *strsignal(int errnum)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *textdomain(const char * domainname)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *tgetstr(char *id, char **area)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *tigetstr(char *capname)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *tmpnam(char *s)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("UNKNOWN")))
 char *ttyname(int fd)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("UNKNOWN")))
 char *getcwd(char *buf, unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("Arg1")))
 char *mem_realloc(void *ptr, unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("Arg1")))
 char *realloc(void *ptr, unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("Arg1")))
 void* safe_realloc(void *p, unsigned long n)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("Arg1"), annotate("Arg2")))
 void* saferealloc(void *p, unsigned long n1, unsigned long n2)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("UNKNOWN")))
 void* safexrealloc()
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("UNKNOWN")))
 char *strtok(char *str, const char *delim)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("UNKNOWN")))
 char *strtok_r(char *str, const char *delim, char **saveptr)
 {
     return NULL;
 }
 
-__attribute__((annotate("REALLOC_RET")))
+__attribute__((annotate("REALLOC_RET"), annotate("Arg1")))
 void *xrealloc(void *ptr, unsigned long bytes)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *_Znwm(unsigned long size)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *_ZnwmRKSt9nothrow_t(unsigned long size, void *)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 void *_ZnamRKSt9nothrow_t(unsigned long size, void *)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_ARG0")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
 int asprintf(char **restrict strp, const char *restrict fmt, ...)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
 int vasprintf(char **strp, const char *fmt, void* ap)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
 int db_create(void **dbp, void *dbenv, unsigned int flags)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
 int gnutls_pkcs12_bag_init(void *a)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
 int gnutls_pkcs12_init(void *a)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
 int gnutls_x509_crt_init(void *a)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("UNKNOWN")))
 int gnutls_x509_privkey_init(void *a)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG0")))
+__attribute__((annotate("ALLOC_ARG0"), annotate("Arg2")))
 int posix_memalign(void **a, unsigned long b, unsigned long c)
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG1")))
+__attribute__((annotate("ALLOC_ARG1"), annotate("UNKNOWN")))
 int scandir(const char *restrict dirp, struct dirent ***restrict namelist, int (*filter)(const struct dirent *), int (*compar)(const struct dirent **, const struct dirent **))
 {
     return 0;
 }
 
-__attribute__((annotate("ALLOC_ARG2")))
+__attribute__((annotate("ALLOC_ARG2"), annotate("UNKNOWN")))
 int XmbTextPropertyToTextList(void *a, void *b, char ***c, int *d)
 {
     return 0;
@@ -664,7 +664,7 @@ void* _ZNSt5arrayIPK1ALm2EE4backEv(void *arg)
     return ptr2;
 }
 
-__attribute__((annotate("ALLOC_RET")))
+__attribute__((annotate("ALLOC_RET"), annotate("Arg0")))
 __attribute__((annotate("OVERWRITE")))
 void *SyGetmem(unsigned long size)
 {

--- a/svf/include/SVFIR/SymbolTableInfo.h
+++ b/svf/include/SVFIR/SymbolTableInfo.h
@@ -438,6 +438,13 @@ public:
     /// Whether it is a black hole object
     bool isBlackHoleObj() const;
 
+    /// Get the byte size of this object
+    u32_t getByteSizeOfObj() const;
+
+    /// Check if byte size is a const value
+    bool isConstantByteSize() const;
+
+
     /// object attributes methods
     //@{
     bool isFunction() const;
@@ -505,6 +512,9 @@ private:
     /// Size of the object or number of elements
     u32_t elemNum;
 
+    /// Byte size of object
+    u32_t byteSize;
+
     void resetTypeForHeapStaticObj(const SVFType* type);
 public:
 
@@ -545,6 +555,22 @@ public:
     inline u32_t getNumOfElements() const
     {
         return elemNum;
+    }
+
+    /// Get the byte size of this object
+    inline u32_t getByteSizeOfObj() const {
+        assert(isConstantByteSize() && "This Obj's byte size is not constant.");
+        return byteSize;
+    }
+
+    /// Set the byte size of this object
+    inline void setByteSizeOfObj(u32_t size)  {
+        byteSize = size;
+    }
+
+    /// Check if byte size is a const value
+    inline bool isConstantByteSize() const {
+        return byteSize != 0;
     }
 
     /// Flag for this object type

--- a/svf/lib/SVFIR/SymbolTableInfo.cpp
+++ b/svf/lib/SVFIR/SymbolTableInfo.cpp
@@ -429,6 +429,19 @@ u32_t MemObj::getNumOfElements() const
     return typeInfo->getNumOfElements();
 }
 
+/// Get the byte size of this object
+u32_t MemObj::getByteSizeOfObj() const
+{
+    return typeInfo->getByteSizeOfObj();
+}
+
+/// Check if byte size is static determined
+bool MemObj::isConstantByteSize() const
+{
+    return typeInfo->isConstantByteSize();
+}
+
+
 /// Set the number of elements of this object
 void MemObj::setNumOfElements(u32_t num)
 {


### PR DESCRIPTION
1) add getByteSizeofObj() and isConstantByteSize() in SymbolTableInfo.h/cpp
2) add annotation to ALLOC_RET and ALLOC_ARGi extapis in extapi.c
3) add analyzeHeapAllocByteSize() in SymbolTableBuilder.h/cpp to handle ALLOC_RET and ALLOC_ARGi
