### PR TITLE
Modify SVFIR2ItvExeState.cpp

### DIFF
--- a/svf/include/AbstractExecution/IntervalValue.h
+++ b/svf/include/AbstractExecution/IntervalValue.h
@@ -662,8 +662,8 @@ inline IntervalValue operator<(const IntervalValue &lhs, const IntervalValue &rh
             // Return [0,0] means lhs is totally impossible to be less than rhs
             // i.e., lhs is totally greater than or equal to rhs
             // When lhs.ub >= rhs.lb, e.g., lhs:[3, 4] rhs:[4，5]
-            // lhs.ub(4) >= rhs.lb(4)
-            else if (rhs.ub().geq(lhs.lb()))
+            // lhs.lb(4) >= rhs.ub(4)
+            else if (lhs.lb().geq(rhs.ub()))
             {
                 return IntervalValue(0, 0);
             }

--- a/svf/include/Graphs/GraphPrinter.h
+++ b/svf/include/Graphs/GraphPrinter.h
@@ -66,7 +66,7 @@ public:
             return;
         }
 
-        O << "Writing '" << Filename << "'...";
+        O << "Writing '" << Filename << "'...\n";
 
         WriteGraph(outFile, GT, simple);
         outFile.close();


### PR DESCRIPTION
Fix translatePhi and translateLoad statements, prevent it using previous IntervalExeState from global es.