### PR TITLE
fix getbasevalueforextarg

### DIFF
--- a/svf-llvm/include/SVF-LLVM/ObjTypeInference.h
+++ b/svf-llvm/include/SVF-LLVM/ObjTypeInference.h
@@ -70,7 +70,7 @@ public:
     /// get or infer the type of the object pointed by the value
     const Type *inferObjType(const Value *var);
 
-    const Type *inferSingleObjType(const Value *var);
+    const Type *inferPointsToType(const Value *var);
 
     /// validate type inference
     void validateTypeCheck(const CallBase *cs);

--- a/svf-llvm/include/SVF-LLVM/ObjTypeInference.h
+++ b/svf-llvm/include/SVF-LLVM/ObjTypeInference.h
@@ -70,6 +70,8 @@ public:
     /// get or infer the type of the object pointed by the value
     const Type *inferObjType(const Value *var);
 
+    const Type *inferSingleObjType(const Value *var);
+
     /// validate type inference
     void validateTypeCheck(const CallBase *cs);
 

--- a/svf-llvm/lib/ObjTypeInference.cpp
+++ b/svf-llvm/lib/ObjTypeInference.cpp
@@ -135,22 +135,25 @@ LLVMContext &ObjTypeInference::getLLVMCtx()
  */
 const Type *ObjTypeInference::inferObjType(const Value *var)
 {
-    const Type* res = inferSingleObjType(var);
+    const Type* res = inferPointsToType(var);
     // infer type by leveraging the type alignment of src and dst in memcpy
+    // for example, we can infer the obj type of %0 based on that of %inner_v:
+    //
+    // %inner_v = alloca %struct.inner, align 8
+    // call void @llvm.memcpy.p0.p0.i64(ptr align 8 %inner_v, ptr align 8 %0, i64 24, i1 false), !dbg !39
     if (res == defaultType(var)) {
         for (const auto& use: var->users()) {
             if (const CallBase* cs = SVFUtil::dyn_cast<CallBase>(use)) {
                 if (const Function* calledFun = cs->getCalledFunction())
                 if (LLVMUtil::isMemcpyExtFun(LLVMModuleSet::getLLVMModuleSet()->getSVFFunction(calledFun))) {
+                    assert(cs->getNumOperands() > 1 && "arguments should be greater than 1");
                     const Value* dst = cs->getArgOperand(0);
                     const Value* src = cs->getArgOperand(1);
-                    const auto name = cs->getName();
-                    assert(name == name);
                     if(calledFun->getName().find("iconv") != std::string::npos)
                         dst = cs->getArgOperand(3), src = cs->getArgOperand(1);
 
-                    if (var == dst) return inferSingleObjType(src);
-                    else if (var == src) return inferSingleObjType(dst);
+                    if (var == dst) return inferPointsToType(src);
+                    else if (var == src) return inferPointsToType(dst);
                     else ABORT_MSG("invalid memcpy call");
                 }
             }
@@ -159,7 +162,7 @@ const Type *ObjTypeInference::inferObjType(const Value *var)
     return res;
 }
 
-const Type *ObjTypeInference::inferSingleObjType(const Value *var) {
+const Type *ObjTypeInference::inferPointsToType(const Value *var) {
     if (isAlloc(var)) return fwInferObjType(var);
     Set<const Value *> &sources = bwfindAllocOfVar(var);
     Set<const Type *> types;

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1386,20 +1386,23 @@ void SVFIRBuilder::handleDirectCall(CallBase* cs, const Function *F)
 
 /*!
  * Example 1:
- *     p = q->f_0 (f_0 is the 0-th field)
- *     extapi(p)
- *     The base value for the external argument p is q.
- *     Note: We only handle the field index 0 for now.
- *
+
+    %0 = getelementptr inbounds %struct.outer, %struct.inner %base, i32 0, i32 0
+    call void @llvm.memcpy(ptr %inner, ptr %0, i64 24, i1 false)
+    The base value for the external argument inner is %base.
+    Note: We only handle the field index 0 for now.
+
  * Example 2:
  *     https://github.com/SVF-tools/SVF/issues/1650
  *
- *     g_n =  { } (some struct)
- *     g = { g_0, ..., g_n }
- *     q = g->g_n (g is a global struct, g_n is the n-th field)
- *     p = *q
- *     extapi(p)
- *     The base value for p is g_n. Load -> GEP (collect the GEP index) based on g (a global struct) -> g_n.
+    @i1 = dso_local global %struct.inner { i32 0, ptr @f1, ptr @f2 }
+    @n1 = dso_local global %struct.outer { i32 0, ptr @i1 }
+
+    %inner = alloca %struct.inner
+    %0 = load ptr, ptr getelementptr inbounds (%struct.outer, ptr @n1, i32 0, i32 1)
+    call void @llvm.memcpy(ptr %inner, ptr %0, i64 24, i1 false)
+
+    The base value for %0 is @i1
  */
 const Value* SVFIRBuilder::getBaseValueForExtArg(const Value* V)
 {

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1400,6 +1400,14 @@ const Value* SVFIRBuilder::getBaseValueForExtArg(const Value* V)
             value = gep->getPointerOperand();
     } else if (const LoadInst* load = SVFUtil::dyn_cast<LoadInst>(value)) {
         // https://github.com/SVF-tools/SVF/issues/1650
+        /*!
+            @i1 = dso_local global %struct.interesting { i32 0, ptr @f1, ptr @f2 }
+            @n1 = dso_local global %struct.nested_ptr { i32 0, ptr @i1 }
+
+            %0 = load ptr, ptr getelementptr inbounds (%struct.nested_ptr, ptr @n1, i32 0, i32 1)
+            call void @llvm.memcpy.p0.p0.i64(ptr align 8 %interesting_stub, ptr align 8 %0, i64 24, i1 false)
+            the base value for %0 is @i1. load -> gep -> global
+        */
         const Value* loadP = load->getPointerOperand();
         if (const GetElementPtrInst* gep = SVFUtil::dyn_cast<GetElementPtrInst>(loadP)) {
             APOffset totalidx = 0;

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1390,11 +1390,12 @@ void SVFIRBuilder::handleDirectCall(CallBase* cs, const Function *F)
     %0 = getelementptr inbounds %struct.outer, %struct.inner %base, i32 0, i32 0
     call void @llvm.memcpy(ptr %inner, ptr %0, i64 24, i1 false)
     The base value for %0 is %base.
-    Note: We only handle the field index 0 for now.
+    Note: the %base is recognized as the base value if the offset (field index) is 0
 
  * Example 2:
  *     https://github.com/SVF-tools/SVF/issues/1650
- *
+       https://github.com/SVF-tools/SVF/pull/1652
+
     @i1 = dso_local global %struct.inner { i32 0, ptr @f1, ptr @f2 }
     @n1 = dso_local global %struct.outer { i32 0, ptr @i1 }
 

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1385,7 +1385,6 @@ void SVFIRBuilder::handleDirectCall(CallBase* cs, const Function *F)
 }
 
 /*!
-/*!
  * Example 1:
  *     p = q->f_0 (f_0 is the 0-th field)
  *     extapi(p)

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1389,7 +1389,7 @@ void SVFIRBuilder::handleDirectCall(CallBase* cs, const Function *F)
 
     %0 = getelementptr inbounds %struct.outer, %struct.inner %base, i32 0, i32 0
     call void @llvm.memcpy(ptr %inner, ptr %0, i64 24, i1 false)
-    The base value for the external argument inner is %base.
+    The base value for %0 is %base.
     Note: We only handle the field index 0 for now.
 
  * Example 2:

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1385,20 +1385,23 @@ void SVFIRBuilder::handleDirectCall(CallBase* cs, const Function *F)
 }
 
 /*!
-    Example 1:
-        p = q->f_1 (f_1 is the first field)
-        extapi(p)
-        the base value for ext arg p is q
-    Example 2:
-        https://github.com/SVF-tools/SVF/issues/1650
-
-        g_n =  { } (some struct)
-        g_0 = { g_1, ..., g_n }
-        q = g_0->f_n (g_0 is a global struct, f_n is the n-th field)
-        p = *q
-        extapi(p)
-        the base value for p is g_n. load -> gep (collect the gep index) based on g_0 (a global struct) -> g_n
-*/
+/*!
+ * Example 1:
+ *     p = q->f_0 (f_0 is the 0-th field)
+ *     extapi(p)
+ *     The base value for the external argument p is q.
+ *     Note: We only handle the field index 0 for now.
+ *
+ * Example 2:
+ *     https://github.com/SVF-tools/SVF/issues/1650
+ *
+ *     g_n =  { } (some struct)
+ *     g = { g_0, ..., g_n }
+ *     q = g->g_n (g is a global struct, g_n is the n-th field)
+ *     p = *q
+ *     extapi(p)
+ *     The base value for p is g_n. Load -> GEP (collect the GEP index) based on g (a global struct) -> g_n.
+ */
 const Value* SVFIRBuilder::getBaseValueForExtArg(const Value* V)
 {
     const Value*  value = stripAllCasts(V);


### PR DESCRIPTION
fix issue #1650 
--- log/nginx.log	2025-02-11 10:27:54.119860076 +1100
+++ log/nginx-xiao.log	2025-02-11 10:28:55.531230995 +1100
@@ -39,9 +39,9 @@
 VarArrayObj         153
 VarStructObj        630
 ----------------Time and memory stats--------------------
-LLVMIRTime          1.236
-SVFIRTime           1.473
-SymbolTableTime     0.17
+LLVMIRTime          1.208
+SVFIRTime           1.429
+SymbolTableTime     0.169
 #######################################################
 
 *********PTACallGraph Stats (Andersen analysis)***************
@@ -68,11 +68,11 @@
 CollapseTime        0
 CopyGepTime         0
 LoadStoreTime       0
-MemoryUsageVmrss    2.3221e+06
+MemoryUsageVmrss    2.32208e+06
 MemoryUsageVmsize   2.3222e+06
 SCCDetectTime       0
 SCCMergeTime        0
-TotalTime           126.089
+TotalTime           127.024
 UpdateCGTime        0
 ----------------Numbers stats----------------------------
 AddrProcessed       5909
@@ -144,11 +144,11 @@
 CollapseTime        0
 CopyGepTime         0
 LoadStoreTime       0
-MemoryUsageVmrss    2.32711e+06
-MemoryUsageVmsize   2.32703e+06
+MemoryUsageVmrss    2.32708e+06
+MemoryUsageVmsize   2.32704e+06
 SCCDetectTime       0
 SCCMergeTime        0
-TotalTime           140.533
+TotalTime           141.498
 UpdateCGTime        0
 ----------------Numbers stats----------------------------
 AddrProcessed       5909
@@ -220,11 +220,11 @@
 ################ (program : nginx.bc)###############
 ----------------Time and memory stats--------------------
 AverageRegSize      39.1348
-GenMUCHITime        1.135
-GenRegionTime       86.259
-InsertPHITime       0.388
-SSARenameTime       0.035
-TotalMSSATime       87.818
+GenMUCHITime        1.255
+GenRegionTime       86.796
+InsertPHITime       0.423
+SSARenameTime       0.033
+TotalMSSATime       88.509
 ----------------Numbers stats----------------------------
 BBHasMSSAPhi        4056
 CSChiNode           22213
@@ -247,13 +247,13 @@
 *********SVFG Statistics***************
 ################ (program : nginx.bc)###############
 ----------------Time and memory stats--------------------
-ATNodeTime          0.208
+ATNodeTime          0.202
 AvgWeight           198.378
 ConnDirEdgeTime     0
-ConnIndEdgeTime     1.323
+ConnIndEdgeTime     1.307
 OptTime             0
 TLNodeTime          0
-TotalTime           1.531
+TotalTime           1.509
 ----------------Numbers stats----------------------------
 ActualIn            30142
 ActualOut           22213
@@ -315,20 +315,20 @@
 GepTime             0
 IndirectPropaTime   0
 LoadTime            0
-MemoryUsageVmrss    4.79128e+06
-MemoryUsageVmsize   4.84208e+06
+MemoryUsageVmrss    4.79166e+06
+MemoryUsageVmsize   4.84191e+06
 PhiTime             0
-PrelabelingTime     0.156
+PrelabelingTime     0.167
 ProcessTime         0
 PropagationTime     0
 SCCTime             0
-SolveTime           825.305
+SolveTime           846.687
 StoreTime           0
 Strong/WeakUpdTime  0
-TotalTime           895.608
+TotalTime           915.415
 UpdateCGTime        0
 VersionPropTime     0
-meldLabelingTime    67.586
+meldLabelingTime    65.894
 ----------------Numbers stats----------------------------
 CopysNum            80
 DummyFieldPtrs      1510
@@ -348,11 +348,11 @@
 ProcessedAddr       23636
 ProcessedCopy       324
 ProcessedFRet       0
-ProcessedGep        1031986
-ProcessedLoad       1293940
+ProcessedGep        1031985
+ProcessedLoad       1294061
 ProcessedMSSANode   344692
-ProcessedPhi        86796
-ProcessedStore      687765
+ProcessedPhi        86794
+ProcessedStore      687872
 SolveIterations     4
 StoresNum           14929
 StrongUpdates       282
@@ -368,11 +368,11 @@
 ****Persistent Points-To Cache Statistics: flow-sensitive analysis bitvector****
 ################ (program : nginx.bc)###############
 UniquePointsToSets       30238
-TotalUnions              1937098543
-PropertyUnions           1237912403
-UniqueUnions             108827
-LookupUnions             698939016
-PreemptiveUnions         138297
+TotalUnions              1937482060
+PropertyUnions           1238078939
+UniqueUnions             108830
+LookupUnions             699155991
+PreemptiveUnions         138300
 TotalComplements         0
 PropertyComplements      0
 UniqueComplements        0
