### PR TITLE
Fix incomplete/incorrect callgraphs due to incorrect class names

### DIFF
--- a/svf-llvm/include/SVF-LLVM/ObjTypeInference.h
+++ b/svf-llvm/include/SVF-LLVM/ObjTypeInference.h
@@ -48,7 +48,7 @@ public:
     typedef Map<const Value *, const Type *> ValueToType;
     typedef std::pair<const Value *, bool> ValueBoolPair;
     typedef Map<const Value *, Set<std::string>> ValueToClassNames;
-    typedef Map<const CallBase *, Set<const Function *>> AllocToClsNameSources;
+    typedef Map<const Value *, Set<const Value *>> ObjToClsNameSources;
 
 
 private:
@@ -57,7 +57,7 @@ private:
     ValueToSources _valueToAllocs; // value allocations (stack, static, heap) cache
     ValueToClassNames _thisPtrClassNames; // thisptr class name cache
     ValueToSources _valueToAllocOrClsNameSources; // value alloc/clsname sources cache
-    AllocToClsNameSources _allocToClsNameSources; // alloc clsname sources cache
+    ObjToClsNameSources _objToClsNameSources; // alloc clsname sources cache
 
 
 public:
@@ -122,7 +122,7 @@ protected:
     Set<const Value *> &bwFindAllocOrClsNameSources(const Value *startValue);
 
     /// forward find class name sources starting from an allocation
-    Set<const Function *> &fwFindClsNameSources(const CallBase *alloc);
+    Set<const Value *> &fwFindClsNameSources(const Value *startValue);
 };
 }
 #endif //SVF_OBJTYPEINFERENCE_H

--- a/svf-llvm/lib/CppUtil.cpp
+++ b/svf-llvm/lib/CppUtil.cpp
@@ -28,7 +28,9 @@
  */
 
 #include "SVF-LLVM/CppUtil.h"
+#include "SVF-LLVM/BasicTypes.h"
 #include "SVF-LLVM/LLVMUtil.h"
+#include "Util/Casting.h"
 #include "Util/SVFUtil.h"
 #include "SVF-LLVM/LLVMModule.h"
 #include "SVF-LLVM/ObjTypeInference.h"
@@ -640,9 +642,9 @@ Set<std::string> cppUtil::extractClsNamesFromFunc(const Function *foo)
 {
     assert(foo->hasName() && "foo does not have a name? possible indirect call");
     const std::string &name = foo->getName().str();
-    if (isConstructor(foo))
+    if (isConstructor(foo) || isDestructor(foo))
     {
-        // c++ constructor
+        // c++ constructor or destructor
         DemangledName demangledName = cppUtil::demangle(name);
         return {demangledName.className};
     }
@@ -796,6 +798,10 @@ bool cppUtil::isClsNameSource(const Value *val)
         // indirect call
         if(!foo) return false;
         return isConstructor(foo) || isDestructor(foo) || isTemplateFunc(foo) || isDynCast(foo);
+    }
+    else if (const auto *func = SVFUtil::dyn_cast<Function>(val))
+    {
+        return isConstructor(func) || isDestructor(func) || isTemplateFunc(func);
     }
     return false;
 }

--- a/svf-llvm/lib/ObjTypeInference.cpp
+++ b/svf-llvm/lib/ObjTypeInference.cpp
@@ -653,7 +653,7 @@ Set<std::string> &ObjTypeInference::inferThisPtrClsName(const Value *thisPtr)
             for (const auto *src : fwFindClsNameSources(val))
             {
                 if (const auto *func = SVFUtil::dyn_cast<Function>(src)) addNamesFromFunc(func);
-                else if (const auto *call = SVFUtil::dyn_cast<CallBase>(src)) addNamesFromCall(SVFUtil::cast<CallBase>(src));
+                else if (const auto *call = SVFUtil::dyn_cast<CallBase>(src)) addNamesFromCall(call);
                 else ABORT_MSG("Source site from forward walk is invalid: " + dumpValueAndDbgInfo(src));
             }
         }

--- a/svf-llvm/lib/ObjTypeInference.cpp
+++ b/svf-llvm/lib/ObjTypeInference.cpp
@@ -28,9 +28,11 @@
  */
 
 #include "SVF-LLVM/ObjTypeInference.h"
+#include "SVF-LLVM/BasicTypes.h"
 #include "SVF-LLVM/LLVMModule.h"
 #include "SVF-LLVM/LLVMUtil.h"
 #include "SVF-LLVM/CppUtil.h"
+#include "Util/Casting.h"
 
 #define TYPE_DEBUG 0 /* Turn this on if you're debugging type inference */
 #define ERR_MSG(msg)                                                           \
