### PR TITLE
Add Memory Statistics and Clean Solitaries in Constraint Graph

### DIFF
--- a/svf/include/DDA/DDAStat.h
+++ b/svf/include/DDA/DDAStat.h
@@ -75,18 +75,6 @@ public:
 
     void getNumOfOOBQuery();
 
-    inline void setMemUsageBefore(u32_t vmrss, u32_t vmsize)
-    {
-        _vmrssUsageBefore = vmrss;
-        _vmsizeUsageBefore = vmsize;
-    }
-
-    inline void setMemUsageAfter(u32_t vmrss, u32_t vmsize)
-    {
-        _vmrssUsageAfter = vmrss;
-        _vmsizeUsageAfter = vmsize;
-    }
-
 private:
     FlowDDA* flowDDA;
     ContextDDA* contextDDA;
@@ -109,11 +97,6 @@ private:
     u32_t _NumOfNullPtr;
     u32_t _NumOfConstantPtr;
     u32_t _NumOfBlackholePtr;
-
-    u32_t _vmrssUsageBefore;
-    u32_t _vmrssUsageAfter;
-    u32_t _vmsizeUsageBefore;
-    u32_t _vmsizeUsageAfter;
 
     double _AvgNumOfDPMAtSVFGNode;
     u32_t _MaxNumOfDPMAtSVFGNode;

--- a/svf/include/Graphs/ConsG.h
+++ b/svf/include/Graphs/ConsG.h
@@ -67,6 +67,8 @@ protected:
 
     void destroy();
 
+    void clearSolitaries();  // remove nodes that are neither pointers nor connected with any edge
+
     SVFStmt::SVFStmtSetTy& getPAGEdgeSet(SVFStmt::PEDGEK kind)
     {
         return pag->getPTASVFStmtSet(kind);

--- a/svf/include/Util/PTAStat.h
+++ b/svf/include/Util/PTAStat.h
@@ -53,11 +53,29 @@ public:
 
     NodeBS localVarInRecursion;
 
+    inline void setMemUsageBefore(u32_t vmrss, u32_t vmsize)
+    {
+        _vmrssUsageBefore = vmrss;
+        _vmsizeUsageBefore = vmsize;
+    }
+
+    inline void setMemUsageAfter(u32_t vmrss, u32_t vmsize)
+    {
+        _vmrssUsageAfter = vmrss;
+        _vmsizeUsageAfter = vmsize;
+    }
+
     void performStat() override;
 
     void callgraphStat() override;
-private:
+
+
+protected:
     PointerAnalysis* pta;
+    u32_t _vmrssUsageBefore;
+    u32_t _vmrssUsageAfter;
+    u32_t _vmsizeUsageBefore;
+    u32_t _vmsizeUsageAfter;
 };
 
 } // End namespace SVF

--- a/svf/lib/DDA/DDAStat.cpp
+++ b/svf/lib/DDA/DDAStat.cpp
@@ -82,9 +82,6 @@ void DDAStat::initDefault()
     _AnaTimePerQuery = 0;
     _AnaTimeCyclePerQuery = 0;
     _TotalTimeOfQueries = 0;
-
-    _vmrssUsageBefore = _vmrssUsageAfter = 0;
-    _vmsizeUsageBefore = _vmsizeUsageAfter = 0;
 }
 
 SVFG* DDAStat::getSVFG() const

--- a/svf/lib/Graphs/ConsG.cpp
+++ b/svf/lib/Graphs/ConsG.cpp
@@ -139,8 +139,28 @@ void ConstraintGraph::buildCG()
         StoreStmt* edge = SVFUtil::cast<StoreStmt>(*iter);
         addStoreCGEdge(edge->getRHSVarID(),edge->getLHSVarID());
     }
+
+    clearSolitaries();
 }
 
