### PR TITLE
Fix statically allocated objects

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMModule.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMModule.h
@@ -414,7 +414,7 @@ public:
     bool is_arg_alloc(const Function *F);
 
     // Does (F) allocate a new stack object and return it?
-    bool is_alloc_stack_ret(const Function *F);
+    bool is_static_ret(const Function *F);
 
     // Get the position of argument which holds the new object
     s32_t get_alloc_arg_pos(const Function *F);

--- a/svf-llvm/include/SVF-LLVM/LLVMModule.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMModule.h
@@ -413,7 +413,7 @@ public:
     // Does (F) allocate a new object and assign it to one of its arguments?
     bool is_arg_alloc(const Function *F);
 
-    // Does (F) allocate a new stack object and return it?
+    // Does (F) return a pointer to an unknown object with static lifetime?
     bool is_static_ret(const Function *F);
 
     // Get the position of argument which holds the new object

--- a/svf-llvm/include/SVF-LLVM/LLVMUtil.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMUtil.h
@@ -398,18 +398,8 @@ inline bool isHeapAllocExtCall(const Instruction *inst)
     return isHeapAllocExtCallViaRet(inst) || isHeapAllocExtCallViaArg(inst);
 }
 
-bool isStackAllocExtCallViaRet(const Instruction *inst);
-
-inline bool isStackAllocExtCall(const Instruction *inst)
-{
-    return isStackAllocExtCallViaRet(inst);
-}
-
 // Check if a given value represents a heap object.
 bool isHeapObj(const Value* val);
-
-// Check if a given value represents a stack object.
-bool isStackObj(const Value* val);
 
 /// Whether an instruction is a callsite in the application code, excluding llvm intrinsic calls
 bool isNonInstricCallSite(const Instruction* inst);

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -1466,9 +1466,9 @@ bool LLVMModuleSet::is_arg_alloc(const Function* F)
     return F && hasExtFuncAnnotation(F, "ALLOC_HEAP_ARG");
 }
 
-bool LLVMModuleSet::is_alloc_stack_ret(const Function* F)
+bool LLVMModuleSet::is_static_ret(const Function* F)
 {
-    return F && hasExtFuncAnnotation(F, "ALLOC_STACK_RET");
+    return F && hasExtFuncAnnotation(F, "STATIC_RET");
 }
 
 // Get the position of argument which holds the new object

--- a/svf-llvm/lib/LLVMUtil.cpp
+++ b/svf-llvm/lib/LLVMUtil.cpp
@@ -659,20 +659,6 @@ bool LLVMUtil::isHeapAllocExtCallViaArg(const Instruction* inst)
     }
 }
 