@@ -590,9 +592,13 @@ u32_t ObjTypeInference::objTyToNumFields(const Type *objTy)
 
 
 /*!
- * get or infer the class names of thisptr
+ * get or infer the class names of thisptr; starting from :param:`thisPtr`, will walk backwards to find
+ * all potential sources for the class name. Valid sources include global or stack variables, heap allocations,
+ * or C++ dynamic casts/constructors/destructors.
+ * If the source site is a global/stack/heap variable, find the corresponding constructor/destructor to
+ * extract the class' name from (since the type of the variable is not reliable but the demangled name is)
  * @param thisPtr
- * @return
+ * @return a set of all possible type names that :param:`thisPtr` could point to
  */
 Set<std::string> &ObjTypeInference::inferThisPtrClsName(const Value *thisPtr)
 {
@@ -600,59 +606,63 @@ Set<std::string> &ObjTypeInference::inferThisPtrClsName(const Value *thisPtr)
     if (it != _thisPtrClassNames.end()) return it->second;
 
     Set<std::string> names;
-    auto insertClassNames = [&names](Set<std::string> &classNames)
+
+    // Lambda for checking a function is a valid name source & extracting a class name from it
+    auto addNamesFromFunc = [&names](const Function *func) -> void
     {
-        names.insert(classNames.begin(), classNames.end());
+        ABORT_IFNOT(isClsNameSource(func), "Func is invalid class name source: " + dumpValueAndDbgInfo(func));
+        for (auto name : extractClsNamesFromFunc(func)) names.insert(name);
     };
 
-    // backward find heap allocations or class name sources
-    Set<const Value *> &vals = bwFindAllocOrClsNameSources(thisPtr);
-    for (const auto &val: vals)
+    // Lambda for getting callee & extracting class name for calls to constructors/destructors/template funcs
+    auto addNamesFromCall = [&names, &addNamesFromFunc](const CallBase *call) -> void
     {
+        ABORT_IFNOT(isClsNameSource(call), "Call is invalid class name source: " + dumpValueAndDbgInfo(call));
+
+        const auto *func = call->getCalledFunction();
+        if (isDynCast(func)) names.insert(extractClsNameFromDynCast(call));
+        else addNamesFromFunc(func);
+    };
+
+    // Walk backwards to find all valid source sites for the pointer (e.g. stack/global/heap variables)
+    for (const auto &val: bwFindAllocOrClsNameSources(thisPtr))
+    {
+        // A source site is either a constructor/destructor/template function from which the class name can be
+        // extracted; a call to a C++ constructor/destructor/template function from which the class name can be
+        // extracted; or an allocation site of an object (i.e. a stack/global/heap variable), from which a
+        // forward walk can be performed to find calls to C++ constructor/destructor/template functions from
+        // which the class' name can then be extracted; skip starting pointer
         if (val == thisPtr) continue;
 
         if (const auto *func = SVFUtil::dyn_cast<Function>(val))
         {
-            // extract class name from function name
-            Set<std::string> classNames = extractClsNamesFromFunc(func);
-            insertClassNames(classNames);
+            // Constructor/destructor/template func; extract name from func directly
+            addNamesFromFunc(func);
         }
-        else if (SVFUtil::isa<LoadInst, StoreInst, GetElementPtrInst, AllocaInst, GlobalValue>(val))
+        else if (isClsNameSource(val))
         {
-            // extract class name from instructions
-            const Type *type = infersiteToType(val);
-            const std::string &className = typeToClsName(type);
-            if (!className.empty())
+            // Call to constructor/destructor/template func; get callee; extract name from callee
+            ABORT_IFNOT(SVFUtil::isa<CallBase>(val), "Call source site is not a callbase: " + dumpValueAndDbgInfo(val));
+            addNamesFromCall(SVFUtil::cast<CallBase>(val));
+        }
+        else if (isAlloc(val))
+        {
+            // Stack/global/heap allocation site; walk forward; find constructor/destructor/template calls
+            ABORT_IFNOT((SVFUtil::isa<AllocaInst, CallBase, GlobalVariable>(val)),
+                        "Alloc site source is not a stack/heap/global variable: " + dumpValueAndDbgInfo(val));
+            for (const auto *src : fwFindClsNameSources(val))
             {
-                Set<std::string> tgt{className};
-                insertClassNames(tgt);
+                if (const auto *func = SVFUtil::dyn_cast<Function>(src)) addNamesFromFunc(func);
+                else if (const auto *call = SVFUtil::dyn_cast<CallBase>(src)) addNamesFromCall(SVFUtil::cast<CallBase>(src));
+                else ABORT_MSG("Source site from forward walk is invalid: " + dumpValueAndDbgInfo(src));
             }
         }
-        else if (const auto *callBase = SVFUtil::dyn_cast<CallBase>(val))
+        else
         {
-            if (const Function *callFunc = callBase->getCalledFunction())
-            {
-                Set<std::string> classNames = extractClsNamesFromFunc(callFunc);
-                insertClassNames(classNames);
-                if (isDynCast(callFunc))
-                {
-                    // dynamic cast
-                    Set<std::string> tgt{extractClsNameFromDynCast(callBase)};
-                    insertClassNames(tgt);
-                }
-                else if (isNewAlloc(callFunc))
-                {
-                    // for heap allocation, we forward find class name sources
-                    Set<const Function *>& srcs = fwFindClsNameSources(callBase);
-                    for (const auto &src: srcs)
-                    {
-                        classNames = extractClsNamesFromFunc(src);
-                        insertClassNames(classNames);
-                    }
-                }
-            }
+            ERR_MSG("Unsupported source type found:" + dumpValueAndDbgInfo(val));
         }
     }
+
     return _thisPtrClassNames[thisPtr] = names;
 }
 
