### PR TITLE
fix issue #1306: compute vf guard for strong update in another branch

### DIFF
--- a/svf/include/CFL/CFLSVFGBuilder.h
+++ b/svf/include/CFL/CFLSVFGBuilder.h
@@ -46,6 +46,10 @@ public:
 protected:
     /// Re-write create SVFG method
     virtual void buildSVFG();
+
+    /// Remove Incoming Edge for strong-update (SU) store instruction
+    /// Because the SU node does not receive indirect value
+    virtual void rmIncomingEdgeForSUStore(BVDataPTAImpl* pta);
 };
 
 }

--- a/svf/include/CFL/CFLSVFGBuilder.h
+++ b/svf/include/CFL/CFLSVFGBuilder.h
@@ -1,4 +1,4 @@
-//===----- CFLVF.h -- CFL Value-Flow Client--------------//
+//===- CFLSVFGBuilder.h -- Building SVFG for CFL--------------------------//
 //
 //                     SVF: Static Value-Flow Analysis
 //
@@ -20,49 +20,33 @@
 //
 //===----------------------------------------------------------------------===//
 
-/*
- * CFLVF.h
- *
- *  Created on: September 5, 2022
- *      Author: Pei Xu
- */
+//
+// Created by Xiao on 30/12/23.
+//
 
-#ifndef INCLUDE_CFL_CFLVF_H_
-#define INCLUDE_CFL_CFLVF_H_
+#ifndef SVF_CFLSVFGBUILDER_H
+#define SVF_CFLSVFGBUILDER_H
 
+#include "SABER/SaberSVFGBuilder.h"
 
-#include "CFL/CFLBase.h"
-#include "CFL/CFLStat.h"
-#include "CFL/CFLSVFGBuilder.h"
-#include "WPA/Andersen.h"
+namespace SVF{
 
-namespace SVF
-{
-class CFLVF : public CFLBase
-{
-
+class CFLSVFGBuilder: public SaberSVFGBuilder {
 public:
-    CFLVF(SVFIR* ir) : CFLBase(ir, PointerAnalysis::CFLFSCS_WPA)
-    {
-    }
+    typedef Set<const SVFGNode*> SVFGNodeSet;
+    typedef Map<NodeID, PointsTo> NodeToPTSSMap;
+    typedef FIFOWorkList<NodeID> WorkList;
 
-    /// Parameter Checking
-    virtual void checkParameter();
+    /// Constructor
+    CFLSVFGBuilder() = default;
 
-    /// Initialize the grammar, graph, solver
-    virtual void initialize();
+    /// Destructor
+    virtual ~CFLSVFGBuilder() = default;
 
-    /// Print grammar and graph
-    virtual void finalize();
-
-    /// Build CFLGraph via VFG
-    void buildCFLGraph();
-
-private:
-    CFLSVFGBuilder memSSA;
-    SVFG* svfg;
+protected:
+    /// Re-write create SVFG method
+    virtual void buildSVFG();
 };
 
-} // End namespace SVF
-
-#endif /* INCLUDE_CFL_CFLVF_H_*/
+}
+#endif //SVF_CFLSVFGBUILDER_H

--- a/svf/include/Graphs/SVFG.h
+++ b/svf/include/Graphs/SVFG.h
@@ -66,6 +66,7 @@ class SVFG : public VFG
 {
     friend class SVFGBuilder;
     friend class SaberSVFGBuilder;
+    friend class CFLSVFGBuilder;
     friend class TaintSVFGBuilder;
     friend class DDASVFGBuilder;
     friend class MTASVFGBuilder;

--- a/svf/include/SABER/ProgSlice.h
+++ b/svf/include/SABER/ProgSlice.h
@@ -58,10 +58,13 @@ public:
     typedef FIFOWorkList<const SVFGNode*> VFWorkList;		    ///< worklist for value-flow guard computation
     typedef FIFOWorkList<const SVFBasicBlock*> CFWorkList;	///< worklist for control-flow guard computation
 
+    typedef SaberCondAllocator::SVFGNodeToSVFGNodeSetMap SVFGNodeToSVFGNodeSetMap;
+
+
     /// Constructor
-    ProgSlice(const SVFGNode* src, SaberCondAllocator* pa, const SVFG* graph, const Map<const SVFGNode*, SVFGNodeSet>& edges):
+    ProgSlice(const SVFGNode* src, SaberCondAllocator* pa, const SVFG* graph):
         root(src), partialReachable(false), fullReachable(false), reachGlob(false),
-        pathAllocator(pa), _curSVFGNode(nullptr), finalCond(pa->getFalseCond()), svfg(graph), removedSUVFEdges(edges)
+        pathAllocator(pa), _curSVFGNode(nullptr), finalCond(pa->getFalseCond()), svfg(graph)
     {
     }
 
@@ -299,6 +302,10 @@ protected:
     /// Compute invalid branch condition stemming from removed strong update value-flow edges
     Condition computeInvalidCondFromRemovedSUVFEdge(const SVFGNode * cur);
 
+    const SVFGNodeToSVFGNodeSetMap& getRemovedSUVFEdges() const {
+        return pathAllocator->getRemovedSUVFEdges();
+    }
+
 private:
     SVFGNodeSet forwardslice;				///<  the forward slice
     SVFGNodeSet backwardslice;				///<  the backward slice
@@ -312,7 +319,6 @@ private:
     const SVFGNode* _curSVFGNode;			///<  current svfg node during guard computation
     Condition finalCond;					///<  final condition
     const SVFG* svfg;						///<  SVFG
-    const Map<const SVFGNode*, SVFGNodeSet>& removedSUVFEdges;
 };
 
 } // End namespace SVF

