### PR TITLE
Fix potential vulnerable cloned functions

### DIFF
--- a/svf/lib/Util/cJSON.cpp
+++ b/svf/lib/Util/cJSON.cpp
@@ -402,8 +402,12 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
 {
     char *copy = NULL;
     /* if object's type is not cJSON_String or is cJSON_IsReference, it should not set valuestring */
-    if (!(object->type & cJSON_String) || (object->type & cJSON_IsReference))
+    if ((object == NULL) || !(object->type & cJSON_String) || (object->type & cJSON_IsReference))
     {
+        return NULL;
+    }
+    /* return NULL if the object is corrupted */
+    if (object->valuestring == NULL)
         return NULL;
     }
     if (strlen(valuestring) <= strlen(object->valuestring))
@@ -2270,7 +2274,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON 
 {
     cJSON *after_inserted = NULL;
 
-    if (which < 0)
+    if (which < 0 || newitem == NULL)
     {
         return false;
     }
@@ -2279,6 +2283,11 @@ CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON 
     if (after_inserted == NULL)
     {
         return add_item_to_array(array, newitem);
+    }
+
+    if (after_inserted != array->child && newitem->prev == NULL) {
+        /* return false if after_inserted is a corrupted array item */
+        return false;
     }
 
     newitem->next = after_inserted;


### PR DESCRIPTION
Hi Development Team,

I identified a potential null pointer dereference in clone functions cJSON_InsertItemInArray() and cJSON_SetValuestring() in `svf/lib/Util/cJSON.cpp` sourced from [DaveGamble/cJSON](https://github.com/DaveGamble/cJSON). This issue, originally reported in [CVE-2023-50471](https://nvd.nist.gov/vuln/detail/cve-2023-50471) and [CVE-2023-50472](https://nvd.nist.gov/vuln/detail/cve-2023-50472), was resolved in the repository via this commit https://github.com/DaveGamble/cJSON/commit/60ff122ef5862d04b39b150541459e7f5e35add8.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!