### PR TITLE
consider multiple uses of heap object

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMUtil.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMUtil.h
@@ -225,9 +225,9 @@ const Value* stripAllCasts(const Value* val);
 /// Get the type of the heap allocation
 const Type* getTypeOfHeapAlloc(const Instruction* inst);
 
-/// Return the bitcast instruction which is val's only use site, otherwise
+/// Return the bitcast instruction right next to val, otherwise
 /// return nullptr
-const Value* getUniqueUseViaCastInst(const Value* val);
+const Value* getFirstUseViaCastInst(const Value* val);
 
 /// Return corresponding constant expression, otherwise return nullptr
 //@{

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1101,7 +1101,7 @@ const Value* SVFIRBuilder::getBaseValueForExtArg(const Value* V)
             const SVFInstruction* svfInst = LLVMModuleSet::getLLVMModuleSet()->getSVFInstruction(cb);
             if (SVFUtil::isHeapAllocExtCallViaRet(svfInst))
             {
-                if (const Value* bitCast = getUniqueUseViaCastInst(cb))
+                if (const Value* bitCast = getFirstUseViaCastInst(cb))
                     return bitCast;
             }
         }

--- a/svf-llvm/lib/SymbolTableBuilder.cpp
+++ b/svf-llvm/lib/SymbolTableBuilder.cpp
@@ -755,7 +755,7 @@ u32_t SymbolTableBuilder::analyzeHeapAllocByteSize(const Value* val)
  */
 void SymbolTableBuilder::analyzeHeapObjType(ObjTypeInfo* typeinfo, const Value* val)
 {
-    if(const Value* castUse = getUniqueUseViaCastInst(val))
+    if(const Value* castUse = getFirstUseViaCastInst(val))
     {
         typeinfo->setFlag(ObjTypeInfo::HEAP_OBJ);
         typeinfo->resetTypeForHeapStaticObj(
@@ -774,7 +774,7 @@ void SymbolTableBuilder::analyzeHeapObjType(ObjTypeInfo* typeinfo, const Value* 
  */
 void SymbolTableBuilder::analyzeStaticObjType(ObjTypeInfo* typeinfo, const Value* val)
 {
-    if(const Value* castUse = getUniqueUseViaCastInst(val))
+    if(const Value* castUse = getFirstUseViaCastInst(val))
     {
         typeinfo->setFlag(ObjTypeInfo::STATIC_OBJ);
         typeinfo->resetTypeForHeapStaticObj(


### PR DESCRIPTION
Solve problem described in #1289.

Sometimes a return value of heap allocation has multiple uses. We need to find out the one right next to it, and make sure it is a `bitcast` operation. This requires performing a scan over all uses and find out the last one, which corresponds to the first use in human readable IR.