### PR TITLE
fix incorrect implementation of getting CallGraphSCCRevTopoOrder

### DIFF
--- a/svf/include/Graphs/SCC.h
+++ b/svf/include/Graphs/SCC.h
@@ -136,7 +136,7 @@ public:
     inline GNodeStack revTopoNodeStack()
     {
         GNodeStack revTopoOrder;
-        GNodeStack &topoOrder = topoNodeStack();
+        GNodeStack topoOrder = topoNodeStack();
         while(!topoOrder.empty())
         {
             NodeID nodeID = topoOrder.top();

--- a/svf/include/Graphs/SCC.h
+++ b/svf/include/Graphs/SCC.h
@@ -139,9 +139,9 @@ public:
         GNodeStack &topoOrder = topoNodeStack();
         while(!topoOrder.empty())
         {
-            NodeID callgraphNodeID = topoOrder.top();
+            NodeID nodeID = topoOrder.top();
             topoOrder.pop();
-            revTopoOrder.push(callgraphNodeID);
+            revTopoOrder.push(nodeID);
         }
         return revTopoOrder;
     }

--- a/svf/include/Graphs/SCC.h
+++ b/svf/include/Graphs/SCC.h
@@ -123,14 +123,30 @@ public:
 
 
     // Return a handle to the stack of nodes in topological
-    // order.  This will be used to seed the initial solution
+    // order. This will be used to seed the initial solution
     // and improve efficiency.
     inline GNodeStack &topoNodeStack()
     {
         return _T;
     }
 
-    const inline  GNODESCCInfoMap &GNodeSCCInfo() const
+    /// Return a handle to the stack of nodes in reverse topological
+    /// order. This will be used to seed the initial solution
+    /// and improve efficiency.
+    inline GNodeStack revTopoNodeStack()
+    {
+        GNodeStack revTopoOrder;
+        GNodeStack &topoOrder = topoNodeStack();
+        while(!topoOrder.empty())
+        {
+            NodeID callgraphNodeID = topoOrder.top();
+            topoOrder.pop();
+            revTopoOrder.push(callgraphNodeID);
+        }
+        return revTopoOrder;
+    }
+
+    const inline GNODESCCInfoMap &GNodeSCCInfo() const
     {
         return _NodeSCCAuxInfo;
     }

--- a/svf/include/WPA/WPAFSSolver.h
+++ b/svf/include/WPA/WPAFSSolver.h
@@ -69,29 +69,21 @@ protected:
         /// SCC detection
         this->getSCCDetector()->find();
 
-        /// Both rep and sub nodes need to be processed later.
-        /// Collect sub nodes from SCCDetector.
-        NodeStack revTopoStack;
-        NodeStack& topoStack = this->getSCCDetector()->topoNodeStack();
-        while (!topoStack.empty())
-        {
-            NodeID nodeId = topoStack.top();
-            topoStack.pop();
-            const NodeBS& subNodes = this->getSCCDetector()->subNodes(nodeId);
-            for (NodeBS::iterator it = subNodes.begin(), eit = subNodes.end(); it != eit; ++it)
-            {
-                revTopoStack.push(*it);
-            }
-        }
-
         assert(nodeStack.empty() && "node stack is not empty, some nodes are not popped properly.");
 
-        /// restore the topological order.
+        /// Both rep and sub nodes need to be processed later.
+        /// Collect sub nodes from SCCDetector.
+        NodeStack revTopoStack = this->getSCCDetector()->revTopoNodeStack();
         while (!revTopoStack.empty())
         {
             NodeID nodeId = revTopoStack.top();
             revTopoStack.pop();
-            nodeStack.push(nodeId);
+            const NodeBS& subNodes = this->getSCCDetector()->subNodes(nodeId);
+            for (NodeBS::iterator it = subNodes.begin(), eit = subNodes.end(); it != eit; ++it)
+            {
+                /// restore the topological order.
+                nodeStack.push(*it);
+            }
         }
 
         return nodeStack;

--- a/svf/lib/MSSA/MemRegion.cpp
+++ b/svf/lib/MSSA/MemRegion.cpp
@@ -250,6 +250,7 @@ void MRGenerator::collectModRefForCall()
         {
             PTACallGraphNode* subCallGraphNode = callGraph->getCallGraphNode(*it);
             /// Get mod-ref of all callsites calling callGraphNode
+            std::cout << subCallGraphNode->getFunction()->getName() << std::endl;
             modRefAnalysis(subCallGraphNode,worklist);
         }
     }
