### PR TITLE
Fix Arm64 toolkit

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -5,9 +5,19 @@ on:
     branches: [ master ]
 
 jobs:
-  docker-x86-image:
+  docker-build:
     if: github.repository == 'SVF-tools/SVF'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            tag: latest
+          - arch: arm64
+            platform: linux/arm64
+            tag: latest-arm64
 
     steps:
       - name: Checkout
@@ -20,24 +30,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Build and push x86 image
+      - name: Build and push Docker image for ${{ matrix.arch }}
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{secrets.DOCKER_USER}}/svf:latest
-          platforms: linux/amd64
-          
+          tags: ${{secrets.DOCKER_USER}}/svf:${{ matrix.tag }}
+          platforms: ${{ matrix.platform }}
+
   dispatch:
-      needs: docker-x86-image
-      runs-on: ubuntu-latest
-      strategy: 
-        matrix:
-          repo: ['SVF-tools/Software-Security-Analysis', 'SVF-tools/Teaching-Software-Analysis', 'SVF-tools/Teaching-Software-Verification', 'SVF-tools/SVF-example']
-      steps:
-      -
-        name: dispatch
+    needs: docker-build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['SVF-tools/Software-Security-Analysis', 'SVF-tools/Teaching-Software-Analysis', 'SVF-tools/Teaching-Software-Verification', 'SVF-tools/SVF-example']
+    steps:
+      - name: dispatch
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.yulei_git_key }}

--- a/.github/workflows/svf-lib_publish.yml
+++ b/.github/workflows/svf-lib_publish.yml
@@ -13,13 +13,14 @@ env:
 
 jobs:
   publish:
-    if: github.repository == 'SVF-tools/SVF'
+    if: github.repository == 'bjjwwang/SVF'
     runs-on: ${{ matrix.os }}
     env:
       XCODE_VERSION: '15.3.0'  # Define Xcode version here to reuse it
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+
     steps:
       # checkout the repo
       - uses: actions/checkout@v2
@@ -34,15 +35,16 @@ jobs:
         run: |
           ln -sfn /Applications/Xcode_${{ env.XCODE_VERSION }}.app /Applications/Xcode.app
           brew install astyle
+
+      # Ubuntu settings
       - name: ubuntu-setup
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install cmake gcc g++ nodejs doxygen graphviz libncurses5-dev libtinfo6 libzstd-dev
-          sudo apt-get update
-          sudo apt-get install -y astyle
+          sudo apt-get install -y cmake gcc g++ nodejs doxygen graphviz libncurses5-dev libtinfo6 libzstd-dev astyle
+
       - name: env-setup
         if: github.event_name == 'push' && github.repository == 'SVF-tools/SVF'
         run: |

--- a/.github/workflows/svf-lib_publish.yml
+++ b/.github/workflows/svf-lib_publish.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   publish:
-    if: github.repository == 'bjjwwang/SVF'
+    if: github.repository == 'SVF-tools/SVF'
     runs-on: ${{ matrix.os }}
     env:
       XCODE_VERSION: '15.3.0'  # Define Xcode version here to reuse it
@@ -112,8 +112,8 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE/..
             git clone https://github.com/SVF-tools/SVF-npm.git
-            if [ "$RUNNER_OS" == "Linux" ]; then export osVersion="linux"; fi
-            if [ "$RUNNER_OS" == "macOS" ]; then export osVersion="osx"; fi
+          if [ "$RUNNER_OS" == "Linux" ]; then export osVersion="linux-$(uname -m | sed 's/x86_64/x86/;s/aarch64/arm/')"; fi          
+          if [ "$RUNNER_OS" == "macOS" ]; then export osVersion="osx"; fi
             echo $osVersion
             cd ./SVF-npm
             git fetch origin

--- a/.github/workflows/svf-lib_publish.yml
+++ b/.github/workflows/svf-lib_publish.yml
@@ -19,7 +19,7 @@ jobs:
       XCODE_VERSION: '15.3.0'  # Define Xcode version here to reuse it
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+        os: [ubuntu-24.04, macos-14, ubuntu-24.04-arm]
 
     steps:
       # checkout the repo
@@ -112,7 +112,7 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE/..
             git clone https://github.com/SVF-tools/SVF-npm.git
-          if [ "$RUNNER_OS" == "Linux" ]; then export osVersion="linux-$(uname -m | sed 's/x86_64/x86/;s/aarch64/arm/')"; fi          
+          if [ "$RUNNER_OS" == "Linux" ]; then export osVersion="linux-$(uname -m)"; fi          
           if [ "$RUNNER_OS" == "macOS" ]; then export osVersion="osx"; fi
             echo $osVersion
             cd ./SVF-npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,8 @@ RUN apt-get install -y $build_deps $lib_deps
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update
 RUN set -ex; \
-    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-        apt-get update && apt-get install -y python3.10-dev \
-        && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        apt-get update && apt-get install -y python3.8-dev \
-        && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1; \
-    else \
-        echo "Unsupported platform: $TARGETPLATFORM" && exit 1; \
-    fi
+    apt-get update && apt-get install -y python3.10-dev \
+            && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1;
 
 # Fetch and build SVF source.
 RUN echo "Downloading LLVM and building SVF to " ${HOME}

