### PR TITLE
Expose version info to parent CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(SVF
   HOMEPAGE_URL "https://github.com/SVF-tools/SVF"
   LANGUAGES C CXX
 )
+# Export version info to parent
+set(SVF_VERSION "${PROJECT_VERSION}" PARENT_SCOPE)
 
 # Ensure installation directories like ${CMAKE_INSTALL_LIBDIR} are available
 include(GNUInstallDirs)


### PR DESCRIPTION
Hi

We use SVF in a submodule, and sometimes use different versions for different projects that share some common code (I know). Since SVF's API changes sometimes, we would like to inform the code about which SVF version they are running against at compile time with `#ifdef`s, so they can adjust accordingly. 

I didn't find a standard way to do this using the current CMake setup of SVF, but the following small patch exposes SVF's internal version information to the outside world, so it can make its own decisions accordingly.

Open to any feedback on how to do this differently, but this PR works for us.