-bool LLVMUtil::isStackAllocExtCallViaRet(const Instruction *inst)
-{
-    LLVMModuleSet* pSet = LLVMModuleSet::getLLVMModuleSet();
-    bool isPtrTy = inst->getType()->isPointerTy();
-    if (const CallBase* call = SVFUtil::dyn_cast<CallBase>(inst))
-    {
-        const Function* fun = call->getCalledFunction();
-        return fun && isPtrTy &&
-               pSet->is_alloc_stack_ret(fun);
-    }
-    else
-        return false;
-}
-
 /**
  * Check if a given value represents a heap object.
  *
@@ -690,26 +676,6 @@ bool LLVMUtil::isHeapObj(const Value* val)
     // Check if the value is an instruction and if it is a heap allocation external call
     else if (SVFUtil::isa<Instruction>(val) &&
              LLVMUtil::isHeapAllocExtCall(SVFUtil::cast<Instruction>(val)))
-    {
-        return true;
-    }
-    // Return false if none of the above conditions are met
-    return false;
-}
-
-/**
- * @param val The value to check.
- * @return True if the value represents a stack object, false otherwise.
- */
-bool LLVMUtil::isStackObj(const Value* val)
-{
-    if (SVFUtil::isa<AllocaInst>(val))
-    {
-        return true;
-    }
-    // Check if the value is an instruction and if it is a stack allocation external call
-    else if (SVFUtil::isa<Instruction>(val) &&
-             LLVMUtil::isStackAllocExtCall(SVFUtil::cast<Instruction>(val)))
     {
         return true;
     }

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -404,7 +404,7 @@ void SVFIRBuilder::initialiseBaseObjVars()
             pag->addHeapObjNode(iter->second, pag->getObjTypeInfo(id), llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
         }
         // Check if the value is an alloca instruction and add a stack object node
-        else if (LLVMUtil::isStackObj(llvmValue))
+        else if (SVFUtil::isa<AllocaInst>(llvmValue))
         {
             NodeID id = llvmModuleSet()->getObjectNode(iter->first);
             pag->addStackObjNode(iter->second, pag->getObjTypeInfo(id), llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);

--- a/svf-llvm/lib/extapi.c
+++ b/svf-llvm/lib/extapi.c
@@ -9,7 +9,7 @@
 
         ALLOC_HEAP_RET,    // returns a pointer to a newly allocated heap object
         ALLOC_HEAP_ARGi    // stores a pointer to an allocated object in *argi
-        ALLOC_STACK_RET,   // returns a pointer to a newly allocated stack object
+        STATIC_RET,        // returns a pointer to an external object with static lifetime
         REALLOC_HEAP_RET,  
         MEMSET,            // memcpy() operations
         MEMCPY,            // memset() operations
@@ -1045,241 +1045,241 @@ void _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEC1EPKcRKS3_(void **arg
     *arg0 = arg1;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 const unsigned short **__ctype_b_loc(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 int **__ctype_tolower_loc(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 int **__ctype_toupper_loc(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 int *__errno_location(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 int * __h_errno_location(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 void* __res_state(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char *asctime(const void *timeptr)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char * bindtextdomain(const char * domainname, const char * dirname)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char * bind_textdomain_codeset(const char * domainname, const char * codeset)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char *ctermid(char *s)
 {
     return s;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char * dcgettext(const char * domainname, const char * msgid, int category)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char * dgettext(const char * domainname, const char * msgid)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char * dngettext(const char * domainname, const char * msgid, const char * msgid_plural, unsigned long int n)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct group *getgrgid(unsigned int gid)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct group *getgrnam(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct hostent *gethostbyaddr(const void *addr, unsigned int len, int type)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct hostent *gethostbyname(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct hostent *gethostbyname2(const char *name, int af)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct mntent *getmntent(void *stream)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct protoent *getprotobyname(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct protoent *getprotobynumber(int proto)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct passwd *getpwent(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct passwd *getpwnam(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct passwd *getpwuid(unsigned int uid)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct servent *getservbyname(const char *name, const char *proto)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct servent *getservbyport(int port, const char *proto)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct spwd *getspnam(const char *name)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char * gettext(const char * msgid)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct tm *gmtime(const void *timer)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 const char *gnu_get_libc_version(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 const char * gnutls_check_version(const char * req_version)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct lconv *localeconv(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 struct tm *localtime(const void *timer)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char * ngettext(const char * msgid, const char * msgid_plural, unsigned long int n)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 void *pango_cairo_font_map_get_default(void)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char *re_comp(const char *regex)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char *setlocale(int category, const char *locale)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char *tgoto(const char *cap, int col, int row)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 char *tparm(char *str, ...)
 {
     return NULL;
 }
 
-__attribute__((annotate("ALLOC_STACK_RET")))
+__attribute__((annotate("STATIC_RET")))
 const char *zError(int a)
 {
     return NULL;

--- a/svf/include/Util/ExtAPI.h
+++ b/svf/include/Util/ExtAPI.h
@@ -97,8 +97,8 @@ public:
     // Does (F) allocate a new object and assign it to one of its arguments?
     bool is_arg_alloc(const FunObjVar *F);
 
-    // Does (F) allocate a new stack object and return it?
-    bool is_alloc_stack_ret(const FunObjVar *F);
+    // Does (F) return a pointer to an external object with static lifetime?
+    bool is_static_ret(const FunObjVar *F);
 
     // Get the position of argument which holds the new object
     s32_t get_alloc_arg_pos(const FunObjVar *F);

--- a/svf/lib/Util/ExtAPI.cpp
+++ b/svf/lib/Util/ExtAPI.cpp
@@ -228,9 +228,9 @@ bool ExtAPI::is_arg_alloc(const FunObjVar* F)
     return F && hasExtFuncAnnotation(F, "ALLOC_HEAP_ARG");
 }
 
-bool ExtAPI::is_alloc_stack_ret(const FunObjVar* F)
+bool ExtAPI::is_static_ret(const FunObjVar* F)
 {
-    return F && hasExtFuncAnnotation(F, "ALLOC_STACK_RET");
+    return F && hasExtFuncAnnotation(F, "STATIC_RET");
 }
 
 // Get the position of argument which holds the new object


### PR DESCRIPTION
Hi

As discussed in #1680, this patch largely reverts #1616, which mistakenly seems to refer to statically-allocated objects as "stack-allocated objects". As far as we can tell, this lead to only 1 bug in SVF, in the SVFIRBuilder, where a regular `isa<Alloca>` was replaced with a function to check for a call to an extapi func returning "stack-allocated storage" (which actually returned an unknown static object). That's obviously wrong. Fixed in [4d7ece4e5b4](https://github.com/SVF-tools/SVF/commit/4d7ece4e5b4b1d8049601fefa6aba2e858e292d9).

However, we (surprisingly!) did not notice any build failures after updating this naming convention and deleting some utility functions. Does that mean that SVF does not check for statically-allocated objects in its handling of external calls? I'm confused here: where should we find & update the code that treats all calls to such functions as aliasing?

I believe there's more work to be done to properly handle these STATIC_RET functions. @mortkever/@shuangxiangkan  any ideas?
