### PR TITLE
add LF check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
By setting this, we ensure that all text files checked out will have LF line endings on every system, and when committed, regardless of the local development environment's line ending configurations.