### PR TITLE
Fix bugs for big program

### DIFF
--- a/svf/include/Util/SVFStat.h
+++ b/svf/include/Util/SVFStat.h
@@ -30,6 +30,8 @@
 #ifndef SVF_SVFSTAT_H
 #define SVF_SVFSTAT_H
 
+#include <string>
+
 namespace SVF
 {
 
@@ -41,9 +43,9 @@ class SVFStat
 {
 public:
 
-    typedef OrderedMap<const char *, u32_t> NUMStatMap;
+    typedef OrderedMap<std::string, u32_t> NUMStatMap;
 
-    typedef OrderedMap<const char *, double> TIMEStatMap;
+    typedef OrderedMap<std::string, double> TIMEStatMap;
 
     enum ClockType
     {

--- a/svf/lib/AbstractExecution/SVFIR2ItvExeState.cpp
+++ b/svf/lib/AbstractExecution/SVFIR2ItvExeState.cpp
@@ -95,6 +95,13 @@ IntervalValue SVFIR2ItvExeState::getRangeLimitFromType(const SVFType* type)
         }
         return IntervalValue(lb, ub);
     }
+    else if (SVFUtil::isa<SVFOtherType>(type))
+    {
+        // handle other type like float double, set s32_t as the range
+        s64_t ub = static_cast<s64_t>(std::numeric_limits<s32_t>::max());
+        s64_t lb = static_cast<s64_t>(std::numeric_limits<s32_t>::min());
+        return IntervalValue(lb, ub);
+    }
     else
     {
         assert(false && "cannot support");


### PR DESCRIPTION
1. in SVFStat.h. 
```
typedef OrderedMap<std::string, u32_t> NUMStatMap;
```
The key type should be string, since `const char*` cannot support NUMStatMap["$KEYNAME"]

2. in SVFIR2ItvExeState.cpp
add SVFOtherType handler, since float/double is one of SVFOtherType, the intervalValue range of double/float is s32_t's range.