### PR TITLE
CI, Formatting, API & SVFG Builder Improvements

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,354 @@
+# ----------------------------------
+# Options affecting listfile parsing
+# ----------------------------------
+with section("parse"):  # type: ignore
+
+    # Specify structure for custom cmake functions
+    additional_commands = {
+        "target_link_options": {
+            "pargs": 1,
+            "flags": [
+                "BEFORE",
+            ],
+            "kwargs": {
+                "PUBLIC": "+",
+                "PRIVATE": "+",
+                "INTERFACE": "+",
+            },
+        },
+        "target_sources": {
+            "pargs": 1,
+            "flags": [],
+            "kwargs": {
+                "PUBLIC": {
+                    "flags": [],
+                    "pargs": "*",
+                    "kwargs": {
+                        "FILE_SET": {
+                            "pargs": 1,
+                            "kwargs": {
+                                "TYPE": 1,
+                                "FILES": "+",
+                                "BASE_DIRS": "+",
+                            },
+                        },
+                    },
+                },
+                "PRIVATE": {
+                    "flags": [],
+                    "pargs": "*",
+                    "kwargs": {
+                        "FILE_SET": {
+                            "pargs": 1,
+                            "kwargs": {
+                                "TYPE": 1,
+                                "FILES": "+",
+                                "BASE_DIRS": "+",
+                            },
+                        },
+                    },
+                },
+                "INTERFACE": {
+                    "flags": [],
+                    "pargs": "*",
+                    "kwargs": {
+                        "FILE_SET": {
+                            "pargs": 1,
+                            "kwargs": {
+                                "TYPE": 1,
+                                "FILES": "+",
+                                "BASE_DIRS": "+",
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        "find_package": {
+            "pargs": "+",
+            "flags": [
+                "EXACT",
+                "QUIET",
+                "CONFIG",
+                "GLOBAL",
+                "REQUIRED",
+                "NO_MODULE",
+                "NO_CMAKE_PATH",
+                "BYPASS_PROVIDER",
+                "NO_POLICY_SCOPE",
+                "NO_DEFAULT_PATH",
+                "NO_CMAKE_BUILDS_PATH",
+                "NO_CMAKE_SYSTEM_PATH",
+                "NO_PACKAGE_ROOT_PATH",
+                "NO_CMAKE_FIND_ROOT_PATH",
+                "NO_CMAKE_INSTALL_PREFIX",
+                "NO_CMAKE_ENVIRONMENT_PATH",
+                "CMAKE_FIND_ROOT_PATH_BOTH",
+                "NO_CMAKE_PACKAGE_REGISTRY",
+                "ONLY_CMAKE_FIND_ROOT_PATH",
+                "NO_SYSTEM_ENVIRONMENT_PATH",
+                "NO_CMAKE_SYSTEM_PACKAGE_REGISTRY",
+            ],
+            "kwargs": {
+                "HINTS": "+",
+                "NAMES": "+",
+                "PATHS": "+",
+                "CONFIGS": "+",
+                "COMPONENTS": "*",
+                "PATH_SUFFIXES": "+",
+                "REGISTRY_VIEW": "1",
+                "OPTIONAL_COMPONENTS": "*",
+            },
+        },
+        "write_basic_package_version_file": {
+            "pargs": 1,
+            "flags": [
+                "ARCH_INDEPENDENT",
+            ],
+            "kwargs": {
+                "COMPATIBILITY": 1,
+                "VERSION": 1,
+            },
+        },
+        "configure_package_config_file": {
+            "pargs": "2",
+            "kwargs": {
+                "PATH_VARS": "*",
+                "INSTALL_PREFIX": "1",
+                "INSTALL_DESTINATION": "1",
+            },
+            "flags": ["NO_SET_AND_CHECK_MACRO", "NO_CHECK_REQUIRED_COMPONENTS_MACRO"],
+        },
+    }
+
+    # Override configurations per-command where available
+    override_spec = {}
+
+    # Specify variable tags.
+    vartags = []
+
+    # Specify property tags.
+    proptags = []
+
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section("format"):  # type: ignore
+
+    # Disable formatting entirely, making cmake-format a no-op
+    disable = False
+
+    # How wide to allow formatted cmake files
+    line_width = 120
+
+    # How many spaces to tab for indent
+    tab_size = 4
+
+    # If true, lines are indented using tab characters (utf-8 0x09) instead of
+    # <tab_size> space characters (utf-8 0x20). In cases where the layout would
+    # require a fractional tab character, the behavior of the  fractional
+    # indentation is governed by <fractional_tab_policy>
+    use_tabchars = False
+
+    # If <use_tabchars> is True, then the value of this variable indicates how
+    # fractional indentions are handled during whitespace replacement. If set to
+    # 'use-space', fractional indentation is left as spaces (utf-8 0x20). If set
+    # to `round-up` fractional indentation is replaced with a single tab character
+    # (utf-8 0x09) effectively shifting the column to the next tabstop
+    fractional_tab_policy = "use-space"
+
+    # If an argument group contains more than this many sub-groups (parg or kwarg
+    # groups) then force it to a vertical layout.
+    max_subgroups_hwrap = 2
+
+    # If a positional argument group contains more than this many arguments, then
+    # force it to a vertical layout.
+    max_pargs_hwrap = 5
+
+    # If a cmdline positional group consumes more than this many lines without
+    # nesting, then invalidate the layout (and nest)
+    max_rows_cmdline = 2
+
+    # If true, separate flow control names from their parentheses with a space
+    separate_ctrl_name_with_space = False
+
+    # If true, separate function names from parentheses with a space
+    separate_fn_name_with_space = False
+
+    # If a statement is wrapped to more than one line, than dangle the closing
+    # parenthesis on its own line.
+    dangle_parens = True  # Default: False
+
+    # If the trailing parenthesis must be 'dangled' on its on line, then align it
+    # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
+    # the start of the statement, plus one indentation  level, `child`: align to
+    # the column of the arguments
+    dangle_align = "prefix-indent"  # Default: prefix
+
+    # If the statement spelling length (including space and parenthesis) is
+    # smaller than this amount, then force reject nested layouts.
+    min_prefix_chars = 4
+
+    # If the statement spelling length (including space and parenthesis) is larger
+    # than the tab width by more than this amount, then force reject un-nested
+    # layouts.
+    max_prefix_chars = 20  # Default: 10
+
+    # If a candidate layout is wrapped horizontally but it exceeds this many
+    # lines, then reject the layout.
+    max_lines_hwrap = 3  # Default: 2
+
+    # What style line endings to use in the output.
+    line_ending = "unix"
+
+    # Format command names consistently as 'lower' or 'upper' case
+    command_case = "lower"  # Default: canonical
+
+    # Format keywords consistently as 'lower' or 'upper' case
+    keyword_case = "upper"  # Default: unchanged
+
+    # A list of command names which should always be wrapped
+    always_wrap = []
+
+    # If true, the argument lists which are known to be sortable will be sorted
+    # lexicographicall
+    enable_sort = True
+
+    # If true, the parsers may infer whether or not an argument list is sortable
+    # (without annotation).
+    autosort = True  # Default: False
+
+    # By default, if cmake-format cannot successfully fit everything into the
+    # desired linewidth it will apply the last, most aggressive attempt that it
+    # made. If this flag is True, however, cmake-format will print error, exit
+    # with non-zero status code, and write-out nothing
+    require_valid_layout = False
+
+    # A dictionary mapping layout nodes to a list of wrap decisions. See the
+    # documentation for more information.
+    layout_passes = {}
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section("markup"):  # type: ignore
+
+    # What character to use for bulleted lists
+    bullet_char = "*"
+
+    # What character to use as punctuation after numerals in an enumerated list
+    enum_char = "."
+
+    # If comment markup is enabled, don't reflow the first comment block in each
+    # listfile. Use this to preserve formatting of your copyright/license
+    # statements.
+    first_comment_is_literal = False
+
+    # If comment markup is enabled, don't reflow any comment block which matches
+    # this (regex) pattern. Default is `None` (disabled).
+    literal_comment_pattern = None
+
+    # Regular expression to match preformat fences in comments default=
+    # ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+    fence_pattern = "^\\s*([`~]{3}[`~]*)(.*)$"
+
+    # Regular expression to match rulers in comments default=
+    # ``r'^\s*[^\w\s]{3}.*[^\w\s]{3}$'``
+    ruler_pattern = "^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$"
+
+    # If a comment line matches starts with this pattern then it is explicitly a
+    # trailing comment for the preceding argument. Default is '#<'
+    explicit_trailing_pattern = "#<"
+
+    # If a comment line starts with at least this many consecutive hash
+    # characters, then don't lstrip() them off. This allows for lazy hash rulers
+    # where the first hash char is not separated by space
+    hashruler_min_length = 10
+
+    # If true, then insert a space between the first hash char and remaining hash
+    # chars in a hash ruler, and normalize its length to fill the column
+    canonicalize_hashrulers = True
+
+    # enable comment markup parsing and reflow
+    enable_markup = False
+
+# ----------------------------
+# Options affecting the linter
+# ----------------------------
+with section("lint"):  # type: ignore
+
+    # a list of lint codes to disable
+    disabled_codes = []
+
+    # regular expression pattern describing valid function names
+    function_pattern = "[0-9a-z_]+"
+
+    # regular expression pattern describing valid macro names
+    macro_pattern = "[0-9A-Z_]+"
+
+    # regular expression pattern describing valid names for variables with global
+    # (cache) scope
+    global_var_pattern = "[A-Z][0-9A-Z_]+"
+
+    # regular expression pattern describing valid names for variables with global
+    # scope (but internal semantic)
+    internal_var_pattern = "_[A-Z][0-9A-Z_]+"
+
+    # regular expression pattern describing valid names for variables with local
+    # scope
+    local_var_pattern = "[a-z][a-z0-9_]+"
+
+    # regular expression pattern describing valid names for privatedirectory
+    # variables
+    private_var_pattern = "_[0-9a-z_]+"
+
+    # regular expression pattern describing valid names for public directory
+    # variables
+    public_var_pattern = "[A-Z][0-9A-Z_]+"
+
+    # regular expression pattern describing valid names for function/macro
+    # arguments and loop variables.
+    argument_var_pattern = "[a-z][a-z0-9_]+"
+
+    # regular expression pattern describing valid names for keywords used in
+    # functions or macros
+    keyword_pattern = "[A-Z][0-9A-Z_]+"
+
+    # In the heuristic for C0201, how many conditionals to match within a loop in
+    # before considering the loop a parser.
+    max_conditionals_custom_parser = 2
+
+    # Require at least this many newlines between statements
+    min_statement_spacing = 1
+
+    # Require no more than this many newlines between statements
+    max_statement_spacing = 2
+    max_returns = 6
+    max_branches = 12
+    max_arguments = 5
+    max_localvars = 15
+    max_statements = 50
+
+# -------------------------------
+# Options affecting file encoding
+# -------------------------------
+with section("encode"):  # type: ignore
+
+    # If true, emit the unicode byte-order mark (BOM) at the start of the file
+    emit_byteorder_mark = False
+
+    # Specify the encoding of the input file. Defaults to utf-8
+    input_encoding = "utf-8"
+
+    # Specify the encoding of the output file. Defaults to utf-8. Note that cmake
+    # only claims to support utf-8 so be careful when using anything else
+    output_encoding = "utf-8"
+
+# -------------------------------------
+# Miscellaneous configurations options.
+# -------------------------------------
+with section("misc"):  # type: ignore
+
+    # A dictionary containing any per-command configuration overrides. Currently
+    # only `command_case` is supported.
+    per_command = {}

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -139,11 +139,11 @@ jobs:
         if: runner.os == 'Linux' && matrix.sanitizer == ''
         run: |
           lcov --capture --directory ./ --output-file coverage.info
-          lcov --remove coverage.info '/usr/*' --output-file coverage.info
-          lcov --remove coverage.info '${{github.workspace}}/z3.obj/*' --output-file coverage.info
-          lcov --remove coverage.info '${{github.workspace}}/llvm-*.obj/*' --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' --output-file coverage.info --ignore-errors unused
+          lcov --remove coverage.info '${{github.workspace}}/z3.obj/*' --output-file coverage.info --ignore-errors unused
+          lcov --remove coverage.info '${{github.workspace}}/llvm-*.obj/*' --output-file coverage.info --ignore-errors unused
           lcov --remove coverage.info '${{github.workspace}}/svf/include/FastCluster/*' --output-file coverage.info --ignore-errors unused
-          lcov --remove coverage.info '${{github.workspace}}/svf/lib/FastCluster/*' --output-file coverage.info
+          lcov --remove coverage.info '${{github.workspace}}/svf/lib/FastCluster/*' --output-file coverage.info --ignore-errors unused
 
       - name: upload-coverage
         if: runner.os == 'Linux'

--- a/svf-llvm/include/SVF-LLVM/LLVMModule.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMModule.h
@@ -250,6 +250,11 @@ public:
         addToSVFVar2LLVMValueMap(inst, svfInst);
     }
 
+    inline bool hasLLVMValue(const SVFValue* value) const
+    {
+        return SVFBaseNode2LLVMValue.find(value) != SVFBaseNode2LLVMValue.end();
+    }
+
     const Value* getLLVMValue(const SVFValue* value) const
     {
         SVFBaseNode2LLVMValueMap ::const_iterator it = SVFBaseNode2LLVMValue.find(value);

--- a/svf-llvm/lib/extapi.c
+++ b/svf-llvm/lib/extapi.c
@@ -1,5 +1,9 @@
 #include <stddef.h>
-#define NULL ((void *)0)
+
+// Ensure NULL is always defined (but don't redefine)
+#ifndef NULL
+#  define NULL ((void *)0)
+#endif
 
 /*
     Functions with __attribute__((annotate("XXX"))) will be handle by SVF specifcially.
@@ -190,24 +194,6 @@ void* xmalloc(unsigned long size)
 }
 
 __attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
-void *_Znam(unsigned long size)
-{
-    return NULL;
-}
-
-__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
-void *_Znaj(unsigned long size)
-{
-    return NULL;
-}
-
-__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
-void *_Znwj(unsigned long size)
-{
-    return NULL;
-}
-
-__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
 void *__cxa_allocate_exception(unsigned long size)
 {
     return NULL;
@@ -227,6 +213,12 @@ void* memalign(unsigned long size1, unsigned long size2)
 
 __attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
 void *valloc(unsigned long size)
+{
+    return NULL;
+}
+
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *pvalloc(unsigned long size)
 {
     return NULL;
 }
@@ -370,6 +362,12 @@ char *strdup(const char *s)
 }
 
 __attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:UNKNOWN")))
+char *strndup(const char *s, unsigned long n)
+{
+    return NULL;
+}
+
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:UNKNOWN")))
 char *strerror(int errnum)
 {
     return NULL;
@@ -429,6 +427,12 @@ char *realloc(void *ptr, unsigned long size)
     return NULL;
 }
 
+__attribute__((annotate("REALLOC_HEAP_RET"), annotate("AllocSize:Arg1*Arg2")))
+char *reallocarray(void *ptr, unsigned long elems, unsigned long size)
+{
+    return NULL;
+}
+
 __attribute__((annotate("REALLOC_HEAP_RET"), annotate("AllocSize:Arg1")))
 void* safe_realloc(void *p, unsigned long n)
 {
@@ -469,26 +473,120 @@ void *xrealloc(void *ptr, unsigned long bytes)
     return NULL;
 }
 
+// ::operator new (size (unsigned int))
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_Znwj(unsigned int size)
+{
+    return NULL;
+}
+
+// ::operator new (size (unsigned int), nothrow)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnwjRKSt9nothrow_t(unsigned int size, void *)
+{
+    return NULL;
+}
+
+// ::operator new (size (unsigned int), aligned)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnwjSt11align_val_t(unsigned int size, unsigned long)
+{
+    return NULL;
+}
+
+// ::operator new (size (unsigned int), aligned, nothrow)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnwjSt11align_val_tRKSt9nothrow_t(unsigned int size, unsigned long, void *)
+{
+    return NULL;
+}
+
+// ::operator new[] (size (unsigned int))
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_Znaj(unsigned int size)
+{
+    return NULL;
+}
+
+// ::operator new[] (size (unsigned int), nothrow)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnajRKSt9nothrow_t(unsigned int size, void *)
+{
+    return NULL;
+}
+
+// ::operator new[] (size (unsigned int), aligned)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnajSt11align_val_t(unsigned int size, unsigned long)
+{
+    return NULL;
+}
+
+// ::operator new[] (size (unsigned int), aligned, nothrow)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnajSt11align_val_tRKSt9nothrow_t(unsigned int size, unsigned long, void *)
+{
+    return NULL;
+}
+
+// ::operator new (size (size_t))
 __attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
 void *_Znwm(unsigned long size)
 {
     return NULL;
 }
 
+// ::operator new (size (size_t), nothrow)
 __attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
 void *_ZnwmRKSt9nothrow_t(unsigned long size, void *)
 {
     return NULL;
 }
 
+// ::operator new (size (size_t), aligned)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnwmSt11align_val_t(unsigned long size, unsigned long)
+{
+    return NULL;
+}
+
+// ::operator new (size (size_t), aligned, nothrow)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnwmSt11align_val_tRKSt9nothrow_t(unsigned long size, unsigned long, void *)
+{
+    return NULL;
+}
+
+// ::operator new[]
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_Znam(unsigned long size)
+{
+    return NULL;
+}
+
+// ::operator new[] (nothrow)
 __attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
 void *_ZnamRKSt9nothrow_t(unsigned long size, void *)
 {
     return NULL;
 }
 
+// ::operator new[] (aligned)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnamSt11align_val_t(unsigned long size, unsigned long)
+{
+    return NULL;
+}
+
+// ::operator new[] (aligned, nothrow)
+__attribute__((annotate("ALLOC_HEAP_RET"), annotate("AllocSize:Arg0")))
+void *_ZnamSt11align_val_tRKSt9nothrow_t(unsigned long size, unsigned long, void *)
+{
+    return NULL;
+}
+
 __attribute__((annotate("ALLOC_HEAP_ARG0"), annotate("AllocSize:UNKNOWN")))
-int asprintf(char **restrict strp, const char *restrict fmt, ...)
+int asprintf(char **__restrict strp, const char *__restrict fmt, ...)
 {
     return 0;
 }
@@ -536,7 +634,7 @@ int posix_memalign(void **a, unsigned long b, unsigned long c)
 }
 
 __attribute__((annotate("ALLOC_HEAP_ARG1"), annotate("AllocSize:UNKNOWN")))
-int scandir(const char *restrict dirp, struct dirent ***restrict namelist, int (*filter)(const struct dirent *), int (*compar)(const struct dirent **, const struct dirent **))
+int scandir(const char *__restrict dirp, struct dirent ***__restrict namelist, int (*filter)(const struct dirent *), int (*compar)(const struct dirent **, const struct dirent **))
 {
     return 0;
 }
@@ -590,7 +688,7 @@ __attribute__((annotate("MEMCPY")))
 void bcopy(const void *s1, void *s2, unsigned long n){}
 
 __attribute__((annotate("MEMCPY")))
-void *memccpy( void * restrict dest, const void * restrict src, int c, unsigned long count)
+void *memccpy( void *__restrict dest, const void *__restrict src, int c, unsigned long count)
 {
     return NULL;
 }
@@ -644,7 +742,7 @@ wchar_t* __wcscat_chk(wchar_t * dest, const wchar_t * src)
 }
 
 __attribute__((annotate("STRCPY")))
-char *stpcpy(char *restrict dst, const char *restrict src)
+char *stpcpy(char *__restrict dst, const char *__restrict src)
 {
     return NULL;
 }
@@ -702,7 +800,7 @@ char *wcscpy(wchar_t* dest, const wchar_t* src) {
 }
 
 __attribute__((annotate("MEMCPY")))
-unsigned long iconv(void* cd, char **restrict inbuf, unsigned long *restrict inbytesleft, char **restrict outbuf, unsigned long *restrict outbytesleft)
+unsigned long iconv(void* cd, char **__restrict inbuf, unsigned long *__restrict inbytesleft, char **__restrict outbuf, unsigned long *__restrict outbytesleft)
 {
     return 0;
 }
@@ -906,7 +1004,7 @@ struct tm *localtime_r(const void *timep, struct tm *result)
     return result;
 }
 
-char *realpath(const char *restrict path, char *restrict resolved_path)
+char *realpath(const char *__restrict path, char *__restrict resolved_path)
 {
     return resolved_path;
 }
@@ -921,7 +1019,7 @@ void* freopen(const char* voidname, const char* mode, void* fp)
     return fp;
 }
 
-const char *inet_ntop(int af, const void *restrict src,  char *restrict dst, unsigned int size)
+const char *inet_ntop(int af, const void *__restrict src,  char *__restrict dst, unsigned int size)
 {
     return dst;
 }
@@ -995,9 +1093,9 @@ char* ctime_r(const char *timer, char *buf)
     return buf;
 }
 
-int readdir_r(void *__restrict__dir, void *__restrict__entry, void **__restrict__result)
+int readdir_r(void *__restrict dir, void *__restrict entry, void **__restrict result)
 {
-    __restrict__entry = *__restrict__result;   
+    entry = *result;
     return 0;
 }
 
@@ -1048,13 +1146,13 @@ const unsigned short **__ctype_b_loc(void)
 int ctype_tolower_loc_global[10];
 int **__ctype_tolower_loc(void)
 {
-    return &ctype_tolower_loc_global;
+    return (int **)&ctype_tolower_loc_global;
 }
 
 int ctype_toupper_loc_global[10];
 int **__ctype_toupper_loc(void)
 {
-    return &ctype_toupper_loc_global;
+    return (int **)&ctype_toupper_loc_global;
 }
 
 int error_global[10];
@@ -1075,7 +1173,7 @@ void* __res_state(void)
     return res_state_global;
 }
 
-void *time_global[10];
+char time_global[10];
 char *asctime(const void *timeptr)
 {
     return time_global;

--- a/svf/include/Graphs/SVFGOPT.h
+++ b/svf/include/Graphs/SVFGOPT.h
@@ -81,8 +81,17 @@ public:
         keepContextSelfCycle = true;
     }
 
+    /// Optimised SVFG's aren't written in their optimised form; read full SVFG and optimise it
+    void readAndOptSVFG(const std::string &filename);
+
+    /// Optimised SVFG's shouldn't be written in their optimised form; writes the full SVFG to file before optimising
+    void buildAndWriteSVFG(const std::string &filename);
+
 protected:
     void buildSVFG() override;
+
+    /// Separate optimisation function to avoid duplicate code
+    void optimiseSVFG();
 
     /// Connect SVFG nodes between caller and callee for indirect call sites
     //@{

--- a/svf/include/Graphs/VFG.h
+++ b/svf/include/Graphs/VFG.h
@@ -191,8 +191,69 @@ public:
         return getVFGNode(getDef(pagNode));
     }
 
+    // Given an VFG node, return true if it has a left hand side top level pointer (PAGnode)
+    inline bool hasLHSTopLevPtr(const VFGNode* node) const {
+        return node && SVFUtil::isa<AddrVFGNode,
+                                    CopyVFGNode,
+                                    GepVFGNode,
+                                    LoadVFGNode,
+                                    PHIVFGNode,
+                                    CmpVFGNode,
+                                    BinaryOPVFGNode,
+                                    UnaryOPVFGNode,
+                                    ActualParmVFGNode,
+                                    FormalParmVFGNode,
+                                    ActualRetVFGNode,
+                                    FormalRetVFGNode,
+                                    NullPtrVFGNode>(node);
+    }
+
     // Given an VFG node, return its left hand side top level pointer (PAGnode)
     const PAGNode* getLHSTopLevPtr(const VFGNode* node) const;
+
+    /// Existence checks for VFGNodes
+    //@{
+    inline bool hasStmtVFGNode(const PAGEdge* pagEdge) const
+    {
+        return PAGEdgeToStmtVFGNodeMap.find(pagEdge) != PAGEdgeToStmtVFGNodeMap.end();
+    }
+    inline bool hasIntraPHIVFGNode(const PAGNode* pagNode) const
+    {
+        return PAGNodeToIntraPHIVFGNodeMap.find(pagNode) != PAGNodeToIntraPHIVFGNodeMap.end();
+    }
+    inline bool hasBinaryOPVFGNode(const PAGNode* pagNode) const
+    {
+        return PAGNodeToBinaryOPVFGNodeMap.find(pagNode) != PAGNodeToBinaryOPVFGNodeMap.end();
+    }
+    inline bool hasUnaryOPVFGNode(const PAGNode* pagNode) const
+    {
+        return PAGNodeToUnaryOPVFGNodeMap.find(pagNode) != PAGNodeToUnaryOPVFGNodeMap.end();
+    }
+    inline bool hasBranchVFGNode(const PAGNode* pagNode) const
+    {
+        return PAGNodeToBranchVFGNodeMap.find(pagNode) != PAGNodeToBranchVFGNodeMap.end();
+    }
+    inline bool hasCmpVFGNode(const PAGNode* pagNode) const
+    {
+        return PAGNodeToCmpVFGNodeMap.find(pagNode) != PAGNodeToCmpVFGNodeMap.end();
+    }
+    inline bool hasActualParmVFGNode(const PAGNode* aparm,const CallICFGNode* cs) const
+    {
+        return PAGNodeToActualParmMap.find(std::make_pair(aparm->getId(),cs)) != PAGNodeToActualParmMap.end();
+    }
+    inline bool hasActualRetVFGNode(const PAGNode* aret) const
+    {
+        return PAGNodeToActualRetMap.find(aret) != PAGNodeToActualRetMap.end();
+    }
+    inline bool hasFormalParmVFGNode(const PAGNode* fparm) const
+    {
+        return PAGNodeToFormalParmMap.find(fparm) != PAGNodeToFormalParmMap.end();
+    }
+    inline bool hasFormalRetVFGNode(const PAGNode* fret) const
+    {
+        return PAGNodeToFormalRetMap.find(fret) != PAGNodeToFormalRetMap.end();
+    }
+    //@}
 
     /// Get an VFGNode
     //@{

--- a/svf/include/MSSA/SVFGBuilder.h
+++ b/svf/include/MSSA/SVFGBuilder.h
@@ -32,6 +32,7 @@
 
 #include "MemoryModel/PointerAnalysis.h"
 #include "Graphs/SVFGOPT.h"
+#include "Util/Options.h"
 
 namespace SVF
 {
@@ -49,8 +50,8 @@ public:
     typedef SVFG::SVFGEdgeSetTy SVFGEdgeSet;
 
     /// Constructor
-    explicit SVFGBuilder(bool _SVFGWithIndCall = false, bool _OptimiseSVFG = false) :
-        svfg(nullptr), SVFGWithIndCall(_SVFGWithIndCall), OptimiseSVFG(_OptimiseSVFG)
+    explicit SVFGBuilder(bool _SVFGWithIndCall = Options::SVFGWithIndirectCall(), bool _SVFGWithPostOpts = Options::OPTSVFG())
+        : svfg(nullptr), SVFGWithIndCall(_SVFGWithIndCall), SVFGWithPostOpts(_SVFGWithPostOpts)
     {
     }
 
@@ -95,7 +96,7 @@ protected:
     /// SVFG with precomputed indirect call edges
     bool SVFGWithIndCall;
     /// Build optimised version of SVFG
-    bool OptimiseSVFG;
+    bool SVFGWithPostOpts;
 };
 
 } // End namespace SVF

--- a/svf/include/MSSA/SVFGBuilder.h
+++ b/svf/include/MSSA/SVFGBuilder.h
@@ -49,7 +49,10 @@ public:
     typedef SVFG::SVFGEdgeSetTy SVFGEdgeSet;
 
     /// Constructor
-    explicit SVFGBuilder(bool _SVFGWithIndCall = false): svfg(nullptr), SVFGWithIndCall(_SVFGWithIndCall) {}
+    explicit SVFGBuilder(bool _SVFGWithIndCall = false, bool _OptimiseSVFG = false) :
+        svfg(nullptr), SVFGWithIndCall(_SVFGWithIndCall), OptimiseSVFG(_OptimiseSVFG)
+    {
+    }
 
     /// Destructor
     virtual ~SVFGBuilder() = default;
@@ -91,6 +94,8 @@ protected:
     std::unique_ptr<SVFG> svfg;
     /// SVFG with precomputed indirect call edges
     bool SVFGWithIndCall;
+    /// Build optimised version of SVFG
+    bool OptimiseSVFG;
 };
 
 } // End namespace SVF

--- a/svf/include/WPA/VersionedFlowSensitive.h
+++ b/svf/include/WPA/VersionedFlowSensitive.h
@@ -110,45 +110,12 @@ protected:
     /// Override since we want to assign different weights based on versioning.
     virtual void cluster(void) override;
 
-private:
-    /// Prelabel the SVFG: set y(o) for stores and c(o) for delta nodes to a new version.
-    void prelabel(void);
-    /// Meld label the prelabeled SVFG.
-    void meldLabel(void);
-    /// Melds v2 into v1 (in place), returns whether a change occurred.
-    static bool meld(MeldVersion &mv1, const MeldVersion &mv2);
-
-    /// Removes all indirect edges in the SVFG.
-    void removeAllIndirectSVFGEdges(void);
-
-    /// Propagates version v of o to any version of o which relies on v when o/v is changed.
-    /// Recursively applies to reliant versions till no new changes are made.
-    /// Adds any statements which rely on any changes made to the worklist.
-    void propagateVersion(NodeID o, Version v);
-
-    /// Propagates version v of o to version vp of o. time indicates whether it should record time
-    /// taken itself.
-    void propagateVersion(const NodeID o, const Version v, const Version vp, bool time=true);
-
-    /// Fills in isStoreMap and isLoadMap.
-    virtual void buildIsStoreLoadMaps(void);
-
+public:
     /// Returns true if l is a store node.
     virtual bool isStore(const NodeID l) const;
 
     /// Returns true if l is a load node.
     virtual bool isLoad(const NodeID l) const;
-
-    /// Fills in deltaMap and deltaSourceMap for the SVFG.
-    virtual void buildDeltaMaps(void);
-
-    /// Returns true if l is a delta node, i.e., may get a new incoming indirect
-    /// edge due to on-the-fly callgraph construction.
-    virtual bool delta(const NodeID l) const;
-
-    /// Returns true if l is a delta-source node, i.e., may get a new outgoing indirect
-    /// edge to a delta node due to on-the-fly callgraph construction.
-    virtual bool deltaSource(const NodeID l) const;
 
     /// Shared code for getConsume and getYield. They wrap this function.
     Version getVersion(const NodeID l, const NodeID o, const LocVersionMap &lvm) const;
@@ -158,15 +125,6 @@ private:
 
     /// Returns the yielded version of o at l. If no such version exists, returns invalidVersion.
     Version getYield(const NodeID l, const NodeID o) const;
-
-    /// Shared code for setConsume and setYield. They wrap this function.
-    void setVersion(const NodeID l, const NodeID o, const Version v, LocVersionMap &lvm);
-
-    /// Sets the consumed version of o at l to v.
-    void setConsume(const NodeID l, const NodeID o, const Version v);
-
-    /// Sets the yielded version of o at l to v.
-    void setYield(const NodeID l, const NodeID o, const Version v);
 
     /// Returns the versions of o which rely on o:v.
     std::vector<Version> &getReliantVersions(const NodeID o, const Version v);
@@ -190,6 +148,49 @@ private:
 
     /// Dumps a MeldVersion to stdout.
     static void dumpMeldVersion(MeldVersion &v);
+
+private:
+    /// Prelabel the SVFG: set y(o) for stores and c(o) for delta nodes to a new version.
+    void prelabel(void);
+    /// Meld label the prelabeled SVFG.
+    void meldLabel(void);
+    /// Melds v2 into v1 (in place), returns whether a change occurred.
+    static bool meld(MeldVersion &mv1, const MeldVersion &mv2);
+
+    /// Removes all indirect edges in the SVFG.
+    void removeAllIndirectSVFGEdges(void);
+
+    /// Propagates version v of o to any version of o which relies on v when o/v is changed.
+    /// Recursively applies to reliant versions till no new changes are made.
+    /// Adds any statements which rely on any changes made to the worklist.
+    void propagateVersion(NodeID o, Version v);
+
+    /// Propagates version v of o to version vp of o. time indicates whether it should record time
+    /// taken itself.
+    void propagateVersion(const NodeID o, const Version v, const Version vp, bool time=true);
+
+    /// Fills in isStoreMap and isLoadMap.
+    virtual void buildIsStoreLoadMaps(void);
+
+    /// Fills in deltaMap and deltaSourceMap for the SVFG.
+    virtual void buildDeltaMaps(void);
+
+    /// Returns true if l is a delta node, i.e., may get a new incoming indirect
+    /// edge due to on-the-fly callgraph construction.
+    virtual bool delta(const NodeID l) const;
+
+    /// Returns true if l is a delta-source node, i.e., may get a new outgoing indirect
+    /// edge to a delta node due to on-the-fly callgraph construction.
+    virtual bool deltaSource(const NodeID l) const;
+
+    /// Shared code for setConsume and setYield. They wrap this function.
+    void setVersion(const NodeID l, const NodeID o, const Version v, LocVersionMap &lvm);
+
+    /// Sets the consumed version of o at l to v.
+    void setConsume(const NodeID l, const NodeID o, const Version v);
+
+    /// Sets the yielded version of o at l to v.
+    void setYield(const NodeID l, const NodeID o, const Version v);
 
     /// Maps locations to objects to a version. The object version is what is
     /// consumed at that location.

--- a/svf/lib/Graphs/SVFGOPT.cpp
+++ b/svf/lib/Graphs/SVFGOPT.cpp
@@ -43,11 +43,29 @@ static std::string KeepAllSelfCycle = "all";
 static std::string KeepContextSelfCycle = "context";
 static std::string KeepNoneSelfCycle = "none";
 
+/// Optimised SVFGs aren't written to file; reads the full SVFG and optimises it
+void SVFGOPT::readAndOptSVFG(const std::string &filename)
+{
+    SVFG::readFile(filename);
+    optimiseSVFG();
+}
+
+/// Shouldn't write optimised SVFG to file; writes the built SVFG to file before optimisation
+void SVFGOPT::buildAndWriteSVFG(const std::string &filename)
+{
+    SVFG::buildSVFG();
+    SVFG::writeToFile(filename);
+    optimiseSVFG();
+}
 
 void SVFGOPT::buildSVFG()
 {
     SVFG::buildSVFG();
+    optimiseSVFG();
+}
 
+/// Separate function to optimise the SVFG to avoid duplicate code
+void SVFGOPT::optimiseSVFG() {
     if(Options::DumpVFG())
         dump("SVFG_before_opt");
 
@@ -62,6 +80,7 @@ void SVFGOPT::buildSVFG()
     stat->sfvgOptEnd();
 
 }
+
 /*!
  *
  */

--- a/svf/lib/MSSA/SVFGBuilder.cpp
+++ b/svf/lib/MSSA/SVFGBuilder.cpp
@@ -41,7 +41,7 @@ using namespace SVFUtil;
 
 SVFG* SVFGBuilder::buildPTROnlySVFG(BVDataPTAImpl* pta)
 {
-    if(Options::OPTSVFG())
+    if(Options::OPTSVFG() || this->OptimiseSVFG)
         return build(pta, VFG::PTRONLYSVFG_OPT);
     else
         return build(pta, VFG::PTRONLYSVFG);
@@ -49,7 +49,10 @@ SVFG* SVFGBuilder::buildPTROnlySVFG(BVDataPTAImpl* pta)
 
 SVFG* SVFGBuilder::buildFullSVFG(BVDataPTAImpl* pta)
 {
-    return build(pta, VFG::FULLSVFG);
+    if(Options::OPTSVFG() || this->OptimiseSVFG)
+        return build(pta, VFG::FULLSVFG_OPT);
+    else
+        return build(pta, VFG::FULLSVFG);
 }
 
 

--- a/svf/lib/MSSA/SVFGBuilder.cpp
+++ b/svf/lib/MSSA/SVFGBuilder.cpp
@@ -26,35 +26,28 @@
  *  Created on: Apr 15, 2014
  *      Author: Yulei Sui
  */
+#include "MSSA/SVFGBuilder.h"
+#include "Graphs/CallGraph.h"
+#include "Graphs/SVFG.h"
+#include "MSSA/MemSSA.h"
 #include "Util/Options.h"
 #include "Util/SVFUtil.h"
-#include "MSSA/MemSSA.h"
-#include "Graphs/SVFG.h"
-#include "MSSA/SVFGBuilder.h"
 #include "WPA/Andersen.h"
-#include "Graphs/CallGraph.h"
-
 
 using namespace SVF;
 using namespace SVFUtil;
 
-
 SVFG* SVFGBuilder::buildPTROnlySVFG(BVDataPTAImpl* pta)
 {
-    if(Options::OPTSVFG() || this->OptimiseSVFG)
-        return build(pta, VFG::PTRONLYSVFG_OPT);
-    else
-        return build(pta, VFG::PTRONLYSVFG);
+    return this->SVFGWithPostOpts ? build(pta, VFG::PTRONLYSVFG_OPT)
+                                  : build(pta, VFG::PTRONLYSVFG);
 }
 
 SVFG* SVFGBuilder::buildFullSVFG(BVDataPTAImpl* pta)
 {
-    if(Options::OPTSVFG() || this->OptimiseSVFG)
-        return build(pta, VFG::FULLSVFG_OPT);
-    else
-        return build(pta, VFG::FULLSVFG);
+    return this->SVFGWithPostOpts ? build(pta, VFG::FULLSVFG_OPT)
+                                  : build(pta, VFG::FULLSVFG);
 }
-
 
 /*!
  * Create SVFG
@@ -68,23 +61,24 @@ void SVFGBuilder::buildSVFG()
 SVFG* SVFGBuilder::build(BVDataPTAImpl* pta, VFG::VFGK kind)
 {
 
-    auto mssa = buildMSSA(pta, (VFG::PTRONLYSVFG==kind || VFG::PTRONLYSVFG_OPT==kind));
+    auto mssa = buildMSSA(
+        pta, (VFG::PTRONLYSVFG == kind || VFG::PTRONLYSVFG_OPT == kind));
 
     DBOUT(DGENERAL, outs() << pasMsg("Build Sparse Value-Flow Graph \n"));
-    if(kind == VFG::FULLSVFG_OPT || kind == VFG::PTRONLYSVFG_OPT)
+    if (kind == VFG::FULLSVFG_OPT || kind == VFG::PTRONLYSVFG_OPT)
         svfg = std::make_unique<SVFGOPT>(std::move(mssa), kind);
     else
-        svfg = std::unique_ptr<SVFG>(new SVFG(std::move(mssa),kind));
+        svfg = std::unique_ptr<SVFG>(new SVFG(std::move(mssa), kind));
     buildSVFG();
 
     /// Update call graph using pre-analysis results
-    if(Options::SVFGWithIndirectCall() || SVFGWithIndCall)
+    if (SVFGWithIndCall)
         svfg->updateCallGraph(pta);
 
-    if(svfg->getMSSA()->getPTA()->printStat())
+    if (svfg->getMSSA()->getPTA()->printStat())
         svfg->performStat();
 
-    if(Options::DumpVFG())
+    if (Options::DumpVFG())
         svfg->dump("svfg_final");
 
     return svfg.get();
@@ -98,7 +92,8 @@ void SVFGBuilder::releaseMemory()
     svfg->clearMSSA();
 }
 
-std::unique_ptr<MemSSA> SVFGBuilder::buildMSSA(BVDataPTAImpl* pta, bool ptrOnlyMSSA)
+std::unique_ptr<MemSSA> SVFGBuilder::buildMSSA(BVDataPTAImpl* pta,
+                                               bool ptrOnlyMSSA)
 {
 
     DBOUT(DGENERAL, outs() << pasMsg("Build Memory SSA \n"));
@@ -106,10 +101,10 @@ std::unique_ptr<MemSSA> SVFGBuilder::buildMSSA(BVDataPTAImpl* pta, bool ptrOnlyM
     auto mssa = std::make_unique<MemSSA>(pta, ptrOnlyMSSA);
 
     CallGraph* svfirCallGraph = PAG::getPAG()->getCallGraph();
-    for (const auto& item: *svfirCallGraph)
+    for (const auto& item : *svfirCallGraph)
     {
 
-        const FunObjVar *fun = item.second->getFunction();
+        const FunObjVar* fun = item.second->getFunction();
         if (isExtCall(fun))
             continue;
 
@@ -124,5 +119,3 @@ std::unique_ptr<MemSSA> SVFGBuilder::buildMSSA(BVDataPTAImpl* pta, bool ptrOnlyM
 
     return mssa;
 }
-
-


### PR DESCRIPTION
As per @yuleisui's request in [this pull request (1697)](https://github.com/SVF-tools/SVF/pull/1697), this pull request contains the various fixes, improvements, and other changes unrelated to the build system. Note that this pull request contains one additional commit [c1306f4] not in the original pull request [1697], which adds some additional allocator definitions to `extapi.c` and ensures existing ones are consistent.

## 📝 Overview
This PR consolidates six orthogonal areas of work into one release:

- **CI/Workflow**: harden coverage removal flags in GitHub Actions  
- **CMake Formatting**: add `cmake-format` config for consistent styling & formatting  
- **API Additions**: add missing `has…()` checks alongside existing getters  
- **WPA Backends**: unify public interface for polymorphic use  
- **SVFG Builder**: fix read/write order for optimised graphs  
- **Allocators**: add & fix some allocator definitions

_For full details on each change, see the linked commits below._

---

## 🚀 Highlights

| Area                  | Summary                                                  | Commit                         |
|-----------------------|----------------------------------------------------------|-------------------------------|
| **CI/Workflow**       | Uniform `--ignore-errors unused` on all `lcov --remove`  | [96c021b](https://github.com/SVF-tools/SVF/commit/96c021bef0dabe09df966039b9eeff4bd7716618) |
| **CMake Formatting**  | Add `cmake-format` spec for automatic styling            | [0bc1472](https://github.com/SVF-tools/SVF/commit/0bc1472586cf31258baf769060b90f924a4e5332) |
| **API Existence**     | New `has…()` functions for previously unchecked getters  | [ce288cf](https://github.com/SVF-tools/SVF/commit/ce288cf013171c4b0eba9b40d0fa8c18cba8ad6e) |
| **WPA Polymorphism**  | Publicise ctor/read/dump APIs in `VersionedFlowSensitive`| [93446f6](https://github.com/SVF-tools/SVF/commit/93446f684ad0600854714359434256aed2c9bbed) |
| **SVFG Builder**      | Write unoptimised graph before optimise; explicit flag  | [def7c04](https://github.com/SVF-tools/SVF/commit/def7c043fe32b6bee0b94c68d2de95b3f0b7d2df) |
| **Allocators**      | Add missing allocators; fix restricted keyword; misc fixes    | [583bff0](https://github.com/SVF-tools/SVF/commit/c1306f4b60e9546f54256f02ca571011f87d938a) |

------

## ⚙️ Detailed Changes

### 1️⃣ CI/Workflow Fix ([96c021b])
- Always pass `--ignore-errors unused` to **all** `lcov --remove …` calls  
- Prevent workflow failures when no coverage data exists under `/usr/*` or other paths  
- Ensured error suppression is applied consistently  

### 2️⃣ Automated CMake Formatting ([0bc1472])
- Add `.cmake-format.py` so `cmake-format` can lint & format all CMake files  
- Ensures consistent styling across `CMakeLists.txt`, `*.cmake`, etc.  

### 3️⃣ Existence-Check APIs ([ce288cf])
- Introduce `hasLLVMValue()`, `hasLHSTopLevelPtr()`, etc., for getters that assert on missing entries  
- Avoids breaking existing API: getters still assert, but you can pre-check  
- Getters that return nullptr on missing entries are unmodified  

### 4️⃣ WPA Backend Polymorphism ([93446f6])
- Mark `VersionedFlowSensitive`’s `printStat()`, `dumpTopLevelPtsTo()`, `solveAndWritePtsToFile()`, `readPtsFromFile()`, etc., as **public**  
- Enables code like:
  ```cpp
  SVF::BVDataPTAImpl *pta = nullptr;
  switch(backend) {
    case Andersen_BASE:   pta = new Andersen(...);            break;
    case VFS_WPA:         pta = new VersionedFlowSensitive(...); break;
    default:              /*…*/;                              break;
  }

### 5️⃣ Optimised SVFG Read/Write Fix ([def7c04])
- Add builder argument to build optimised SVFG without command-line option (to support using SVF as a library)  
- Write unoptimised SVFG before optimisation  
- Read unoptimised SVFG, then apply optimisation  
- Resolves crashes when reading a post-optimised file  

### 6️⃣ Allocators ([c1306f4])
- Add missing allocator definitions for C++ allocators (e.g., `new` with alignment operators; `new` with different internal definitions of `size_t`, etc.)
- Add miscellaneous missing allocators (e.g., `pvalloc()`, `strndup()`, etc.)
- Fix `restrict` keyword usage to suppress compiler/IDE warnings (use `__restrict` instead (supported by C & C++))
- Made re-definition of `NULL` conditional (already defined in included header) to suppress compiler/IDE warnings
