### PR TITLE
Add llvm-17.0.6 support

### DIFF
--- a/svf-llvm/include/SVF-LLVM/BasicTypes.h
+++ b/svf-llvm/include/SVF-LLVM/BasicTypes.h
@@ -191,7 +191,7 @@ typedef llvm::IntrinsicInst IntrinsicInst;
 typedef llvm::DbgInfoIntrinsic DbgInfoIntrinsic;
 typedef llvm::DbgVariableIntrinsic DbgVariableIntrinsic;
 typedef llvm::DbgDeclareInst DbgDeclareInst;
-typedef llvm::DbgAddrIntrinsic DbgAddrIntrinsic;
+typedef llvm::DbgInfoIntrinsic DbgInfoIntrinsic;
 typedef llvm::DbgValueInst DbgValueInst;
 typedef llvm::DbgLabelInst DbgLabelInst;
 typedef llvm::VPIntrinsic VPIntrinsic;

--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -510,7 +510,14 @@ void LLVMUtil::removeFunAnnotations(Set<Function*>& removedFuncList)
     glob->setName("llvm.global.annotations.old");
     GlobalVariable *GV = new GlobalVariable(newCA->getType(), glob->isConstant(), glob->getLinkage(), newCA, "llvm.global.annotations");
     GV->setSection(glob->getSection());
+
+#if (LLVM_VERSION_MAJOR < 17)
+    module->getGlobalList().push_back(GV);
+#elif (LLVM_VERSION_MAJOR >= 17)
     module->insertGlobalVariable(GV);
+#else
+    assert(false && "llvm version not supported!");
+#endif
 
     glob->replaceAllUsesWith(GV);
     glob->eraseFromParent();

--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -217,7 +217,6 @@ bool LLVMUtil::isPtrInUncalledFunction (const Value*  value)
 bool LLVMUtil::isIntrinsicFun(const Function* func)
 {
     if (func && (func->getIntrinsicID() == llvm::Intrinsic::donothing ||
-                 func->getIntrinsicID() == llvm::Intrinsic::dbg_addr ||
                  func->getIntrinsicID() == llvm::Intrinsic::dbg_declare ||
                  func->getIntrinsicID() == llvm::Intrinsic::dbg_label ||
                  func->getIntrinsicID() == llvm::Intrinsic::dbg_value))
@@ -511,7 +510,7 @@ void LLVMUtil::removeFunAnnotations(Set<Function*>& removedFuncList)
     glob->setName("llvm.global.annotations.old");
     GlobalVariable *GV = new GlobalVariable(newCA->getType(), glob->isConstant(), glob->getLinkage(), newCA, "llvm.global.annotations");
     GV->setSection(glob->getSection());
-    module->getGlobalList().push_back(GV);
+    module->insertGlobalVariable(GV);
 
     glob->replaceAllUsesWith(GV);
     glob->eraseFromParent();
@@ -693,7 +692,7 @@ const std::string LLVMUtil::getSourceLoc(const Value* val )
     {
         if (SVFUtil::isa<AllocaInst>(inst))
         {
-            for (llvm::DbgInfoIntrinsic *DII : FindDbgAddrUses(const_cast<Instruction*>(inst)))
+            for (llvm::DbgInfoIntrinsic *DII : FindDbgDeclareUses(const_cast<Instruction*>(inst)))
             {
                 if (llvm::DbgDeclareInst *DDI = SVFUtil::dyn_cast<llvm::DbgDeclareInst>(DII))
                 {


### PR DESCRIPTION
There were only very few changes from llvm 16 to llvm 17
-  Module::getGlobalList() was made private since insertGlobalVariable() was added 
- DbgInfoIntrinsic was used instead of DbgAddrIntrinsic, as debug.addr was removed from the IR

fixing these issues lets SVF build with llvm 17 and passes all the tests in the test suite. 