### PR TITLE
fix LD_LIBRARY_PATH error in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -67,7 +67,7 @@ Build="${PTAOBJTY}-build"
 
 # Add LLVM & Z3 to $PATH and $LD_LIBRARY_PATH (prepend so that selected instances will be used first)
 export PATH=$LLVM_DIR/bin:$Z3_DIR/bin:$PATH
-export LD_LIBRARY_PATH=$LLVM_DIR/lib:$Z3_BIN/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LLVM_DIR/lib:$Z3_DIR/bin:$LD_LIBRARY_PATH
 
 # Add compiled SVF binaries dir to $PATH
 export PATH=$SVF_DIR/$Build/bin:$PATH


### PR DESCRIPTION
$Z3_BIN is not defined in the setup.sh script, and libz3.so is located in the $Z3_DIR/bin directory. 
![image](https://github.com/SVF-tools/SVF/assets/44187795/e145ab64-9d42-467b-9fbe-6ea983eeeb4b)