--- a/svf/include/SABER/ProgSlice.h
+++ b/svf/include/SABER/ProgSlice.h
@@ -59,9 +59,9 @@ public:
     typedef FIFOWorkList<const SVFBasicBlock*> CFWorkList;	///< worklist for control-flow guard computation
 
     /// Constructor
-    ProgSlice(const SVFGNode* src, SaberCondAllocator* pa, const SVFG* graph):
+    ProgSlice(const SVFGNode* src, SaberCondAllocator* pa, const SVFG* graph, const Map<const SVFGNode*, SVFGNodeSet>& edges):
         root(src), partialReachable(false), fullReachable(false), reachGlob(false),
-        pathAllocator(pa), _curSVFGNode(nullptr), finalCond(pa->getFalseCond()), svfg(graph)
+        pathAllocator(pa), _curSVFGNode(nullptr), finalCond(pa->getFalseCond()), svfg(graph), removedSUVFEdges(edges)
     {
     }
 
@@ -296,6 +296,9 @@ protected:
         finalCond = cond;
     }
 
+    /// Compute invalid branch condition stemming from removed strong update value-flow edges
+    Condition computeInvalidCondFromRemovedSUVFEdge(const SVFGNode * cur);
+
 private:
     SVFGNodeSet forwardslice;				///<  the forward slice
     SVFGNodeSet backwardslice;				///<  the backward slice
@@ -309,6 +312,7 @@ private:
     const SVFGNode* _curSVFGNode;			///<  current svfg node during guard computation
     Condition finalCond;					///<  final condition
     const SVFG* svfg;						///<  SVFG
+    const Map<const SVFGNode*, SVFGNodeSet>& removedSUVFEdges;
 };
 
 } // End namespace SVF

--- a/svf/include/SABER/SaberCondAllocator.h
+++ b/svf/include/SABER/SaberCondAllocator.h
@@ -241,13 +241,10 @@ public:
         negConds.set(condition.id());
     }
 
-    const SVFGNodeToSVFGNodeSetMap& getRemovedSUVFEdges() const {
+     SVFGNodeToSVFGNodeSetMap & getRemovedSUVFEdges() {
         return removedSUVFEdges;
     }
 
-    inline void setRemovedSUVFEdges(const SVFGNodeToSVFGNodeSetMap& edges) {
-        removedSUVFEdges = edges;
-    }
 private:
 
     /// Allocate path condition for every basic block

--- a/svf/include/SABER/SaberCondAllocator.h
+++ b/svf/include/SABER/SaberCondAllocator.h
@@ -56,6 +56,7 @@ public:
     typedef Map<const SVFFunction*,  BasicBlockSet> FunToExitBBsMap;  ///< map a function to all its basic blocks calling program exit
     typedef Map<const SVFBasicBlock*, Condition> BBToCondMap;	///< map a basic block to its condition during control-flow guard computation
     typedef FIFOWorkList<const SVFBasicBlock*> CFWorkList;	///< worklist for control-flow guard computation
+    typedef Map<const SVFGNode*, Set<const SVFGNode*>> SVFGNodeToSVFGNodeSetMap;
 
 
     /// Constructor
@@ -239,6 +240,14 @@ public:
         setCondInst(condition, inst);
         negConds.set(condition.id());
     }
