### PR TITLE
Break when app and extapi module have a match

### DIFF
--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -947,6 +947,7 @@ void LLVMModuleSet::buildFunToFunMap()
                 // ExtDecl -> ExtDecl in Table 1
                 std::vector<const Function*> calledFunctions = LLVMUtil::getCalledFunctions(extfun);
                 ExtFuncsVec.insert(ExtFuncsVec.end(), calledFunctions.begin(), calledFunctions.end());
+                break;
             }
         }
     }
@@ -977,6 +978,7 @@ void LLVMModuleSet::buildFunToFunMap()
                 // ExtDecl -> ExtDecl in Table 1
                 std::vector<const Function*> calledFunctions = LLVMUtil::getCalledFunctions(owfunc);
                 ExtFuncsVec.insert(ExtFuncsVec.end(), calledFunctions.begin(), calledFunctions.end());
+                break;
             }
         }
     }


### PR DESCRIPTION
As name from app and extapi modules can only have exactly one match, we can break after find it.

The benefit is not limited to performance. 

Take a look at the loop of the second break: `fun` is casted out of `appfunc` from `funDefs`, which is the function list of app module.
Then, `fun->eraseFromParent()` remove that function from the function list. This is ultimately a `list->remove()` operation, see: https://github.com/llvm/llvm-project/blob/main/llvm/lib/IR/Function.cpp#L389
This operation will release the object of `fun`, and also `appfunc`, so when we still try to compare `appfunc` with `owfunc`, the behavior is undefined.

I received a SIGSEGV at line 960 (original version) after thousands of calls to `appfunc->getName()` after the first match. Both the bc file and extapi are quite large so I prefer not pasting it here. Also since this issue is `malloc`-related, it's not easy to provide a stable yet minimal reproducible example, but I think describing it already makes much sense.