### PR TITLE
add source element type in accesspath

### DIFF
--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -345,7 +345,9 @@ void SVFIRBuilder::processCE(const Value* val)
             const Constant* opnd = gepce->getOperand(0);
             // handle recursive constant express case (gep (bitcast (gep X 1)) 1)
             processCE(opnd);
-            AccessPath ap;
+            auto &GEPOp = llvm::cast<llvm::GEPOperator>(*gepce);
+            Type *pType = GEPOp.getSourceElementType();
+            AccessPath ap(0, LLVMModuleSet::getLLVMModuleSet()->getSVFType(pType));
             bool constGep = computeGepOffset(gepce, ap);
             // must invoke pag methods here, otherwise it will be a dead recursion cycle
             const SVFValue* cval = getCurrentValue();
@@ -710,7 +712,7 @@ void SVFIRBuilder::visitGetElementPtrInst(GetElementPtrInst &inst)
 
     NodeID src = getValueNode(inst.getPointerOperand());
 
-    AccessPath ap;
+    AccessPath ap(0, LLVMModuleSet::getLLVMModuleSet()->getSVFType(inst.getSourceElementType()));
     bool constGep = computeGepOffset(&inst, ap);
     addGepEdge(src, dst, ap, constGep);
 }

--- a/svf/include/MemoryModel/AccessPath.h
+++ b/svf/include/MemoryModel/AccessPath.h
@@ -65,12 +65,13 @@ public:
     typedef std::vector<IdxOperandPair> IdxOperandPairs;
 
     /// Constructor
-    AccessPath(APOffset o = 0) : fldIdx(o) {}
+    AccessPath(APOffset o = 0, const SVFType* srcTy = nullptr) : fldIdx(o), sourceElementType(srcTy) {}
 
     /// Copy Constructor
     AccessPath(const AccessPath& ap)
-        : fldIdx(ap.fldIdx),
-          idxOperandPairs(ap.getIdxOperandPairVec())
+            : fldIdx(ap.fldIdx),
+              idxOperandPairs(ap.getIdxOperandPairVec()),
+              sourceElementType(ap.getSourceElementType())
     {
     }
 
@@ -84,12 +85,13 @@ public:
     {
         fldIdx = rhs.fldIdx;
         idxOperandPairs = rhs.getIdxOperandPairVec();
+        sourceElementType = rhs.sourceElementType;
         return *this;
     }
     inline bool operator==(const AccessPath& rhs) const
     {
         return this->fldIdx == rhs.fldIdx &&
-               this->idxOperandPairs == rhs.idxOperandPairs;
+               this->idxOperandPairs == rhs.idxOperandPairs && this->sourceElementType == rhs.sourceElementType;
     }
     //@}
 
@@ -106,6 +108,10 @@ public:
     inline const IdxOperandPairs& getIdxOperandPairVec() const
     {
         return idxOperandPairs;
+    }
+    inline const SVFType* getSourceElementType() const
+    {
+        return sourceElementType;
     }
     //@}
 
@@ -167,6 +173,9 @@ private:
 
     APOffset fldIdx;	///< Accumulated Constant Offsets
     IdxOperandPairs idxOperandPairs;	///< a vector of actual offset in the form of <SVF Var, iterator type>
+    const SVFType* sourceElementType;   /// source element type in gep instruction,
+                                        /// e.g., %f1 = getelementptr inbounds %struct.MyStruct, %struct.MyStruct* %arrayidx, i32 0, i32 0
+                                        /// the source element type is %struct.MyStruct
 };
 
 } // End namespace SVF

--- a/svf/include/MemoryModel/AccessPath.h
+++ b/svf/include/MemoryModel/AccessPath.h
@@ -65,13 +65,13 @@ public:
     typedef std::vector<IdxOperandPair> IdxOperandPairs;
 
     /// Constructor