--- a/build.sh
+++ b/build.sh
@@ -180,7 +180,6 @@ function check_and_install_brew {
 # OS-specific values.
 urlLLVM=""
 urlZ3=""
-OSDisplayName=""
 
 ########
 # Set OS-specific values, mainly URLs to download binaries from.
@@ -188,11 +187,6 @@ OSDisplayName=""
 #######
 if [[ $sysOS == "Darwin" ]]; then
     check_and_install_brew
-    if [[ "$arch" == "arm64" ]]; then
-        OSDisplayName="macOS arm64"
-    else
-        OSDisplayName="macOS x86"
-    fi
 elif [[ $sysOS == "Linux" ]]; then
     if [[ "$arch" == "aarch64" ]]; then
       if [[ "$BUILD_DYN_LIB" == "ON" ]]; then
@@ -201,7 +195,6 @@ elif [[ $sysOS == "Linux" ]]; then
         urlLLVM="$UbuntuArmLLVM"
       fi
       urlZ3="$UbuntuZ3Arm"
-      OSDisplayName="Ubuntu arm64"
     else
       if [[ "$BUILD_DYN_LIB" == "ON" ]]; then
         urlLLVM="$UbuntuLLVM_RTTI"
@@ -214,7 +207,6 @@ elif [[ $sysOS == "Linux" ]]; then
         fi
       fi
       urlZ3="$UbuntuZ3"
-      OSDisplayName="Ubuntu x86"
     fi
 else
     echo "Builds outside Ubuntu and macOS are not supported."

--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,9 @@ sysOS=$(uname -s)
 arch=$(uname -m)
 MajorLLVMVer=16
 LLVMVer=${MajorLLVMVer}.0.4
+UbuntuArmLLVM_RTTI="https://github.com/SVF-tools/SVF/releases/download/SVF-3.0/llvm-${MajorLLVMVer}.0.0-ubuntu24-rtti-aarch64.tar.gz"
 UbuntuArmLLVM="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVMVer}/clang+llvm-${LLVMVer}-aarch64-linux-gnu.tar.xz"
-UbuntuLLVM_RTTI="https://github.com/SVF-tools/SVF/releases/download/SVF-3.0/llvm-${MajorLLVMVer}.0.0-ubuntu24-rtti-amd64.tar.gz"
+UbuntuLLVM_RTTI="https://github.com/SVF-tools/SVF/releases/download/SVF-3.0/llvm-${MajorLLVMVer}.0.0-ubuntu24-rtti-x86-64.tar.gz"
 UbuntuLLVM="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVMVer}/clang+llvm-${LLVMVer}-x86_64-linux-gnu-ubuntu-22.04.tar.xz"
 SourceLLVM="https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-${LLVMVer}.zip"
 UbuntuZ3="https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-ubuntu-16.04.zip"
@@ -58,7 +59,7 @@ for arg in "$@"; do
     fi
 done
 # if static is off (shared lib), rtti is always on, but print a warning if rtti is off
-if [[ "$BUILD_SHARED" == "ON" && "$RTTI" == "OFF" ]]; then
+if [[ "$BUILD_DYN_LIB" == "ON" && "$RTTI" == "OFF" ]]; then
     echo "Warning: LLVM RTTI is always on when building shared libraries."
     RTTI='ON'
 fi
@@ -194,11 +195,15 @@ if [[ $sysOS == "Darwin" ]]; then
     fi
 elif [[ $sysOS == "Linux" ]]; then
     if [[ "$arch" == "aarch64" ]]; then
+      if [[ "$BUILD_DYN_LIB" == "ON" ]]; then
+        urlLLVM="$UbuntuArmLLVM_RTTI"
+      else
         urlLLVM="$UbuntuArmLLVM"
-        urlZ3="$UbuntuZ3Arm"
-        OSDisplayName="Ubuntu arm64"
+      fi
+      urlZ3="$UbuntuZ3Arm"
+      OSDisplayName="Ubuntu arm64"
     else
-      if [[ "$BUILD_SHARED" == "ON" ]]; then
+      if [[ "$BUILD_DYN_LIB" == "ON" ]]; then
         urlLLVM="$UbuntuLLVM_RTTI"
       else
         # if RTTI is on
@@ -208,8 +213,8 @@ elif [[ $sysOS == "Linux" ]]; then
           urlLLVM="$UbuntuLLVM"
         fi
       fi
-        urlZ3="$UbuntuZ3"
-        OSDisplayName="Ubuntu x86"
+      urlZ3="$UbuntuZ3"
+      OSDisplayName="Ubuntu x86"
     fi
 else
     echo "Builds outside Ubuntu and macOS are not supported."


### PR DESCRIPTION
1. Make Arm docker and X86 Docker use same Python 3.10
2. Github CI docker publish Arm docker
3. Fix build.sh to support LLVM ARM RTTI
4. Fix SVF Lib Publish, to support SVF-linux-x86 and SVF-linux-arm. (Should also change the Repo SVF-npm)