### PR TITLE
Add `-fno-rtti`/`fno-exceptions` based on LLVM's configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,77 @@ project("SVF")
 configure_file(${PROJECT_SOURCE_DIR}/.config.in
                ${PROJECT_BINARY_DIR}/include/Util/config.h)
 
-# We need to match the build environment for LLVM: In particular, we need C++14
-# and the -fno-rtti flag
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# add -std=gnu++14
-set(CMAKE_CXX_EXTENSIONS ON)
+# Match configuration used to build LLVM (match C++ standard; match
+# runtime typing information (RTTI); match exception handling; etc)
+if(COMMAND add_llvm_library)
+  message(STATUS "Detected in-tree build configuration; skipping LLVM fetching")
+  set(IN_SOURCE_BUILD 1)
+else()
+  message(STATUS "Detected out-of-tree build configuration; fetching LLVM")
 
-add_compile_options("-fno-rtti")
-add_compile_options("-fno-exceptions")
+  find_package(LLVM REQUIRED CONFIG HINTS ${LLVM_DIR} $ENV{LLVM_DIR})
+  message(STATUS "LLVM STATUS:
+    Version       ${LLVM_PACKAGE_VERSION}
+    Definitions   ${LLVM_DEFINITIONS}
+    Includes      ${LLVM_INCLUDE_DIRS}
+    Libraries     ${LLVM_LIBRARY_DIRS}
+    Targets       ${LLVM_TARGETS_TO_BUILD}
+    Build type    ${LLVM_BUILD_TYPE}
+    Exceptions    ${LLVM_ENABLE_EH}
+    RTTI          ${LLVM_ENABLE_RTTI}
+    Dynamic lib   ${LLVM_LINK_LLVM_DYLIB}"
+  )
+
+  if("${LLVM_PACKAGE_VERSION_MAJOR}" VERSION_GREATER "15")
+    message(FATAL_ERROR "Unsupported LLVM version (need <= 15.0.7; got ${LLVM_PACKAGE_VERSION})")
+  endif()
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT ${LLVM_BUILD_TYPE} STREQUAL "Debug")
+    message(FATAL_ERROR "Got build type 'Debug' but LLVM is not built in Debug mode!")
+  endif()
+
+  if(NOT LLVM_ENABLE_EH)
+    message(STATUS "Building SVF without exception handling")
+    add_compile_options("-fno-exceptions")
+  endif()
+
+  if(NOT LLVM_ENABLE_RTTI)
+    message(STATUS "Building SVF without RTII")
+    add_compile_options("-fno-rtti")
+  endif()
+
+  # Load the LLVM definitions & include directories
+  separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+
+  if(NOT ${LLVM_LINK_LLVM_DYLIB})
+    message(STATUS "Linking to separate LLVM static libraries")
+    llvm_map_components_to_libnames(
+      llvm_libs
+      analysis
+      bitwriter
+      core
+      instcombine
+      instrumentation
+      ipo
+      irreader
+      linker
+      scalaropts
+      support
+      target
+      transformutils)
+  else()
+    message(STATUS "Linking to LLVM dynamic shared library object")
+    set(llvm_libs LLVM)
+  endif()
+
+  # Make the "add_llvm_library()" command available
+  include(AddLLVM)
+endif()
+
+# Set C++ standard; use C++14 as LLVM 15 defaults to that (doesn't need to match)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_EXTENSIONS ON)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Treat compiler warnings as errors
 add_compile_options("-Werror" "-Wall")
@@ -80,11 +142,18 @@ endif()
 add_subdirectory(svf)
 add_subdirectory(svf-llvm)
 
+include(GNUInstallDirs)
+install(
+  TARGETS SvfCore SvfLLVM
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 install(
   DIRECTORY ${PROJECT_SOURCE_DIR}/svf/include/
             ${PROJECT_SOURCE_DIR}/svf-llvm/include/
   COMPONENT devel
-  DESTINATION include/svf
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/include/svf
   FILES_MATCHING
   PATTERN "**/*.h")
 

--- a/svf-llvm/CMakeLists.txt
+++ b/svf-llvm/CMakeLists.txt
@@ -1,56 +1,12 @@
-# To support both in- and out-of-source builds, we check for the presence of the
-# add_llvm_loadable_module command. - if this command is not present, we are
-# building out-of-source
-if(NOT COMMAND add_llvm_library)
-  find_package(LLVM REQUIRED CONFIG HINTS "${LLVM_DIR}")
-  set(LLVM_DIR ${LLVM_BINARY_DIR} PARENT_SCOPE)
-
-  message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
-  if(NOT LLVM_ENABLE_RTTI)
-    add_compile_options("-fno-rtti")
-    message(STATUS "Disable RTTI")
-  endif()
-
-  if(NOT LLVM_ENABLE_EH)
-    add_compile_options("-fno-exceptions")
-    message(STATUS "Disable exceptions")
-  endif()
-
-  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-  include(AddLLVM)
-
-  add_definitions(${LLVM_DEFINITIONS})
-  # include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
-
-  if(LLVM_LINK_LLVM_DYLIB)
-    set(llvm_libs LLVM)
-  else()
-    llvm_map_components_to_libnames(
-      llvm_libs
-      analysis
-      bitwriter
-      core
-      instcombine
-      instrumentation
-      ipo
-      irreader
-      linker
-      scalaropts
-      support
-      target
-      transformutils)
-  endif()
-else()
-  set(IN_SOURCE_BUILD 1)
-endif()
-
 # SVF-LLVM contains LLVM Libs
 file(GLOB SVFLLVM_SOURCES lib/*.cpp)
 
 add_llvm_library(SvfLLVM ${SVFLLVM_SOURCES})
+
 target_include_directories(SvfLLVM SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})
+target_link_directories(SvfLLVM PUBLIC ${LLVM_LIBRARY_DIRS})
+target_compile_definitions(SvfLLVM PUBLIC ${LLVM_DEFINITIONS})
+
 target_include_directories(SvfLLVM PUBLIC include)
 target_link_libraries(SvfLLVM PUBLIC ${llvm_libs} ${Z3_LIBRARIES} SvfCore)
 


### PR DESCRIPTION
Currently the top-level `CMakeLists.txt` script force-adds the flags `-fno-rtti` and `-fno-exceptions` using the `add_compile_options()` function from CMake; adding the flags for all modules built thereafter. This causes SVF to disregard LLVM's configuration and always build `SvfLLVM` without RTTI or exceptions.

This pull request moves the loading of LLVM to the top-level configuration file, where `-fno-rtti` and `-fno-exceptions` are added for both `SvfCore` and `SvfLLVM` iff the LLVM instance being used is configured that way.

Additionally, the way the compile definitions now match the way recommended by LLVM for including LLVM from a `CMakeLists.txt` script.