-    AccessPath(APOffset o = 0, const SVFType* srcTy = nullptr) : fldIdx(o), sourceElementType(srcTy) {}
+    AccessPath(APOffset o = 0, const SVFType* srcTy = nullptr) : fldIdx(o), gepSourceElementType(srcTy) {}
 
     /// Copy Constructor
     AccessPath(const AccessPath& ap)
             : fldIdx(ap.fldIdx),
               idxOperandPairs(ap.getIdxOperandPairVec()),
-              sourceElementType(ap.getSourceElementType())
+              gepSourceElementType(ap.getGepSourceElementType())
     {
     }
 
@@ -85,13 +85,13 @@ public:
     {
         fldIdx = rhs.fldIdx;
         idxOperandPairs = rhs.getIdxOperandPairVec();
-        sourceElementType = rhs.sourceElementType;
+        gepSourceElementType = rhs.gepSourceElementType;
         return *this;
     }
     inline bool operator==(const AccessPath& rhs) const
     {
         return this->fldIdx == rhs.fldIdx &&
-               this->idxOperandPairs == rhs.idxOperandPairs && this->sourceElementType == rhs.sourceElementType;
+               this->idxOperandPairs == rhs.idxOperandPairs && this->gepSourceElementType == rhs.gepSourceElementType;
     }
     //@}
 
@@ -109,9 +109,9 @@ public:
     {
         return idxOperandPairs;
     }
-    inline const SVFType* getSourceElementType() const
+    inline const SVFType* getGepSourceElementType() const
     {
-        return sourceElementType;
+        return gepSourceElementType;
     }
     //@}
 
@@ -173,7 +173,7 @@ private:
 
     APOffset fldIdx;	///< Accumulated Constant Offsets
     IdxOperandPairs idxOperandPairs;	///< a vector of actual offset in the form of <SVF Var, iterator type>
-    const SVFType* sourceElementType;   /// source element type in gep instruction,
+    const SVFType* gepSourceElementType;   /// source element type in gep instruction,
                                         /// e.g., %f1 = getelementptr inbounds %struct.MyStruct, %struct.MyStruct* %arrayidx, i32 0, i32 0
                                         /// the source element type is %struct.MyStruct
 };

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -209,7 +209,8 @@ APOffset AccessPath::computeConstantOffset() const
 
     assert(isConstantOffset() && "not a constant offset");
 
-    if(idxOperandPairs.empty())
+    // source element type is struct
+    if(sourceElementType && sourceElementType->isStructTy())
         return getConstantStructFldIdx();
 
     APOffset totalConstOffset = 0;
@@ -255,6 +256,7 @@ NodeBS AccessPath::computeAllLocations() const
 
 AccessPath AccessPath::operator+(const AccessPath& rhs) const
 {
+    assert(sourceElementType == rhs.getSourceElementType() && "source element type not match");
     AccessPath ap(rhs);
     ap.fldIdx += getConstantStructFldIdx();
     for (auto &p : ap.getIdxOperandPairVec())

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -210,7 +210,7 @@ APOffset AccessPath::computeConstantOffset() const
     assert(isConstantOffset() && "not a constant offset");
 
     // source element type is struct
-    if(sourceElementType && sourceElementType->isStructTy())
+    if(gepSourceElementType && gepSourceElementType->isStructTy())
         return getConstantStructFldIdx();
 
     APOffset totalConstOffset = 0;
@@ -256,7 +256,7 @@ NodeBS AccessPath::computeAllLocations() const
 
 AccessPath AccessPath::operator+(const AccessPath& rhs) const
 {
-    assert(sourceElementType == rhs.getSourceElementType() && "source element type not match");
+    assert(gepSourceElementType == rhs.getGepSourceElementType() && "source element type not match");
     AccessPath ap(rhs);
     ap.fldIdx += getConstantStructFldIdx();
     for (auto &p : ap.getIdxOperandPairVec())


### PR DESCRIPTION
This patch adds a field sourceElementType in accesspath, e.g.,

```cpp
%f1 = getelementptr inbounds %struct.MyStruct, %struct.MyStruct* %arrayidx, i32 0, i32 0
```

The source element type is %struct.MyStruct

This is also useful for the migration regarding opaque pointers (https://llvm.org/docs/OpaquePointers.html#migration-instructions). 