+
+    const SVFGNodeToSVFGNodeSetMap& getRemovedSUVFEdges() const {
+        return removedSUVFEdges;
+    }
+
+    inline void setRemovedSUVFEdges(const SVFGNodeToSVFGNodeSetMap& edges) {
+        removedSUVFEdges = edges;
+    }
 private:
 
     /// Allocate path condition for every basic block
@@ -299,6 +308,7 @@ private:
     NodeBS negConds;                        ///bit vector for distinguish neg
     std::vector<Condition> conditionVec;          /// vector storing z3expression
     static u32_t totalCondNum; /// a counter for fresh condition
+    SVFGNodeToSVFGNodeSetMap removedSUVFEdges;
 
 protected:
     BBCondMap bbConds;						///< map basic block to its successors/predecessors branch conditions

--- a/svf/include/SABER/SaberSVFGBuilder.h
+++ b/svf/include/SABER/SaberSVFGBuilder.h
@@ -84,7 +84,7 @@ protected:
 
     /// Remove Incoming Edge for strong-update (SU) store instruction
     /// Because the SU node does not receive indirect value
-    void rmIncomingEdgeForSUStore(BVDataPTAImpl* pta);
+    virtual void rmIncomingEdgeForSUStore(BVDataPTAImpl* pta);
 
     /// Add actual parameter SVFGNode for 1st argument of a deallocation like external function
     /// In order to path sensitive leak detection

--- a/svf/include/SABER/SaberSVFGBuilder.h
+++ b/svf/include/SABER/SaberSVFGBuilder.h
@@ -33,6 +33,8 @@
 #include "MSSA/SVFGBuilder.h"
 #include "SVFIR/SVFValue.h"
 #include "Util/WorkList.h"
+#include "SABER/SaberCondAllocator.h"
+
 
 namespace SVF
 {
@@ -62,8 +64,8 @@ public:
         svfg->addActualParmVFGNode(pagNode, cs);
     }
 
-    const Map<const SVFGNode*, SVFGNodeSet>& getRemovedSUVFEdges() const {
-        return removedSUVFEdges;
+    void setSaberCondAllocator(SaberCondAllocator* allocator) {
+        saberCondAllocator = allocator;
     }
 
 protected:
@@ -101,8 +103,8 @@ private:
     PointsTo globs;
     /// Store all global SVFG nodes
     SVFGNodeSet globSVFGNodes;
-    /// Removed strong update edge
-    Map<const SVFGNode*, SVFGNodeSet> removedSUVFEdges;
+
+    SaberCondAllocator* saberCondAllocator;
 };
 
 } // End namespace SVF

--- a/svf/include/SABER/SaberSVFGBuilder.h
+++ b/svf/include/SABER/SaberSVFGBuilder.h
@@ -33,11 +33,12 @@
 #include "MSSA/SVFGBuilder.h"
 #include "SVFIR/SVFValue.h"
 #include "Util/WorkList.h"
-#include "SABER/SaberCondAllocator.h"
 
 
 namespace SVF
 {
+
+class SaberCondAllocator;
 
 class SaberSVFGBuilder : public SVFGBuilder
 {

--- a/svf/include/SABER/SaberSVFGBuilder.h
+++ b/svf/include/SABER/SaberSVFGBuilder.h
@@ -76,7 +76,7 @@ protected:
     /// Return TRUE if this is a strong update STORE statement.
     bool isStrongUpdate(const SVFGNode* node, NodeID& singleton, BVDataPTAImpl* pta);
 
-private:
+protected:
     /// Remove direct value-flow edge to a dereference point for Saber source-sink memory error detection
     /// for example, given two statements: p = alloc; q = *p, the direct SVFG edge between them is deleted
     /// Because those edges only stand for values used at the dereference points but they can not pass the value to other definitions

--- a/svf/include/SABER/SaberSVFGBuilder.h
+++ b/svf/include/SABER/SaberSVFGBuilder.h
@@ -62,6 +62,10 @@ public:
         svfg->addActualParmVFGNode(pagNode, cs);
     }
 
+    const Map<const SVFGNode*, SVFGNodeSet>& getRemovedSUVFEdges() const {
+        return removedSUVFEdges;
+    }
+
 protected:
     /// Re-write create SVFG method
     virtual void buildSVFG();
@@ -97,6 +101,8 @@ private:
     PointsTo globs;
     /// Store all global SVFG nodes
     SVFGNodeSet globSVFGNodes;
+    /// Removed strong update edge
+    Map<const SVFGNode*, SVFGNodeSet> removedSUVFEdges;
 };
 
 } // End namespace SVF

