### PR TITLE
Speedup verifier

### DIFF
--- a/svf/include/Graphs/CallGraph.h
+++ b/svf/include/Graphs/CallGraph.h
@@ -195,7 +195,7 @@ public:
     }
 
     /// Return TRUE if this function can be reached from main.
-    bool isReachableFromProgEntry() const;
+    bool isReachableFromProgEntry(Map<NodeID, bool> &reachableFromEntry, NodeBS &visitedNodes) const;
 
 
     /// Overloading operator << for dumping ICFG node ID

--- a/svf/lib/Graphs/CallGraph.cpp
+++ b/svf/lib/Graphs/CallGraph.cpp
@@ -90,30 +90,29 @@ const FunObjVar *CallGraph::getCallerOfCallSite(CallSiteID id) const
     return getCallSite(id)->getCaller();
 }
 
-bool CallGraphNode::isReachableFromProgEntry() const
+bool CallGraphNode::isReachableFromProgEntry(Map<NodeID, bool> &reachableFromEntry, NodeBS &visitedNodes) const
 {
-    std::stack<const CallGraphNode*> nodeStack;
-    NodeBS visitedNodes;
-    nodeStack.push(this);
-    visitedNodes.set(getId());
+    std::function<bool(const CallGraphNode*)> dfs =
+            [&reachableFromEntry, &visitedNodes, &dfs](const CallGraphNode *v) {
+        NodeID id = v->getId();
+        if (!visitedNodes.test_and_set(id))
+            return reachableFromEntry[id];
 
-    while (nodeStack.empty() == false)
-    {
-        CallGraphNode* node = const_cast<CallGraphNode*>(nodeStack.top());
-        nodeStack.pop();
+        if (SVFUtil::isProgEntryFunction(v->getFunction()))
+            return reachableFromEntry[id] = true;
 
-        if (SVFUtil::isProgEntryFunction(node->getFunction()))
-            return true;
-
-        for (const_iterator it = node->InEdgeBegin(), eit = node->InEdgeEnd(); it != eit; ++it)
+        bool result = false;
+        for (const_iterator it = v->InEdgeBegin(), eit = v->InEdgeEnd(); it != eit; ++it)
         {
             CallGraphEdge* edge = *it;
-            if (visitedNodes.test_and_set(edge->getSrcID()))
-                nodeStack.push(edge->getSrcNode());
+            result |= dfs(edge->getSrcNode());
+            if (result)
+                break;
         }
-    }
+        return reachableFromEntry[id] = result;
+    };
 
-    return false;
+    return dfs(this);
 }
 
 
@@ -288,6 +287,9 @@ void CallGraph::verifyCallGraph()
 {
     if (Options::DisableWarn())
         return;
+
+    Map<NodeID, bool> reachableFromEntry;
+    NodeBS visitedNodes;
     CallEdgeMap::const_iterator it = indirectCallMap.begin();
     CallEdgeMap::const_iterator eit = indirectCallMap.end();
     for (; it != eit; ++it)
@@ -297,7 +299,8 @@ void CallGraph::verifyCallGraph()
         {
             const CallICFGNode* cs = it->first;
             const FunObjVar* func = cs->getCaller();
-            if (getCallGraphNode(func)->isReachableFromProgEntry() == false)
+            if (getCallGraphNode(func)->
+                isReachableFromProgEntry(reachableFromEntry, visitedNodes) == false)
                 writeWrnMsg(func->getName() + " has indirect call site but not reachable from main");
         }
     }

--- a/svf/lib/Graphs/CallGraph.cpp
+++ b/svf/lib/Graphs/CallGraph.cpp
@@ -30,6 +30,7 @@
 
 #include "Graphs/CallGraph.h"
 #include "SVFIR/SVFIR.h"
+#include "Util/Options.h"
 #include "Util/SVFUtil.h"
 #include <sstream>
 
