### PR TITLE
Get LLVMContext instance directly from `llvm::Module` when building SVFModule

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMModule.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMModule.h
@@ -67,7 +67,7 @@ private:
     static bool preProcessed;
     SymbolTableInfo* symInfo;
     SVFModule* svfModule; ///< Borrowed from singleton SVFModule::svfModule
-    std::unique_ptr<LLVMContext> cxts;
+    std::unique_ptr<LLVMContext> owned_ctx;
     std::vector<std::unique_ptr<Module>> owned_modules;
     std::vector<std::reference_wrapper<Module>> modules;
 
@@ -111,8 +111,10 @@ public:
         llvmModuleSet = nullptr;
     }
 
-    // The parameter of context should be the llvm context of the mod, the llvm context of mod and extapi module should be the same
-    static SVFModule* buildSVFModule(Module& mod, std::unique_ptr<LLVMContext> context);
+    // Build an SVF module from a given LLVM Module instance (for use e.g. in a LLVM pass)
+    static SVFModule* buildSVFModule(Module& mod);
+
+    // Build an SVF module from the bitcode files provided in `moduleNameVec`
     static SVFModule* buildSVFModule(const std::vector<std::string>& moduleNameVec);
 
     inline SVFModule* getSVFModule()
@@ -357,8 +359,8 @@ private:
     std::vector<const Function*> getLLVMGlobalFunctions(const GlobalVariable* global);
 
     void loadModules(const std::vector<std::string>& moduleNameVec);
-    // The llvm context of app module and extapi module should be the same
-    void loadExtAPIModules(std::unique_ptr<LLVMContext> context = nullptr);
+    // Loads ExtAPI bitcode file; uses LLVMContext made while loading module bitcode files or from Module
+    void loadExtAPIModules();
     void addSVFMain();
 
     void createSVFDataStructure();


### PR DESCRIPTION
The recent commit merged in #1258 modified the interface to build an `SVF::SVFModule` instance from an `llvm::Module` object to include a `std::unique_ptr<llvm::LLVMContext>` parameter to specify the context used when loading the `ExtAPI` module. This change introduces a number of issues however, particularly when using SVF from an LLVM pass.

Most critically, the use of `std::unique_ptr<>` creates problems when SVF is used from an LLVM pass, as automatic garbage collection on the context is done incorrectly. Creating a unique pointer based on the context of the LLVM module incorrectly means ownership of the context is taken by the `LLVMModuleSet` object. This causes issues because the context is obviously not uniquely owned by the module set; when an SVFModule is built from an LLVM module, calling `LLVMModuleSet::releaseLLVMModuleSet()` triggers an invalid free/double free and crashes. Wrapping the unconditional deletion [on line 110](https://github.com/SVF-tools/SVF/blob/af2bdc8036b59cd205b70c7e72dc521a90e91328/svf-llvm/include/SVF-LLVM/LLVMModule.h#L110) also does not solve this issue, as the static pointer remains set after the underlying object is garbage collected.

This issue occurs using LLVM 15 (debug build with RTTI & exception handling enabled) and running SVF on the module from a module pass in a full LTO pipeline. I did not check if the issue also exists when running a pass separately through `opt`, but it could be possible this issue does not exist in that case (as I saw above issues reported by `Clang` for the test programs it compiles to check compiler functionality before compiling the actual target).

Additionally, the change to explicitly passing an `LLVMContext` breaks backwards compatibility unnecessarily. Since the context used when loading ExtAPI should match the module used to build the SVFModule from, it is unnecessary to require the context be passed through a separate argument when it can be gotten directly from the module.