### PR TITLE
remove casting to intraicfgnode when allocating branch condition

### DIFF
--- a/svf/lib/SABER/SaberCondAllocator.cpp
+++ b/svf/lib/SABER/SaberCondAllocator.cpp
@@ -102,8 +102,7 @@ void SaberCondAllocator::allocateForBB(const SVFBasicBlock &bb)
         std::vector<Condition> condVec;
         for (u32_t i = 0; i < bit_num; i++)
         {
-            const IntraICFGNode* svfInst = cast<IntraICFGNode>(bb.back());
-            condVec.push_back(newCond(svfInst));
+            condVec.push_back(newCond(bb.back()));
         }
 
         // iterate each successor


### PR DESCRIPTION
fix issue #1592 