### PR TITLE
Fix incomplete/incorrect PTA when using C++ namespaces & virtual functions

### DIFF
--- a/svf-llvm/lib/CppUtil.cpp
+++ b/svf-llvm/lib/CppUtil.cpp
@@ -639,7 +639,6 @@ Set<std::string> cppUtil::extractClsNamesFromFunc(const Function *foo)
     {
         // c++ constructor
         DemangledName demangledName = cppUtil::demangle(name);
-        updateClassNameBeforeBrackets(demangledName);
         return {demangledName.className};
     }
     else if (isTemplateFunc(foo))


### PR DESCRIPTION
This pull request fixes a bug that caused call graphs to be incomplete/incorrect when using C++ namespaces and virtual functions.

Currently, whenever namespaces and virtual functions are used with C++ classes, the underlying object's name is used to find the VTable for a called function. However, the name used therein is incorrect (the namespace component is stripped off when it shouldn't be), and causes incomplete and incorrect results to be returned, leading to an incomplete callgraph.

For example, take the following snippets:

Example 1:
```
#include <cstdio>
#include <cstring>

class Parent
{
    public:
        Parent( )          = default;
        virtual ~Parent( ) = default;

        virtual void action( ) = 0;
};

class Child : public Parent
{
    public:
        Child( )  = default;
        ~Child( ) = default;

        void action( ) { printf("Doing stuff...\n"); }
};

int main(int argc, char *argv[])
{
    Child *obj = new Child;
    obj->action( );
    delete obj;
    return 0;
}
```
This corresponds to the following — expected — callgraph:
![correct callgraph dot](https://github.com/SVF-tools/SVF/assets/15309778/5f7b1fa4-66e4-4951-b6c5-c452168b4fca)

Example 2:
```
#include <cstdio>
#include <cstring>

namespace n1
{

class Parent
{
    public:
        Parent( )          = default;
        virtual ~Parent( ) = default;

        virtual void action( ) = 0;
};

class Child : public Parent
{
    public:
        Child( )  = default;
        ~Child( ) = default;

        void action( ) { printf("Doing stuff...\n"); }
};

}    // namespace n1

int main(int argc, char *argv[])
{
    n1::Child *obj = new n1::Child;
    obj->action( );
    delete obj;
    return 0;
}
```

This results in the following, incomplete callgraph:
![incorrect callgraph dot](https://github.com/SVF-tools/SVF/assets/15309778/4fee7142-fc94-4d3e-a976-66504a1940a5)

The introduction of the namespaces causes the virtual call not to be found. This is because the set of indirect call edges found in the `AndersenBase::solveConstraints()` function ([line 118](https://github.com/SVF-tools/SVF/blob/dda7fe5da77043bc09dc0a25cc3d83fd7a617764/svf/lib/WPA/Andersen.cpp#L118)) is empty in the second example.

This set is retrieved from the PAG's indirect callsites `SVFIR::indCallSiteToFunPtrMap`, which is then passed to [`Andersen::updateCallGraph()`](https://github.com/SVF-tools/SVF/blob/dda7fe5da77043bc09dc0a25cc3d83fd7a617764/svf/lib/WPA/Andersen.cpp#L654), which again calls [`BVDataPTAImpl::onTheFlyCallGraphSolve`](https://github.com/SVF-tools/SVF/blob/dda7fe5da77043bc09dc0a25cc3d83fd7a617764/svf/lib/MemoryModel/PointerAnalysisImpl.cpp#L492). This calls [`PointerAnalysis::resolveCPPIndCalls`](https://github.com/SVF-tools/SVF/blob/dda7fe5da77043bc09dc0a25cc3d83fd7a617764/svf/lib/MemoryModel/PointerAnalysis.cpp#L486), which, by default, will not connect virtual calls based on the Call Hierarchy Analysis (CHA), and thus calls [`PointerAnalysis::getVFnsFromPts` ](https://github.com/SVF-tools/SVF/blob/dda7fe5da77043bc09dc0a25cc3d83fd7a617764/svf/lib/MemoryModel/PointerAnalysis.cpp#L438).

This function calls `chgraph->csHasVtblsBasedonCHA(SVFUtil::getSVFCallSite(cs->getCallSite()))`, which returns `false` in the second example, because the CHG's `CHG::csToCHAVtblsMap` map has no VTable entries for the given callsite. During construction of the CHG however this map *is* correctly built (note: **without** stripping the namespace component from the objects) and contains mappings for `n1::Child` and such.

However, during lookup, the `getClassNameOfThisPtr` function returns only `Child`, rather than `n1::Child`, causing the lookup to fail, and no call-edge to be created. This is due to `inferThisPtrClsName` calling `extractClsNamesFromFunc`, which calls `updateClassNameBeforeBrackets` on the demangled name. However, this last function call strips the `n1::` part from the demangled name incorrectly, causing the broken lookup. Since this function only gets called on this code-path, removing this stripping (which makes it consistent with other places) should be fine and produces correct call graphs for the above examples.

I believe this could also be the underlying issue for issue #1301 and possibly issue #1314. 