--- a/svf/lib/CFL/CFLSVFGBuilder.cpp
+++ b/svf/lib/CFL/CFLSVFGBuilder.cpp
@@ -55,3 +55,46 @@ void CFLSVFGBuilder::buildSVFG()
     if(pta->printStat())
         svfg->performStat();
 }
+
+
+/*!
+ * Remove Incoming Edge for strong-update (SU) store instruction
+ * Because the SU node does not receive indirect value
+ *
+ * e.g.,
+ *      L1: *p = O; (singleton)
+ *      L2: *p = _; (SU here)
+ *      We should remove the indirect value flow L1 -> L2
+ *      Because the points-to set of O from L1 does not pass to that after L2
+ */
+void CFLSVFGBuilder::rmIncomingEdgeForSUStore(BVDataPTAImpl* pta)
+{
+
+    for(SVFG::iterator it = svfg->begin(), eit = svfg->end(); it!=eit; ++it)
+    {
+        const SVFGNode* node = it->second;
+
+        if(const StoreSVFGNode* stmtNode = SVFUtil::dyn_cast<StoreSVFGNode>(node))
+        {
+            if(SVFUtil::isa<StoreStmt>(stmtNode->getPAGEdge()))
+            {
+                NodeID singleton;
+                if(isStrongUpdate(node, singleton, pta))
+                {
+                    Set<SVFGEdge*> toRemove;
+                    for (SVFGNode::const_iterator it2 = node->InEdgeBegin(), eit2 = node->InEdgeEnd(); it2 != eit2; ++it2)
+                    {
+                        if ((*it2)->isIndirectVFGEdge())
+                        {
+                            toRemove.insert(*it2);
+                        }
+                    }
+                    for (SVFGEdge* edge: toRemove)
+                    {
+                        svfg->removeSVFGEdge(edge);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/svf/lib/SABER/ProgSlice.cpp
+++ b/svf/lib/SABER/ProgSlice.cpp
@@ -93,6 +93,15 @@ bool ProgSlice::AllPathReachableSolve()
 
 /*!
  * Compute invalid branch condition stemming from removed strong update value-flow edges
+ *
+ * Fix issue: https://github.com/SVF-tools/SVF/issues/1306
+ * Line 11->13 is removed due to a strong update at Line 13, which means Line 11 is unreachable to Line 13 on the value flow graph.
+ * However on the control flow graph they are still considered as reachable,
+ * making the vf guard on Line 11 -> Line 15 a true condition (should consider the infeasible branch Line 11 -> Line 13)
+ * Therefore, we collect this infeasible branch condition (condition on Line 11 -> Line 13, `a == b`) as an invalid condition (invalidCond),
+ * and add the negation of invalidCond when computing value flow guard starting from the source of the SU.
+ * In this example, we add `a != b` on Line 11 -> Line 15.
+ *
  * @param cur current SVFG node
  * @return invalid branch condition
  */

--- a/svf/lib/SABER/ProgSlice.cpp
+++ b/svf/lib/SABER/ProgSlice.cpp
@@ -106,8 +106,8 @@ ProgSlice::Condition ProgSlice::computeInvalidCondFromRemovedSUVFEdge(const SVFG
         }
     }
     Condition invalidCond = getFalseCond();
-    auto suVFEdgesIt = removedSUVFEdges.find(cur);
-    if (suVFEdgesIt != removedSUVFEdges.end()) {
+    auto suVFEdgesIt = getRemovedSUVFEdges().find(cur);
+    if (suVFEdgesIt != getRemovedSUVFEdges().end()) {
         for (const auto &succ: suVFEdgesIt->second) {
             if (!validOutBBs.count(getSVFGNodeBB(succ))) {
                 // removed vfg node does not reside in the BBs of valid successors

--- a/svf/lib/SABER/ProgSlice.cpp
+++ b/svf/lib/SABER/ProgSlice.cpp
@@ -52,6 +52,8 @@ bool ProgSlice::AllPathReachableSolve()
     {
         const SVFGNode* node = worklist.pop();
         setCurSVFGNode(node);
+
+        Condition invalidCond = computeInvalidCondFromRemovedSUVFEdge(node);
         Condition cond = getVFCond(node);
         for(SVFGNode::const_iterator it = node->OutEdgeBegin(), eit = node->OutEdgeEnd(); it!=eit; ++it)
         {
@@ -75,7 +77,7 @@ bool ProgSlice::AllPathReachableSolve()
                 }
                 else
                     vfCond = ComputeIntraVFGGuard(nodeBB,succBB);
-
+                vfCond = condAnd(vfCond, condNeg(invalidCond));
                 Condition succPathCond = condAnd(cond, vfCond);
                 if(setVFCond(succ,  condOr(getVFCond(succ), succPathCond) ))
                     worklist.push(succ);
@@ -87,6 +89,36 @@ bool ProgSlice::AllPathReachableSolve()
     }
 
     return isSatisfiableForAll();
+}
+
+/*!
+ * Compute invalid branch condition stemming from removed strong update value-flow edges
+ * @param cur current SVFG node
+ * @return invalid branch condition
+ */
+ProgSlice::Condition ProgSlice::computeInvalidCondFromRemovedSUVFEdge(const SVFGNode * cur) {
+    Set<const SVFBasicBlock*> validOutBBs; // the BBs of valid successors
+    for(SVFGNode::const_iterator it = cur->OutEdgeBegin(), eit = cur->OutEdgeEnd(); it!=eit; ++it) {
+        const SVFGEdge* edge = (*it);
+        const SVFGNode* succ = edge->getDstNode();
+        if(inBackwardSlice(succ)) {
+            validOutBBs.insert(getSVFGNodeBB(succ));
+        }
+    }
+    Condition invalidCond = getFalseCond();
+    auto suVFEdgesIt = removedSUVFEdges.find(cur);
+    if (suVFEdgesIt != removedSUVFEdges.end()) {
+        for (const auto &succ: suVFEdgesIt->second) {
+            if (!validOutBBs.count(getSVFGNodeBB(succ))) {
+                // removed vfg node does not reside in the BBs of valid successors
+                const SVFBasicBlock *nodeBB = getSVFGNodeBB(cur);
+                const SVFBasicBlock *succBB = getSVFGNodeBB(succ);
+                clearCFCond();
+                invalidCond = condOr(invalidCond, ComputeIntraVFGGuard(nodeBB, succBB));
+            }
+        }
+    }
+    return invalidCond;
 }
 
 /*!

--- a/svf/lib/SABER/SaberSVFGBuilder.cpp
+++ b/svf/lib/SABER/SaberSVFGBuilder.cpp
@@ -276,6 +276,8 @@ void SaberSVFGBuilder::rmIncomingEdgeForSUStore(BVDataPTAImpl* pta)
                     }
                     for (SVFGEdge* edge: toRemove)
                     {
+                        if (isa<StoreSVFGNode>(edge->getSrcNode()))
+                            removedSUVFEdges[edge->getSrcNode()].insert(edge->getDstNode());
                         svfg->removeSVFGEdge(edge);
                     }
                 }

--- a/svf/lib/SABER/SaberSVFGBuilder.cpp
+++ b/svf/lib/SABER/SaberSVFGBuilder.cpp
@@ -254,6 +254,7 @@ bool SaberSVFGBuilder::isStrongUpdate(const SVFGNode* node, NodeID& singleton, B
  */
 void SaberSVFGBuilder::rmIncomingEdgeForSUStore(BVDataPTAImpl* pta)
 {
+    assert(saberCondAllocator && "saber condition allocator not set yet!");
 
     for(SVFG::iterator it = svfg->begin(), eit = svfg->end(); it!=eit; ++it)
     {
@@ -277,7 +278,7 @@ void SaberSVFGBuilder::rmIncomingEdgeForSUStore(BVDataPTAImpl* pta)
                     for (SVFGEdge* edge: toRemove)
                     {
                         if (isa<StoreSVFGNode>(edge->getSrcNode()))
-                            removedSUVFEdges[edge->getSrcNode()].insert(edge->getDstNode());
+                            saberCondAllocator->getRemovedSUVFEdges()[edge->getSrcNode()].insert(edge->getDstNode());
                         svfg->removeSVFGEdge(edge);
                     }
                 }

--- a/svf/lib/SABER/SaberSVFGBuilder.cpp
+++ b/svf/lib/SABER/SaberSVFGBuilder.cpp
@@ -52,6 +52,7 @@ void SaberSVFGBuilder::buildSVFG()
 
     rmDerefDirSVFGEdges(pta);
 
+    assert(saberCondAllocator && "saber condition allocator not set yet!");
     rmIncomingEdgeForSUStore(pta);
 
     DBOUT(DGENERAL, outs() << pasMsg("\tAdd Sink SVFG Nodes\n"));
@@ -256,7 +257,6 @@ bool SaberSVFGBuilder::isStrongUpdate(const SVFGNode* node, NodeID& singleton, B
  */
 void SaberSVFGBuilder::rmIncomingEdgeForSUStore(BVDataPTAImpl* pta)
 {
-    assert(saberCondAllocator && "saber condition allocator not set yet!");
 
     for(SVFG::iterator it = svfg->begin(), eit = svfg->end(); it!=eit; ++it)
     {

--- a/svf/lib/SABER/SaberSVFGBuilder.cpp
+++ b/svf/lib/SABER/SaberSVFGBuilder.cpp
@@ -32,6 +32,8 @@
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "Graphs/SVFG.h"
 #include "Util/Options.h"
+#include "SABER/SaberCondAllocator.h"
+
 
 using namespace SVF;
 using namespace SVFUtil;

--- a/svf/lib/SABER/SrcSnkDDA.cpp
+++ b/svf/lib/SABER/SrcSnkDDA.cpp
@@ -97,6 +97,7 @@ void SrcSnkDDA::analyze(SVFModule* module)
             if(Options::DumpSlice())
                 annotateSlice(_curSlice);
 
+            memSSA.getRemovedSUVFEdges();
             if(_curSlice->AllPathReachableSolve())
                 _curSlice->setAllReachable();
 
@@ -277,7 +278,7 @@ void SrcSnkDDA::setCurSlice(const SVFGNode* src)
         clearVisitedMap();
     }
 
-    _curSlice = new ProgSlice(src,getSaberCondAllocator(), getSVFG());
+    _curSlice = new ProgSlice(src,getSaberCondAllocator(), getSVFG(), memSSA.getRemovedSUVFEdges());
 }
 
 void SrcSnkDDA::annotateSlice(ProgSlice* slice)

--- a/svf/lib/SABER/SrcSnkDDA.cpp
+++ b/svf/lib/SABER/SrcSnkDDA.cpp
@@ -43,12 +43,12 @@ void SrcSnkDDA::initialize(SVFModule* module)
     SVFIR* pag = PAG::getPAG();
 
     AndersenWaveDiff* ander = AndersenWaveDiff::createAndersenWaveDiff(pag);
+    memSSA.setSaberCondAllocator(getSaberCondAllocator());
     if(Options::SABERFULLSVFG())
         svfg =  memSSA.buildFullSVFG(ander);
     else
         svfg =  memSSA.buildPTROnlySVFG(ander);
     setGraph(memSSA.getSVFG());
-    getSaberCondAllocator()->setRemovedSUVFEdges(memSSA.getRemovedSUVFEdges());
     ptaCallGraph = ander->getPTACallGraph();
     //AndersenWaveDiff::releaseAndersenWaveDiff();
     /// allocate control-flow graph branch conditions

--- a/svf/lib/SABER/SrcSnkDDA.cpp
+++ b/svf/lib/SABER/SrcSnkDDA.cpp
@@ -48,6 +48,7 @@ void SrcSnkDDA::initialize(SVFModule* module)
     else
         svfg =  memSSA.buildPTROnlySVFG(ander);
     setGraph(memSSA.getSVFG());
+    getSaberCondAllocator()->setRemovedSUVFEdges(memSSA.getRemovedSUVFEdges());
     ptaCallGraph = ander->getPTACallGraph();
     //AndersenWaveDiff::releaseAndersenWaveDiff();
     /// allocate control-flow graph branch conditions
@@ -97,7 +98,6 @@ void SrcSnkDDA::analyze(SVFModule* module)
             if(Options::DumpSlice())
                 annotateSlice(_curSlice);
 
-            memSSA.getRemovedSUVFEdges();
             if(_curSlice->AllPathReachableSolve())
                 _curSlice->setAllReachable();
 
@@ -278,7 +278,7 @@ void SrcSnkDDA::setCurSlice(const SVFGNode* src)
         clearVisitedMap();
     }
 
-    _curSlice = new ProgSlice(src,getSaberCondAllocator(), getSVFG(), memSSA.getRemovedSUVFEdges());
+    _curSlice = new ProgSlice(src,getSaberCondAllocator(), getSVFG());
 }
 
 void SrcSnkDDA::annotateSlice(ProgSlice* slice)


### PR DESCRIPTION
fix issue #1306: we compute the vf guard of invalid branches stemming from removed strong-update value-flow, and conjunct the negation of that.