### PR TITLE
remove a redundant statement in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,6 @@ function set_llvm {
 
 if set_llvm; then
     export LLVM_DIR
-    export PATH="$LLVM_DIR/bin:$PATH"
     echo "LLVM_DIR=$LLVM_DIR"
 else
     echo "- LLVM_DIR not set, probably system-wide installation"


### PR DESCRIPTION
```bash
if set_llvm; then
    export LLVM_DIR
    export PATH="$LLVM_DIR/bin:$PATH" # redundant
    echo "LLVM_DIR=$LLVM_DIR"
else
    echo "- LLVM_DIR not set, probably system-wide installation"
fi

...

if set_z3; then
    export Z3_DIR
    echo "Z3_DIR=$Z3_DIR"
else
    echo "- Z3_DIR not set, probably system-wide installation"
fi

...

export PATH=$LLVM_DIR/bin:$Z3_DIR/bin:$PATH
```

The annotated statement (`export PATH="$LLVM_DIR/bin:$PATH"`) is redundant, because there exists another statement (`export PATH=$LLVM_DIR/bin:$Z3_DIR/bin:$PATH`) below.