@@ -285,6 +286,8 @@ void CallGraph::getIndCallSitesInvokingCallee(const FunObjVar* callee, CallGraph
  */
 void CallGraph::verifyCallGraph()
 {
+    if (Options::DisableWarn())
+        return;
     CallEdgeMap::const_iterator it = indirectCallMap.begin();
     CallEdgeMap::const_iterator eit = indirectCallMap.end();
     for (; it != eit; ++it)


### PR DESCRIPTION
I faced an issue when wpa spends most of the time in `verifyCallGraph`, but this function doesn't do anything useful without `-dwarn=false`.

Without patch:
```
  62,56%  wpa      libSvfCore.so         [.] SVF::CallGraphNode::isReachableFromProgEntry() const                                                                                                                                       
  16,23%  wpa      libstdc++.so.6.0.33   [.] std::_Rb_tree_increment(std::_Rb_tree_node_base const*)                                                                                                                                    
   5,79%  wpa      libSvfCore.so         [.] std::_Rb_tree_increment(std::_Rb_tree_node_base const*)@plt                                                                                                                                
   2,59%  wpa      libSvfCore.so         [.] std::_Rb_tree<SVF::ConstraintEdge*, SVF::ConstraintEdge*, std::_Identity<SVF::ConstraintEdge*>, SVF::GenericEdge<SVF::ConstraintNode>::equalGEdge, std::allocator<SVF::ConstraintEdge*> >::
   1,75%  wpa      libSvfCore.so         [.] SVF::PointerAnalysis::resolveIndCalls(SVF::CallICFGNode const*, SVF::PointsTo const&, std::map<SVF::CallICFGNode const*, std::unordered_set<SVF::FunObjVar const*, SVF::Hash<SVF::FunObjVar
   1,03%  wpa      libSvfCore.so         [.] SVF::ConstraintGraph::addCopyCGEdge(unsigned int, unsigned int)                                                                                                                            
   0,96%  wpa      libSvfLLVM.so.16      [.] SVF::GenericGraph<SVF::SVFVar, SVF::SVFStmt>::getGNode(unsigned int) const
```
With patch and without warnings:
```
  15,26%  wpa      libSvfCore.so         [.] std::_Rb_tree<SVF::ConstraintEdge*, SVF::ConstraintEdge*, std::_Identity<SVF::ConstraintEdge*>, SVF::GenericEdge<SVF::ConstraintNode>::equalGEdge, std::allocator<SVF::ConstraintEdge*> >::
  10,03%  wpa      libSvfCore.so         [.] SVF::PointerAnalysis::resolveIndCalls(SVF::CallICFGNode const*, SVF::PointsTo const&, std::map<SVF::CallICFGNode const*, std::unordered_set<SVF::FunObjVar const*, SVF::Hash<SVF::FunObjVar
   6,53%  wpa      libSvfCore.so         [.] SVF::ConstraintGraph::addCopyCGEdge(unsigned int, unsigned int)                                                                                                                            
   6,28%  wpa      libSvfLLVM.so.16      [.] SVF::GenericGraph<SVF::SVFVar, SVF::SVFStmt>::getGNode(unsigned int) const
```
With patch and warnings:
```
  15,83%  wpa      libSvfCore.so         [.] std::_Rb_tree<SVF::ConstraintEdge*, SVF::ConstraintEdge*, std::_Identity<SVF::ConstraintEdge*>, SVF::GenericEdge<SVF::ConstraintNode>::equalGEdge, std::allocator<SVF::ConstraintEdge*> >::
  10,01%  wpa      libSvfCore.so         [.] SVF::PointerAnalysis::resolveIndCalls(SVF::CallICFGNode const*, SVF::PointsTo const&, std::map<SVF::CallICFGNode const*, std::unordered_set<SVF::FunObjVar const*, SVF::Hash<SVF::FunObjVar
   6,44%  wpa      libSvfCore.so         [.] SVF::ConstraintGraph::addCopyCGEdge(unsigned int, unsigned int)                                                                                                                            
   5,96%  wpa      libSvfLLVM.so.16      [.] SVF::GenericGraph<SVF::SVFVar, SVF::SVFStmt>::getGNode(unsigned int) const 
   ...
   0,14%  wpa      libSvfCore.so         [.] std::_Function_handler<bool (SVF::CallGraphNode const*), SVF::CallGraphNode::isReachableFromProgEntry(std::unordered_map<unsigned int, bool, SVF::Hash<unsigned int>, std::equal_to<unsigned int>, std
   0,00%  wpa      libSvfCore.so         [.] SVF::CallGraphNode::isReachableFromProgEntry(std::unordered_map<unsigned int, bool, SVF::Hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, bool> > >&, SVF
```

Let's skip verification when there will be no debug output. Also, memorize graph traversal results to achieve linear time.