@@ -461,20 +462,11 @@ bool MRGenerator::addModSideEffectOfCallSite(const CallICFGNode* cs, const NodeB
  */
 void MRGenerator::getCallGraphSCCRevTopoOrder(WorkList& worklist)
 {
-    /// get topological order
-    NodeStack& topoOrder = callGraphSCC->topoNodeStack();
-    std::vector<NodeID> topoOrderVec(topoOrder.size());
-    while(!topoOrder.empty())
+    NodeStack revTopoNodeStack = callGraphSCC->revTopoNodeStack();
+    while(!revTopoNodeStack.empty())
     {
-        NodeID callgraphNodeID = topoOrder.top();
-        topoOrder.pop();
-        topoOrderVec.push_back(callgraphNodeID);
-    }
-
-    /// reverse topological order
-    for (auto it = topoOrderVec.rbegin(); it!= topoOrderVec.rend(); ++it)
-    {
-        NodeID callgraphNodeID = *it;
+        NodeID callgraphNodeID = revTopoNodeStack.top();
+        revTopoNodeStack.pop();
         worklist.push(callgraphNodeID);
     }
 }

--- a/svf/lib/MSSA/MemRegion.cpp
+++ b/svf/lib/MSSA/MemRegion.cpp
@@ -461,12 +461,20 @@ bool MRGenerator::addModSideEffectOfCallSite(const CallICFGNode* cs, const NodeB
  */
 void MRGenerator::getCallGraphSCCRevTopoOrder(WorkList& worklist)
 {
-
+    /// get topological order
     NodeStack& topoOrder = callGraphSCC->topoNodeStack();
+    std::vector<NodeID> topoOrderVec(topoOrder.size());
     while(!topoOrder.empty())
     {
         NodeID callgraphNodeID = topoOrder.top();
         topoOrder.pop();
+        topoOrderVec.push_back(callgraphNodeID);
+    }
+
+    /// reverse topological order
+    for (auto it = topoOrderVec.rbegin(); it!= topoOrderVec.rend(); ++it)
+    {
+        NodeID callgraphNodeID = *it;
         worklist.push(callgraphNodeID);
     }
 }

--- a/svf/lib/MSSA/MemRegion.cpp
+++ b/svf/lib/MSSA/MemRegion.cpp
@@ -250,7 +250,6 @@ void MRGenerator::collectModRefForCall()
         {
             PTACallGraphNode* subCallGraphNode = callGraph->getCallGraphNode(*it);
             /// Get mod-ref of all callsites calling callGraphNode
-            std::cout << subCallGraphNode->getFunction()->getName() << std::endl;
             modRefAnalysis(subCallGraphNode,worklist);
         }
     }

--- a/svf/lib/WPA/Andersen.cpp
+++ b/svf/lib/WPA/Andersen.cpp
@@ -710,8 +710,6 @@ inline void Andersen::collapseFields()
 void Andersen::mergeSccCycle()
 {
     NodeStack revTopoOrder = getSCCDetector()->revTopoNodeStack();
-    /// referenced topoOrder is used for restoring the topological order for later solving.
-    NodeStack &topoOrder = getSCCDetector()->topoNodeStack();
     while (!revTopoOrder.empty())
     {
         NodeID repNodeId = revTopoOrder.top();
@@ -720,9 +718,6 @@ void Andersen::mergeSccCycle()
         const NodeBS& subNodes = getSCCDetector()->subNodes(repNodeId);
         // merge sub nodes to rep node
         mergeSccNodes(repNodeId, subNodes);
-
-        /// restore the topological order for later solving.
-        topoOrder.push(repNodeId);
     }
 }
 

--- a/svf/lib/WPA/Andersen.cpp
+++ b/svf/lib/WPA/Andersen.cpp
@@ -709,24 +709,20 @@ inline void Andersen::collapseFields()
  */
 void Andersen::mergeSccCycle()
 {
-    NodeStack revTopoOrder;
-    NodeStack & topoOrder = getSCCDetector()->topoNodeStack();
-    while (!topoOrder.empty())
+    NodeStack revTopoOrder = getSCCDetector()->revTopoNodeStack();
+    /// referenced topoOrder is used for restoring the topological order for later solving.
+    NodeStack &topoOrder = getSCCDetector()->topoNodeStack();
+    while (!revTopoOrder.empty())
     {
-        NodeID repNodeId = topoOrder.top();
-        topoOrder.pop();
-        revTopoOrder.push(repNodeId);
+        NodeID repNodeId = revTopoOrder.top();
+        revTopoOrder.pop();
+
         const NodeBS& subNodes = getSCCDetector()->subNodes(repNodeId);
         // merge sub nodes to rep node
         mergeSccNodes(repNodeId, subNodes);
-    }
 
-    // restore the topological order for later solving.
-    while (!revTopoOrder.empty())
-    {
-        NodeID nodeId = revTopoOrder.top();
-        revTopoOrder.pop();
-        topoOrder.push(nodeId);
+        /// restore the topological order for later solving.
+        topoOrder.push(repNodeId);
     }
 }
 


### PR DESCRIPTION
an example of test.c:
```c
#include <stdlib.h>

#define SZ 100

int* mem_alloc(unsigned sz)
{
    int *buf = (int *)malloc(sizeof(int) * sz);
    return buf;
}

void set_mem(int *ar, int x)
{
    ar[0] = x;
    ar[x] = 0;
}

void baz(int arg)
{
    int *buf = mem_alloc(SZ);
    set_mem(buf, 1);
    int t1 = buf[0];
    int t2 = buf[1];
    buf[t1-1] = 0;
    buf[t2-1] = 0;
}
```
before fix, `MRGenerator::getCallGraphSCCRevTopoOrder` will get:
```
baz
set_mem
mem_alloc
malloc
```
after fix, it will get:
```
malloc
mem_alloc
set_mem
baz
```