### PR TITLE
fix a bug: 'getExitBB' of SVFFunction may get incorrect exit block.

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMUtil.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMUtil.h
@@ -206,7 +206,7 @@ inline bool isArgOfUncalledFunction (const Value*  val)
 //@}
 
 /// Return true if the function has a return instruction
-bool basicBlockHasRet(const BasicBlock* bb);
+bool basicBlockHasRetInst(const BasicBlock* bb);
 
 /// Return true if the function has a return instruction reachable from function
 /// entry

--- a/svf-llvm/include/SVF-LLVM/LLVMUtil.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMUtil.h
@@ -205,6 +205,9 @@ inline bool isArgOfUncalledFunction (const Value*  val)
 }
 //@}
 
+/// Return true if the function has a return instruction
+bool basicBlockHasRet(const BasicBlock* bb);
+
 /// Return true if the function has a return instruction reachable from function
 /// entry
 bool functionDoesNotRet(const Function* fun);

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -321,14 +321,11 @@ void LLVMModuleSet::initSVFBasicBlock(const Function* func)
             svfbb->addPredBasicBlock(svf_pred_bb);
         }
 
-        // set exit block
-        if (svfbb->getSuccessors().empty() && !bb->getInstList().empty())
+        /// set exit block
+        if (svfbb->getSuccessors().empty())
         {
-            const Instruction &lastInst = bb->getInstList().back();
-            if (SVFUtil::dyn_cast<ReturnInst>(&lastInst))
-            {
-                svfFun->setExitBlock(svfbb);
-            }
+            assert(LLVMUtil::basicBlockHasRet(bb) && "exit basic block must have no successors and have a return instruction");
+            svfFun->setExitBlock(svfbb);
         }
 
         for (BasicBlock::const_iterator iit = bb->begin(), eiit = bb->end(); iit != eiit; ++iit)

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -321,12 +321,11 @@ void LLVMModuleSet::initSVFBasicBlock(const Function* func)
             svfbb->addPredBasicBlock(svf_pred_bb);
         }
 
-        /// set exit block
+        /// set exit block: exit basic block must have no successors and have a return instruction
         if (svfbb->getSuccessors().empty())
         {
-            if (LLVMUtil::basicBlockHasRet(bb))
+            if (LLVMUtil::basicBlockHasRetInst(bb))
             {
-                // exit basic block must have no successors and have a return instruction
                 svfFun->setExitBlock(svfbb);
             }
         }

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -321,14 +321,14 @@ void LLVMModuleSet::initSVFBasicBlock(const Function* func)
             svfbb->addPredBasicBlock(svf_pred_bb);
         }
 
