### PR TITLE
Load extapi module in buildSVFModule(Module& mod)

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMModule.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMModule.h
@@ -111,7 +111,8 @@ public:
         llvmModuleSet = nullptr;
     }
 
-    static SVFModule* buildSVFModule(Module& mod);
+    // The parameter of context should be the llvm context of the mod, the llvm context of mod and extapi module should be the same
+    static SVFModule* buildSVFModule(Module& mod, std::unique_ptr<LLVMContext> context);
     static SVFModule* buildSVFModule(const std::vector<std::string>& moduleNameVec);
 
     inline SVFModule* getSVFModule()
@@ -356,7 +357,8 @@ private:
     std::vector<const Function*> getLLVMGlobalFunctions(const GlobalVariable* global);
 
     void loadModules(const std::vector<std::string>& moduleNameVec);
-    void loadExtAPIModules();
+    // The llvm context of app module and extapi module should be the same
+    void loadExtAPIModules(std::unique_ptr<LLVMContext> context = nullptr);
     void addSVFMain();
 
     void createSVFDataStructure();


### PR DESCRIPTION
Use `static SVFModule* buildSVFModule(Module& mod, std::unique_ptr<LLVMContext> context)` to create an svfModule. It is necessary to ensure that the LLVM Context of the `mod` and the `extapi module`'s LLVM Context are the same, meaning the `context` parameter should be the `mod`'s LLVM Context.