+/*!
+ * Remove nodes that are neither pointers nor connected with any edge
+ */
+void ConstraintGraph::clearSolitaries()
+{
+    Set<ConstraintNode*> nodesToRemove;
+    for (auto it = this->begin(); it != this->end(); ++it)
+    {
+        if (it->second->hasIncomingEdge() || it->second->hasOutgoingEdge())
+            continue;
+        if (pag->getGNode(it->first)->isPointer())
+            continue;
+        nodesToRemove.insert(it->second);
+    }
+
+    for (auto node : nodesToRemove)
+        removeConstraintNode(node);
+}
 
 /*!
  * Memory has been cleaned up at GenericGraph

--- a/svf/lib/Util/PTAStat.cpp
+++ b/svf/lib/Util/PTAStat.cpp
@@ -43,6 +43,10 @@ PTAStat::PTAStat(PointerAnalysis* p) : SVFStat(),
                                        _vmsizeUsageBefore(0),
                                        _vmsizeUsageAfter(0)
 {
+    u32_t vmrss = 0;
+    u32_t vmsize = 0;
+    SVFUtil::getMemoryUsageKB(&vmrss, &vmsize);
+    setMemUsageBefore(vmrss, vmsize);
 }
 
 void PTAStat::performStat()
@@ -64,6 +68,13 @@ void PTAStat::performStat()
         }
     }
     PTNumStatMap["LocalVarInRecur"] = localVarInRecursion.count();
+
+    u32_t vmrss = 0;
+    u32_t vmsize = 0;
+    SVFUtil::getMemoryUsageKB(&vmrss, &vmsize);
+    setMemUsageAfter(vmrss, vmsize);
+    PTNumStatMap["MemoryUsageVmrss"] = _vmrssUsageAfter - _vmrssUsageBefore;
+    PTNumStatMap["MemoryUsageVmsize"] = _vmsizeUsageAfter - _vmsizeUsageBefore;
 }
 
 void PTAStat::callgraphStat()

--- a/svf/lib/Util/PTAStat.cpp
+++ b/svf/lib/Util/PTAStat.cpp
@@ -36,7 +36,12 @@
 using namespace SVF;
 using namespace std;
 
-PTAStat::PTAStat(PointerAnalysis* p) : SVFStat(), pta(p)
+PTAStat::PTAStat(PointerAnalysis* p) : SVFStat(),
+                                       pta(p),
+                                       _vmrssUsageBefore(0),
+                                       _vmrssUsageAfter(0),
+                                       _vmsizeUsageBefore(0),
+                                       _vmsizeUsageAfter(0)
 {
 }
 

--- a/svf/lib/WPA/Andersen.cpp
+++ b/svf/lib/WPA/Andersen.cpp
@@ -76,15 +76,9 @@ void AndersenBase::initialize()
     PointerAnalysis::initialize();
     /// Create statistic class
     stat = new AndersenStat(this);
-
-    u32_t vmrss = 0;
-    u32_t vmsize = 0;
-    SVFUtil::getMemoryUsageKB(&vmrss, &vmsize);
-    stat->setMemUsageBefore(vmrss, vmsize);
     /// Build Constraint Graph
     consCG = new ConstraintGraph(pag);
     setGraph(consCG);
-
     if (Options::ConsCGDotGraph())
         consCG->dump("consCG_initial");
 }
@@ -100,12 +94,6 @@ void AndersenBase::finalize()
 
     if (Options::PrintCGGraph())
         consCG->print();
-
-    u32_t vmrss = 0;
-    u32_t vmsize = 0;
-    SVFUtil::getMemoryUsageKB(&vmrss, &vmsize);
-    stat->setMemUsageAfter(vmrss, vmsize);
-
     BVDataPTAImpl::finalize();
 }
 

--- a/svf/lib/WPA/Andersen.cpp
+++ b/svf/lib/WPA/Andersen.cpp
@@ -74,11 +74,17 @@ void AndersenBase::initialize()
 {
     /// Build SVFIR
     PointerAnalysis::initialize();
+    /// Create statistic class
+    stat = new AndersenStat(this);
+
+    u32_t vmrss = 0;
+    u32_t vmsize = 0;
+    SVFUtil::getMemoryUsageKB(&vmrss, &vmsize);
+    stat->setMemUsageBefore(vmrss, vmsize);
     /// Build Constraint Graph
     consCG = new ConstraintGraph(pag);
     setGraph(consCG);
-    /// Create statistic class
-    stat = new AndersenStat(this);
+
     if (Options::ConsCGDotGraph())
         consCG->dump("consCG_initial");
 }
@@ -94,6 +100,12 @@ void AndersenBase::finalize()
 
     if (Options::PrintCGGraph())
         consCG->print();
+
+    u32_t vmrss = 0;
+    u32_t vmsize = 0;
+    SVFUtil::getMemoryUsageKB(&vmrss, &vmsize);
+    stat->setMemUsageAfter(vmrss, vmsize);
+
     BVDataPTAImpl::finalize();
 }
 

--- a/svf/lib/WPA/AndersenStat.cpp
+++ b/svf/lib/WPA/AndersenStat.cpp
@@ -352,6 +352,9 @@ void AndersenStat::performStat()
     PTNumStatMap["PointsToConstPtr"] = _NumOfConstantPtr;
     PTNumStatMap["PointsToBlkPtr"] = _NumOfBlackholePtr;
 
+    PTNumStatMap["MemoryUsageVmrss"] = _vmrssUsageAfter - _vmrssUsageBefore;
+    PTNumStatMap["MemoryUsageVmsize"] = _vmsizeUsageAfter - _vmsizeUsageBefore;
+
     PTAStat::printStat("Andersen Pointer Analysis Stats");
 }
 


### PR DESCRIPTION

![3](https://github.com/SVF-tools/SVF/assets/28613518/6e2e665b-e10e-4933-8db3-1bd10c24c8a0)

As shown in the above graph, in this patch,
1) memory statistics of WPA are now printed;
2) non-pointer nodes which are not connected by any edge are removed from constraint graph in the preprocessing stage, which reduced time and memory consumption.