-        // set entry / exit block
-        if (svfbb->getPredecessors().empty())
+        // set exit block
+        if (svfbb->getSuccessors().empty() && !bb->getInstList().empty())
         {
-            svfFun->setEntryBlock(svfbb);
-        }
-        if (svfbb->getSuccessors().empty())
-        {
-            svfFun->setExitBlock(svfbb);
+            const Instruction &lastInst = bb->getInstList().back();
+            if (SVFUtil::dyn_cast<ReturnInst>(&lastInst))
+            {
+                svfFun->setExitBlock(svfbb);
+            }
         }
 
         for (BasicBlock::const_iterator iit = bb->begin(), eiit = bb->end(); iit != eiit; ++iit)

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -324,8 +324,11 @@ void LLVMModuleSet::initSVFBasicBlock(const Function* func)
         /// set exit block
         if (svfbb->getSuccessors().empty())
         {
-            assert(LLVMUtil::basicBlockHasRet(bb) && "exit basic block must have no successors and have a return instruction");
-            svfFun->setExitBlock(svfbb);
+            if (LLVMUtil::basicBlockHasRet(bb))
+            {
+                // exit basic block must have no successors and have a return instruction
+                svfFun->setExitBlock(svfbb);
+            }
         }
 
         for (BasicBlock::const_iterator iit = bb->begin(), eiit = bb->end(); iit != eiit; ++iit)

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -305,6 +305,7 @@ void LLVMModuleSet::initSVFFunction()
 
 void LLVMModuleSet::initSVFBasicBlock(const Function* func)
 {
+    SVFFunction *svfFun = getSVFFunction(func);
     for (Function::const_iterator bit = func->begin(), ebit = func->end(); bit != ebit; ++bit)
     {
         const BasicBlock* bb = &*bit;
@@ -319,6 +320,17 @@ void LLVMModuleSet::initSVFBasicBlock(const Function* func)
             const SVFBasicBlock* svf_pred_bb = getSVFBasicBlock(*pred_it);
             svfbb->addPredBasicBlock(svf_pred_bb);
         }
+
+        // set entry / exit block
+        if (svfbb->getPredecessors().empty())
+        {
+            svfFun->setEntryBlock(svfbb);
+        }
+        if (svfbb->getSuccessors().empty())
+        {
+            svfFun->setExitBlock(svfbb);
+        }
+
         for (BasicBlock::const_iterator iit = bb->begin(), eiit = bb->end(); iit != eiit; ++iit)
         {
             const Instruction* inst = &*iit;

--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -101,7 +101,7 @@ void LLVMUtil::getFunReachableBBs (const Function* fun, std::vector<const SVFBas
 /**
  * Return true if the basic block has a return instruction
  */
-bool LLVMUtil::basicBlockHasRet(const BasicBlock* bb)
+bool LLVMUtil::basicBlockHasRetInst(const BasicBlock* bb)
 {
     for (BasicBlock::const_iterator it = bb->begin(), eit = bb->end();
          it != eit; ++it)
@@ -115,7 +115,7 @@ bool LLVMUtil::basicBlockHasRet(const BasicBlock* bb)
 /*!
  * Return true if the function has a return instruction reachable from function entry
  */
-bool LLVMUtil::functionDoesNotRet (const Function*  fun)
+bool LLVMUtil::functionDoesNotRet(const Function*  fun)
 {
     const SVFFunction* svffun = LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(fun);
     if (SVFUtil::isExtCall(svffun))
@@ -129,7 +129,7 @@ bool LLVMUtil::functionDoesNotRet (const Function*  fun)
     {
         const BasicBlock* bb = bbVec.back();
         bbVec.pop_back();
-        if (basicBlockHasRet(bb))
+        if (basicBlockHasRetInst(bb))
         {
             return false;
         }

--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -98,6 +98,20 @@ void LLVMUtil::getFunReachableBBs (const Function* fun, std::vector<const SVFBas
     }
 }
 
+/**
+ * Return true if the basic block has a return instruction
+ */
+bool LLVMUtil::basicBlockHasRet(const BasicBlock* bb)
+{
+    for (BasicBlock::const_iterator it = bb->begin(), eit = bb->end();
+         it != eit; ++it)
+    {
+        if(SVFUtil::isa<ReturnInst>(*it))
+            return true;
+    }
+    return false;
+}
+
 /*!
  * Return true if the function has a return instruction reachable from function entry
  */
@@ -115,11 +129,9 @@ bool LLVMUtil::functionDoesNotRet (const Function*  fun)
     {
         const BasicBlock* bb = bbVec.back();
         bbVec.pop_back();
-        for (BasicBlock::const_iterator it = bb->begin(), eit = bb->end();
-                it != eit; ++it)
+        if (basicBlockHasRet(bb))
         {
-            if(SVFUtil::isa<ReturnInst>(*it))
-                return false;
+            return false;
         }
 
         for (succ_const_iterator sit = succ_begin(bb), esit = succ_end(bb);

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -320,15 +320,7 @@ private:
     std::vector<const SVFBasicBlock*> allBBs;   /// all BasicBlocks of this function
     std::vector<const SVFArgument*> allArgs;    /// all formal arguments of this function
     std::vector<std::string> annotations; /// annotations of this function
-    SVFBasicBlock *entryBlock;                  /// entry BasicBlock of this function
     SVFBasicBlock *exitBlock;                   /// exit BasicBlock of this function
-    SVFBasicBlock *uniqueExitBlock;             /// multi exit BasicBlocks connect to a single unique Exit Block
-
-private:
-    /// get dummy exit basic block. if not exits, then create it, else return
-    /// @param exitBB one of multi exit Basic Blocks
-    /// @return the dummy exit basic block
-    SVFBasicBlock* getUniqueExitBlock(SVFBasicBlock* exitBB);
 
 protected:
     ///@{ attributes to be set only through Module builders e.g., LLVMModule
@@ -418,21 +410,13 @@ public:
     inline const SVFBasicBlock* getEntryBlock() const
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
-        assert(entryBlock && "have not yet set entry Basicblock");
-        return entryBlock;
-    }
-
-    inline void setEntryBlock(SVFBasicBlock *bb)
-    {
-        assert(!entryBlock && "function already has entry Basicblock.");
-        entryBlock = bb;
+        return allBBs.front();
     }
 
     inline const SVFBasicBlock* getExitBB() const
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
-        assert(exitBlock && "have not yet set exit Basicblock");
-        assert((!uniqueExitBlock || uniqueExitBlock == exitBlock) && "unique exit basic block must be null or just equal to exit block");
+        assert(exitBlock && "have not yet set exit Basicblock?");
         return exitBlock;
     }
 

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -322,6 +322,14 @@ private:
     std::vector<std::string> annotations; /// annotations of this function
     SVFBasicBlock *entryBlock;                  /// entry BasicBlock of this function
     SVFBasicBlock *exitBlock;                   /// exit BasicBlock of this function
+    SVFBasicBlock *uniqueExitBlock;             /// multi exit BasicBlocks connect to a single unique Exit Block
+
+private:
+    /// get dummy exit basic block. if not exits, then create it, else return
+    /// @param exitBB one of multi exit Basic Blocks
+    /// @return the dummy exit basic block
+    SVFBasicBlock* getUniqueExitBlock(SVFBasicBlock* exitBB);
+
 protected:
     ///@{ attributes to be set only through Module builders e.g., LLVMModule
     inline void addBasicBlock(const SVFBasicBlock* bb)
@@ -424,14 +432,13 @@ public:
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
         assert(exitBlock && "have not yet set exit Basicblock");
+        assert((!uniqueExitBlock || uniqueExitBlock == exitBlock) && "unique exit basic block must be null or just equal to exit block");
         return exitBlock;
     }
 
-    inline void setExitBlock(SVFBasicBlock *bb)
-    {
-        assert(!exitBlock && "function already has a exit Basicblock.");
-        exitBlock = bb;
-    }
+    /// set exit basic block, if multi exit basic blocks exist,
+    /// then create a unique basic block, and set the unique exit basic block
+    void setExitBlock(SVFBasicBlock *bb);
 
     inline const SVFBasicBlock* front() const
     {
@@ -535,6 +542,7 @@ class SVFBasicBlock : public SVFValue
     friend class SVFIRWriter;
     friend class SVFIRReader;
     friend class SVFIRBuilder;
+    friend class SVFFunction;
 
 public:
     typedef std::vector<const SVFInstruction*>::const_iterator const_iterator;

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -431,6 +431,7 @@ public:
 
     inline const SVFBasicBlock* back() const
     {
+        assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
         /// Carefully! 'back' is just the last basic block of function,
         /// but not necessarily a exit basic block
         /// more refer to: https://github.com/SVF-tools/SVF/pull/1262

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -320,7 +320,7 @@ private:
     std::vector<const SVFBasicBlock*> allBBs;   /// all BasicBlocks of this function
     std::vector<const SVFArgument*> allArgs;    /// all formal arguments of this function
     std::vector<std::string> annotations; /// annotations of this function
-    SVFBasicBlock *exitBlock;                   /// exit BasicBlock of this function
+    SVFBasicBlock *exitBlock;             /// exit BasicBlock of this function
 
 protected:
     ///@{ attributes to be set only through Module builders e.g., LLVMModule
@@ -416,12 +416,11 @@ public:
     inline const SVFBasicBlock* getExitBB() const
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
-        assert(exitBlock && "have not yet set exit Basicblock?");
+        /// Carefully! exit BasicBlock may be return nullptr
+        /// more refer to: https://github.com/SVF-tools/SVF/pull/1262#issuecomment-1833400405
         return exitBlock;
     }
 
-    /// set exit basic block, if multi exit basic blocks exist,
-    /// then create a unique basic block, and set the unique exit basic block
     void setExitBlock(SVFBasicBlock *bb);
 
     inline const SVFBasicBlock* front() const
@@ -431,7 +430,10 @@ public:
 
     inline const SVFBasicBlock* back() const
     {
-        return getExitBB();
+        /// Carefully! 'back' is just the last basic block of function,
+        /// but not necessarily a exit basic block
+        /// more refer to: https://github.com/SVF-tools/SVF/pull/1262
+        return allBBs.back();
     }
 
     inline const_iterator begin() const

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -320,7 +320,7 @@ private:
     std::vector<const SVFBasicBlock*> allBBs;   /// all BasicBlocks of this function
     std::vector<const SVFArgument*> allArgs;    /// all formal arguments of this function
     std::vector<std::string> annotations; /// annotations of this function
-    SVFBasicBlock *exitBlock;             /// exit BasicBlock of this function
+    SVFBasicBlock *exitBlock;             /// a 'single' basic block having no successors and containing return instruction in a function
 
 protected:
     ///@{ attributes to be set only through Module builders e.g., LLVMModule
@@ -418,7 +418,7 @@ public:
     inline const SVFBasicBlock* getExitBB() const
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
-        assert((!isNotRet && exitBlock) && "have not yet set exit Basicblock?");
+        assert((hasReturn() && exitBlock) && "ensure the function has a single basic block containing a return instruction!");
         return exitBlock;
     }
 
@@ -465,6 +465,11 @@ public:
     inline bool isNotRetFunction() const
     {
         return isNotRet;
+    }
+
+    inline bool hasReturn() const
+    {
+        return !isNotRet;
     }
 
     inline const std::vector<std::string>& getAnnotations() const

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -320,7 +320,8 @@ private:
     std::vector<const SVFBasicBlock*> allBBs;   /// all BasicBlocks of this function
     std::vector<const SVFArgument*> allArgs;    /// all formal arguments of this function
     std::vector<std::string> annotations; /// annotations of this function
-
+    SVFBasicBlock *entryBlock;                  /// entry BasicBlock of this function
+    SVFBasicBlock *exitBlock;                   /// exit BasicBlock of this function
 protected:
     ///@{ attributes to be set only through Module builders e.g., LLVMModule
     inline void addBasicBlock(const SVFBasicBlock* bb)
@@ -409,13 +410,27 @@ public:
     inline const SVFBasicBlock* getEntryBlock() const
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
-        return allBBs.front();
+        assert(entryBlock && "have not yet set entry Basicblock");
+        return entryBlock;
+    }
+
+    inline void setEntryBlock(SVFBasicBlock *bb)
+    {
+        assert(!entryBlock && "function already has entry Basicblock.");
+        entryBlock = bb;
     }
 
     inline const SVFBasicBlock* getExitBB() const
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
-        return allBBs.back();
+        assert(exitBlock && "have not yet set exit Basicblock");
+        return exitBlock;
+    }
+
+    inline void setExitBlock(SVFBasicBlock *bb)
+    {
+        assert(!exitBlock && "function already has a exit Basicblock.");
+        exitBlock = bb;
     }
 
     inline const SVFBasicBlock* front() const

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -413,11 +413,12 @@ public:
         return allBBs.front();
     }
 
+    /// Carefully! when you call getExitBB, you need ensure the function has return instruction
+    /// more refer to: https://github.com/SVF-tools/SVF/pull/1262
     inline const SVFBasicBlock* getExitBB() const
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
-        /// Carefully! exit BasicBlock may be return nullptr
-        /// more refer to: https://github.com/SVF-tools/SVF/pull/1262#issuecomment-1833400405
+        assert((!isNotRet && exitBlock) && "have not yet set exit Basicblock?");
         return exitBlock;
     }
 

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -418,7 +418,7 @@ public:
     inline const SVFBasicBlock* getExitBB() const
     {
         assert(hasBasicBlock() && "function does not have any Basicblock, external function?");
-        assert((hasReturn() && exitBlock) && "ensure the function has a single basic block containing a return instruction!");
+        assert((!isNotRet && exitBlock) && "ensure the function has a single basic block containing a return instruction!");
         return exitBlock;
     }
 