@@ -711,48 +721,43 @@ Set<const Value *> &ObjTypeInference::bwFindAllocOrClsNameSources(const Value *s
             workList.push({curValue, true});
         }
 
-        // current inst reside in cpp self-inference function
+        // If current value is an instruction inside a constructor/destructor/template, use it as a source
         if (const auto *inst = SVFUtil::dyn_cast<Instruction>(curValue))
         {
-            if (const Function *foo = inst->getFunction())
+            if (const auto *parent = inst->getFunction())
             {
-                if (isConstructor(foo) || isDestructor(foo) || isTemplateFunc(foo) || isDynCast(foo))
-                {
-                    insertSource(foo);
-                    if (canUpdate)
-                    {
-                        _valueToAllocOrClsNameSources[curValue] = sources;
-                    }
-                    continue;
-                }
+                if (isClsNameSource(parent)) insertSource(parent);
             }
         }
+
+        // If the current value is an object (global, heap, stack, etc) or name source (constructor/destructor,
+        // a C++ dynamic cast, or a template function), use it as a source
         if (isAlloc(curValue) || isClsNameSource(curValue))
         {
             insertSource(curValue);
         }
-        else if (const auto *getElementPtrInst = SVFUtil::dyn_cast<GetElementPtrInst>(curValue))
+
+        // Explore the current value further depending on the type of the value; use cached values if possible
+        if (const auto *getElementPtrInst = SVFUtil::dyn_cast<GetElementPtrInst>(curValue))
         {
-            insertSource(getElementPtrInst);
             insertSourcesOrPushWorklist(getElementPtrInst->getPointerOperand());
         }
         else if (const auto *bitCastInst = SVFUtil::dyn_cast<BitCastInst>(curValue))
         {
-            Value *prevVal = bitCastInst->getOperand(0);
-            insertSourcesOrPushWorklist(prevVal);
+            insertSourcesOrPushWorklist(bitCastInst->getOperand(0));
         }
         else if (const auto *phiNode = SVFUtil::dyn_cast<PHINode>(curValue))
         {
-            for (u32_t i = 0; i < phiNode->getNumOperands(); ++i)
+            for (const auto *op : phiNode->operand_values())
             {
-                insertSourcesOrPushWorklist(phiNode->getOperand(i));
+                insertSourcesOrPushWorklist(op);
             }
         }
         else if (const auto *loadInst = SVFUtil::dyn_cast<LoadInst>(curValue))
         {
-            for (const auto &use: loadInst->getPointerOperand()->uses())
+            for (const auto *user : loadInst->getPointerOperand()->users())
             {
-                if (const auto *storeInst = SVFUtil::dyn_cast<StoreInst>(use.getUser()))
+                if (const auto *storeInst = SVFUtil::dyn_cast<StoreInst>(user))
                 {
                     if (storeInst->getPointerOperand() == loadInst->getPointerOperand())
                     {
@@ -763,9 +768,9 @@ Set<const Value *> &ObjTypeInference::bwFindAllocOrClsNameSources(const Value *s
         }
         else if (const auto *argument = SVFUtil::dyn_cast<Argument>(curValue))
         {
-            for (const auto &use: argument->getParent()->uses())
+            for (const auto *user: argument->getParent()->users())
             {
-                if (const auto *callBase = SVFUtil::dyn_cast<CallBase>(use.getUser()))
+                if (const auto *callBase = SVFUtil::dyn_cast<CallBase>(user))
                 {
                     // skip function as parameter
                     // e.g., call void @foo(%struct.ssl_ctx_st* %9, i32 (i8*, i32, i32, i8*)* @passwd_callback)
@@ -778,7 +783,7 @@ Set<const Value *> &ObjTypeInference::bwFindAllocOrClsNameSources(const Value *s
         else if (const auto *callBase = SVFUtil::dyn_cast<CallBase>(curValue))
         {
             ABORT_IFNOT(!callBase->doesNotReturn(), "callbase does not return:" + dumpValueAndDbgInfo(callBase));
-            if (Function *callee = callBase->getCalledFunction())
+            if (const auto *callee = callBase->getCalledFunction())
             {
                 if (!callee->isDeclaration())
                 {
@@ -790,47 +795,56 @@ Set<const Value *> &ObjTypeInference::bwFindAllocOrClsNameSources(const Value *s
                 }
             }
         }
+
+        // If updating is allowed; store the gathered sources as sources for the current value in the cache
         if (canUpdate)
         {
             _valueToAllocOrClsNameSources[curValue] = sources;
         }
     }
+
     return _valueToAllocOrClsNameSources[startValue];
 }
 
-Set<const Function *> &ObjTypeInference::fwFindClsNameSources(const CallBase *alloc)
+Set<const Value *> &ObjTypeInference::fwFindClsNameSources(const Value *startValue)
 {
+    assert(startValue && "startValue was null?");
+
     // consult cache
-    auto tIt = _allocToClsNameSources.find(alloc);
-    if (tIt != _allocToClsNameSources.end())
+    auto tIt = _objToClsNameSources.find(startValue);
+    if (tIt != _objToClsNameSources.end())
     {
         return tIt->second;
     }
 
-    Set<const Function *> clsSources;
-    // for heap allocation, we forward find class name sources
-    auto inferViaCppCall = [&clsSources](const CallBase *callBase)
+    Set<const Value *> sources;
+
+    // Lambda for adding a callee to the sources iff it is a constructor/destructor/template/dyncast
+    auto inferViaCppCall = [&sources](const CallBase *caller)
     {
-        if (!callBase->getCalledFunction()) return;
-        const Function *constructFoo = callBase->getCalledFunction();
-        clsSources.insert(constructFoo);
+        if (!caller) return;
+        if (isClsNameSource(caller)) sources.insert(caller);
     };
-    for (const auto &use: alloc->uses())
+    
+    // Find all calls of starting val (or through cast); add as potential source iff applicable
+    for (const auto *user : startValue->users())
     {
-        if (const auto *cppCall = SVFUtil::dyn_cast<CallBase>(use.getUser()))
+        if (const auto *caller = SVFUtil::dyn_cast<CallBase>(user))
         {
-            inferViaCppCall(cppCall);
+            inferViaCppCall(caller);
         }
-        else if (const auto *bitCastInst = SVFUtil::dyn_cast<BitCastInst>(use.getUser()))
+        else if (const auto *bitcast = SVFUtil::dyn_cast<BitCastInst>(user))
         {
-            for (const auto &use2: bitCastInst->uses())
+            for (const auto *cast_user : bitcast->users())
             {
-                if (const auto *cppCall2 = SVFUtil::dyn_cast<CallBase>(use2.getUser()))
+                if (const auto *caller = SVFUtil::dyn_cast<CallBase>(cast_user))
                 {
-                    inferViaCppCall(cppCall2);
+                    inferViaCppCall(caller);
                 }
             }
         }
     }
-    return _allocToClsNameSources[alloc] = SVFUtil::move(clsSources);
+
+    // Store sources in cache for starting value & return the found sources
+    return _objToClsNameSources[startValue] = SVFUtil::move(sources);
 }


### PR DESCRIPTION
After the pull request I submitted yesterday (#1369) was merged I noticed another issue with C++ virtual functions and the way SVF retrieves the class name (used to determine which function is called for overloaded/virtual functions in derived classes) leading to an incomplete/incorrect call graph being generated.

This fix possibly also addresses issues #1314 and #1301.

This issue is caused by an incorrect way of retrieving the class name when the Class Hierarchy Graph is being built, which relies on the LLVM type and the assumption that an LLVM type can be relied upon for retrieving a class' name. However, if two classes have identical types (but can still have e.g. different overloaded function definitions) LLVM can choose to merge those types. Depending on the order of definition, LLVM can merge into either class' name. When SVF then extracts the class' name from the merged type to determine which function is being called in the VTables, the wrong type can be chosen and thus the call graph finds no/the incorrect callee.

For example, take the following snippet:
```
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <wchar.h>

using namespace std;

class Base
{
    public:
        virtual ~Base( )                      = default;
        virtual void action(void *data) const = 0;
};

class Child1 : public Base
{
    public:
        // int  x = 5;
        ~Child1( ) = default;

        void action(void *data) const;
};

class Child2 : public Base
{
    public:
        ~Child2( ) = default;

        void action(void *data) const;
};

void Child2::action(void *data) const { wprintf((wchar_t *) data); }

void Child1::action(void *data) const { printf("%s\n", (char *) data); }

int main(int argc, char *argv[])
{
    char        data[]     = "AAAAAAAAAAAAAAAAAAAAAAAAA";
    const Base &baseObject = Child1( );
    baseObject.action(data);
    return 0;
}
```

When looking at the LLVM IR for this example, only two types are visible because both `Child1` and `Child2` are identical w.r.t. their type definitions:
```
%class.Child2 = type { %class.Base }
%class.Base = type { i32 (...)** }
```

Because the function definition of `Child2::action` precedes `Child1::action` the classes `Child1` and `Child2` get merged into a single `Child2` type instance. If the definition order of these functions are swapped, the types get merged like this:
```
%class.Child1 = type { %class.Base }
%class.Base = type { i32 (...)** }
```

If the derived classes contain differences in their types (e.g. because `Child1` contains a new private field `int x` or similar) the types cannot be merged, and this issue doesn't occur. Note that this issue also does not occur when the objects are heap-allocated objects, as the current class-name-finding-function finds the class' constructor function and correctly extracts the class name from the mangled constructor name.

However, when types are merged like this, SVF's way of finding the underlying class name while constructing the Call Hierarchy Graph (specifically for virtual functions) fails because it assumes types cannot be merged like this.

More specifically, the `CHGBuilder::buildCHG()` function calls `CHGBuilder::buildInternalMaps()`, which calls `CHGBuilder::buildCSToCHAVtblsAndVfnsMap()`. This function searches for virtual calls, and for each callsite to a virtual function it finds it will try to get the classes that that callsite could resolve to with `CHGBuilder::getCSClasses()`. This last function calls `cppUtil::getClassNameOfThisPtr()` with a pointer to the underlying object to try and get the name of the class that that pointer could point to.

Without any metadata specifying the correct class name however, this function internally calls `ObjTypeInference::inferThisPtrClsName()` to infer the name of the underlying class. This function contains the following snippet:
```
const Type *type = infersiteToType(val);
const std::string &className = typeToClsName(type);
if (!className.empty())
{
    Set<std::string> tgt{className};
    insertClassNames(tgt);
}
```

When the underlying types get merged however, this snippet (as in the above example) incorrectly returns the class as `Child2`, rather than the correct `Child1`. Because (as far as I could find) disabling this merging behaviour in LLVM isn't easily done (and it might be done for good reason), I modified the way the name of the underlying class is found to no longer use the LLVM type.

Instead, rather than only preforming the forward walk for heap allocated objects (note the small fix there because previously the check for `isNewAlloc()` only checked if the function name exactly equalled "_Znwm", but I think it should check for any heap allocator (which, for class objects is necessarily a `new` operator)), the forward walk is also done for stack and global variables. This ensures the constructor function is also found for stack objects or global variables, from which the correct class name can be extracted.

Moreover, because class names can only be extracted from C++ `dynamic_cast` *call sites* (and not the `dynamic_cast` function itself), I also ensured these are handled correctly (previously the `dynamic_cast` function object was added as a source instead of the call site).

Note that I also removed the early-exit (i.e. continue) whenever a source site is found during the backwards walk. In my tests I did not see any issues with this. I removed this early-exit because the rest of the infrastructure parses the returned values as a set with potentially more class names, and I wanted to ensure an early-exit wouldn't cause incomplete results again. If this is entirely useless, feel free to put the early-exit back in!

Also note that while I ran a bunch of my own tests, these were all based on the [2.9 release](https://github.com/SVF-tools/SVF/releases/tag/SVF-2.9) since I currently don't have LLVM 16 on my system. I tried testing against these changes applied to the `master` branch, but ran into unrelated assertion failures in the `CHGBuilder::analyzeVTables()` function. More specifically, recent pushes seem to have removed checks for `BitCast` *OR* `IntToPtr` cast instructions, and now simply assume any cast in the vtable must be a `IntToPtr` cast. But, since I'm running without opaque pointers, the bitcasts in the vtable entries causes these assertions to fail.