### PR TITLE
make the pointee type related to gep more robust

### DIFF
--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -282,15 +282,16 @@ bool SVFIRBuilder::computeGepOffset(const User *V, AccessPath& ap)
 
     bool isConst = true;
 
-    bool addedPointerType = false;
+    bool prevPtrOperand = false;
     for (bridge_gep_iterator gi = bridge_gep_begin(*V), ge = bridge_gep_end(*V);
             gi != ge; ++gi)
     {
         const Type* gepTy = *gi;
         const SVFType* svfGepTy = LLVMModuleSet::getLLVMModuleSet()->getSVFType(gepTy);
 
-        assert((!addedPointerType || !svfGepTy->isPointerTy()) && "multiple pointer type?");
-        if(svfGepTy->isPointerTy()) addedPointerType = true;
+        assert((prevPtrOperand && svfGepTy->isPointerTy()) == false &&
+               "Expect no more than one gep operand to be of a pointer type");
+        if(svfGepTy->isPointerTy()) prevPtrOperand = true;
         const Value* offsetVal = gi.getOperand();
         const SVFValue* offsetSvfVal = LLVMModuleSet::getLLVMModuleSet()->getSVFValue(offsetVal);
         assert(gepTy != offsetVal->getType() && "iteration and operand have the same type?");

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -282,11 +282,15 @@ bool SVFIRBuilder::computeGepOffset(const User *V, AccessPath& ap)
 
     bool isConst = true;
 
+    bool addedPointerType = false;
     for (bridge_gep_iterator gi = bridge_gep_begin(*V), ge = bridge_gep_end(*V);
             gi != ge; ++gi)
     {
         const Type* gepTy = *gi;
         const SVFType* svfGepTy = LLVMModuleSet::getLLVMModuleSet()->getSVFType(gepTy);
+
+        assert((!addedPointerType || !svfGepTy->isPointerTy()) && "multiple pointer type?");
+        if(svfGepTy->isPointerTy()) addedPointerType = true;
         const Value* offsetVal = gi.getOperand();
         const SVFValue* offsetSvfVal = LLVMModuleSet::getLLVMModuleSet()->getSVFValue(offsetVal);
         assert(gepTy != offsetVal->getType() && "iteration and operand have the same type?");

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -58,19 +58,26 @@ bool AccessPath::isConstantOffset() const
 
 /// Return element number of a type
 /// (1) StructType or Array, return flattened number elements.
-/// (2) SingleValueType or Function Type, return 1
+/// (2) Pointer type, return max field limit
+/// (3) Non-pointer SingleValueType or Function Type, return 1
 u32_t AccessPath::getElementNum(const SVFType* type) const
 {
     if (SVFUtil::isa<SVFArrayType, SVFStructType>(type))
     {
         return SymbolTableInfo::SymbolInfo()->getNumOfFlattenElements(type);
-    }
-    else if (type->isSingleValueType() || SVFUtil::isa<SVFFunctionType>(type))
+    } else if (type->isPointerTy())
     {
         // if type is a pointer, should be like:
         // %2 = getelementptr inbounds i32*, i32** %1, ...
         // where gepSrcPointee is of pointer type (i32*).
-        // the element number of int* should be 1
+        // this can be transformed to:
+        // %2 = getelementptr inbounds [N x i32], [N x i32]* %1, ...
+        // However, we do not know N without context information. int** implies non-contiguous blocks of memory
+        // In this case, we conservatively return max field limit
+        return Options::MaxFieldLimit();
+    }
+    else if (type->isSingleValueType() || SVFUtil::isa<SVFFunctionType>(type))
+    {
         return 1;
     }
     else

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -58,17 +58,19 @@ bool AccessPath::isConstantOffset() const
 
 /// Return element number of a type
 /// (1) StructType or Array, return flattened number elements.
-/// (2) non-pointer SingleValueType, return 1
+/// (2) SingleValueType or Function Type, return 1
 u32_t AccessPath::getElementNum(const SVFType* type) const
 {
-    assert(!SVFUtil::isa<SVFPointerType>(type) && "can't be pointer type");
-
     if (SVFUtil::isa<SVFArrayType, SVFStructType>(type))
     {
         return SymbolTableInfo::SymbolInfo()->getNumOfFlattenElements(type);
     }
     else if (type->isSingleValueType() || SVFUtil::isa<SVFFunctionType>(type))
     {
+        // if type is a pointer, should be like:
+        // %2 = getelementptr inbounds i32*, i32** %1, ...
+        // where gepSrcPointee is of pointer type (i32*).
+        // the element number of int* should be 1
         return 1;
     }
     else


### PR DESCRIPTION
1. assert that we can have at most one pointer type (normally the first index that simply pieces the base pointer) when bridging a gep instruction. 

2. remove the assertion checking in getelementNum because the pointee may be of a pointer type for the multi-level pointer, e.g., `%2 = getelementptr inbounds i32*, i32** %1, ... ` the corresponding source code is like:

```cpp
int getValue(int** arr, int x, int y) {
    return arr[x][y];
}
```

This can be transformed to:  `%2 = getelementptr inbounds [N x i32], [N x i32]* %1, ...`
However, we do not know `N` without context information. `int**` implies **non-contiguous blocks of memory**. In this case, we conservatively return the max field limit.