@@ -466,11 +466,6 @@ public:
     inline bool isNotRetFunction() const
     {
         return isNotRet;
-    }
-
-    inline bool hasReturn() const
-    {
-        return !isNotRet;
     }
 
     inline const std::vector<std::string>& getAnnotations() const

--- a/svf/lib/Graphs/ICFG.cpp
+++ b/svf/lib/Graphs/ICFG.cpp
@@ -119,7 +119,7 @@ const std::string FunExitICFGNode::toString() const
     std::stringstream rawstr(str);
     rawstr << "FunExitICFGNode" << getId();
     rawstr << " {fun: " << getFun()->getName();
-    if (isExtCall(getFun())==false)
+    if (!isExtCall(getFun()) && getFun()->hasReturn())
         rawstr << getFun()->getExitBB()->front()->getSourceLoc();
     rawstr << "}";
     for (const SVFStmt *stmt : getSVFStmts())

--- a/svf/lib/Graphs/ICFG.cpp
+++ b/svf/lib/Graphs/ICFG.cpp
@@ -54,7 +54,8 @@ FunExitICFGNode::FunExitICFGNode(NodeID id, const SVFFunction* f)
     // if function is implemented
     if (f->begin() != f->end())
     {
-        if (f->hasReturn())
+        // ensure the enclosing function has exit basic block
+        if (!f->isNotRetFunction())
         {
             bb = f->getExitBB();
         }
@@ -115,12 +116,14 @@ const std::string FunEntryICFGNode::toString() const
 
 const std::string FunExitICFGNode::toString() const
 {
+    const SVFFunction *fun = getFun();
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "FunExitICFGNode" << getId();
-    rawstr << " {fun: " << getFun()->getName();
-    if (!isExtCall(getFun()) && getFun()->hasReturn())
-        rawstr << getFun()->getExitBB()->front()->getSourceLoc();
+    rawstr << " {fun: " << fun->getName();
+    // ensure the enclosing function has exit basic block
+    if (!isExtCall(fun) && !fun->isNotRetFunction())
+        rawstr << fun->getExitBB()->front()->getSourceLoc();
     rawstr << "}";
     for (const SVFStmt *stmt : getSVFStmts())
         rawstr << "\n" << stmt->toString();

--- a/svf/lib/Graphs/ICFG.cpp
+++ b/svf/lib/Graphs/ICFG.cpp
@@ -54,7 +54,10 @@ FunExitICFGNode::FunExitICFGNode(NodeID id, const SVFFunction* f)
     // if function is implemented
     if (f->begin() != f->end())
     {
-        bb = f->getExitBB();
+        if (f->hasReturn())
+        {
+            bb = f->getExitBB();
+        }
     }
 }
 

--- a/svf/lib/SVFIR/SVFValue.cpp
+++ b/svf/lib/SVFIR/SVFValue.cpp
@@ -160,7 +160,8 @@ SVFFunction::SVFFunction(const SVFType* ty, const SVFFunctionType* ft,
                          SVFLoopAndDomInfo* ld, std::vector<std::string> annos)
     : SVFValue(ty, SVFValue::SVFFunc), isDecl(declare), intrinsic(intrinsic),
       addrTaken(adt), isUncalled(false), isNotRet(false), varArg(varg),
-      funcType(ft), loopAndDom(ld), realDefFun(nullptr), annotations(std::move(annos))
+      funcType(ft), loopAndDom(ld), realDefFun(nullptr), annotations(std::move(annos)),
+      entryBlock(nullptr), exitBlock(nullptr)
 {
 }
 

--- a/svf/lib/SVFIR/SVFValue.cpp
+++ b/svf/lib/SVFIR/SVFValue.cpp
@@ -161,7 +161,7 @@ SVFFunction::SVFFunction(const SVFType* ty, const SVFFunctionType* ft,
     : SVFValue(ty, SVFValue::SVFFunc), isDecl(declare), intrinsic(intrinsic),
       addrTaken(adt), isUncalled(false), isNotRet(false), varArg(varg),
       funcType(ft), loopAndDom(ld), realDefFun(nullptr), annotations(std::move(annos)),
-      entryBlock(nullptr), exitBlock(nullptr), uniqueExitBlock(nullptr)
+      exitBlock(nullptr)
 {
 }
 
@@ -190,31 +190,10 @@ bool SVFFunction::isVarArg() const
     return varArg;
 }
 
-SVFBasicBlock* SVFFunction::getUniqueExitBlock(SVFBasicBlock* exitBB)
-{
-    assert(exitBlock && "we do not need unique exit block when exitBlock is null");
-    if (!uniqueExitBlock)
-    {
-        uniqueExitBlock = new SVFBasicBlock(exitBlock->getType(), this);
-        // connect every exit basic block to dummy exit block
-        uniqueExitBlock->addPredBasicBlock(exitBB);
-        exitBB->addSuccBasicBlock(uniqueExitBlock);
-    }
-    return uniqueExitBlock;
-}
-
 void SVFFunction::setExitBlock(SVFBasicBlock *bb)
 {
-    if (exitBlock)
-    {
-        /// multi exit basic block
-        exitBlock = getUniqueExitBlock(bb);
-    }
-    else
-    {
-        /// single exit basic block
-        exitBlock = bb;
-    }
+    assert(!exitBlock && "have already set exit Basicblock!");
+    exitBlock = bb;
 }
 
 SVFBasicBlock::SVFBasicBlock(const SVFType* ty, const SVFFunction* f)


### PR DESCRIPTION
reproduce the bug:
given the code in file bb.c:
```c
int print();

void test()
{
    for (int i = 0 ; i < 100 ; i++)
    {
        print();
    }
}
```
compile and optimize the code with the following commands:
```shell
clang -S -c -Xclang -disable-O0-optnone -fno-discard-value-names -emit-llvm -o bb.ll bb.c
opt -loop-unroll -unroll-count=3 -S -o bb.ll.ll bb.ll
```
we get the final optimized bitcode file `bb.ll.ll` and get the code of test function:
```c
; Function Attrs: noinline nounwind ssp uwtable
define void @test() #0 {
entry:
  %i = alloca i32, align 4
  store i32 0, i32* %i, align 4
  br label %for.cond

for.cond:                                         ; preds = %for.inc.2, %entry
  %0 = load i32, i32* %i, align 4
  %cmp = icmp slt i32 %0, 100
  br i1 %cmp, label %for.body, label %for.end

for.body:                                         ; preds = %for.cond
  %call = call i32 (...) @print()
  br label %for.inc

for.inc:                                          ; preds = %for.body
  %1 = load i32, i32* %i, align 4
  %inc = add nsw i32 %1, 1
  store i32 %inc, i32* %i, align 4
  %2 = load i32, i32* %i, align 4
  %cmp.1 = icmp slt i32 %2, 100
  br i1 %cmp.1, label %for.body.1, label %for.end

for.end:                                          ; preds = %for.inc.1, %for.inc, %for.cond
  ret void

for.body.1:                                       ; preds = %for.inc
  %call.1 = call i32 (...) @print()
  br label %for.inc.1

for.inc.1:                                        ; preds = %for.body.1
  %3 = load i32, i32* %i, align 4
  %inc.1 = add nsw i32 %3, 1
  store i32 %inc.1, i32* %i, align 4
  %4 = load i32, i32* %i, align 4
  %cmp.2 = icmp slt i32 %4, 100
  br i1 %cmp.2, label %for.body.2, label %for.end

for.body.2:                                       ; preds = %for.inc.1
  %call.2 = call i32 (...) @print()
  br label %for.inc.2

for.inc.2:                                        ; preds = %for.body.2
  %5 = load i32, i32* %i, align 4
  %inc.2 = add nsw i32 %5, 1
  store i32 %inc.2, i32* %i, align 4
  br label %for.cond, !llvm.loop !6
}
```
so, the `basic block vector` is:
```c
[
  entry,
  for.cond,
  for.body,
  for.inc,
  for.end,
  for.body.1,
  for.inc.1,
  for.body.2,
  for.inc.2,
]
```
in the code above, we know: `for.end` basic block is the exit basic block of the function test, so I think we can't  get exit basic block by simply retrieving `the last element` of the `basic block vector`

by pulling request, I unify to set entry and exit basic block according to the definition of the entry/exit basic block of a function: no preds/succs.