### PR TITLE
Changed types of SVF install prefix configuration parameters to STRING to avoid absolute path prefixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,27 +117,27 @@ endif()
 # Configure top-level SVF variables (used by CMake for configuring installed SVF package)
 set(SVF_INSTALL_BINDIR
     ${CMAKE_INSTALL_BINDIR}
-    CACHE PATH "Set binaries install dir"
+    CACHE STRING "Set binaries install dir"
 )
 set(SVF_INSTALL_LIBDIR
     ${CMAKE_INSTALL_LIBDIR}
-    CACHE PATH "Set libraries install dir"
+    CACHE STRING "Set libraries install dir"
 )
 set(SVF_INSTALL_EXTAPIDIR
     ${CMAKE_INSTALL_LIBDIR}
-    CACHE PATH "Set extapi.bc install dir"
+    CACHE STRING "Set extapi.bc install dir"
 )
 set(SVF_INSTALL_INCLUDEDIR
     ${CMAKE_INSTALL_INCLUDEDIR}
-    CACHE PATH "Set public headers install dir"
+    CACHE STRING "Set public headers install dir"
 )
 set(SVF_INSTALL_PKGCONFDIR
     ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-    CACHE PATH "Override pkgconfig install dir"
+    CACHE STRING "Override pkgconfig install dir"
 )
 set(SVF_INSTALL_CMAKECONFIGDIR
     ${CMAKE_INSTALL_LIBDIR}/cmake/SVF
-    CACHE PATH "Set CMake package install dir"
+    CACHE STRING "Set CMake package install dir"
 )
 
 # Set location of extapi.bc (installed)


### PR DESCRIPTION
After my previous pull request #1703 was merged, commit a745cdc changed the default installation prefix for public headers from `include/SVF` to just `include`. As discussed in [my last comment](https://github.com/SVF-tools/SVF/issues/1703#issuecomment-2901506766_) on pull request #1703, installing into a dedicated project prefix can often be desirable for clarity and maintenance. To make this behaviour optional, I included user-configurable build parameters like `SVF_INSTALL_INCLUDEDIR` and `SVF_INSTALL_BINDIR` to override the default installation prefixes.

However, I made a mistake in defining the type of these parameters; they are currently defined as `PATH` types instead of `STRING` types. As these defaulted to their `${CMAKE_INSTALL_<...>}` counterparts (which are always correctly interpreted as **relative to the installation prefix**, this would ensure the final installation destination would be correct (i.e., `<install_prefix>/include/SVF/...`, `<install_prefix>/bin/...`, etc.). However, defining these types as `PATH` types would cause them to be incorrectly resolved into **absolute paths**. Consequently, the current working directory would be internally prepended to these installation prefix parameters, causing the final installation destinations to look like `<pwd>/<user_config_prefix>` (e.g., `$(pwd)/include/SVF`). Consequently, the source/install paths to contain their own prefixes, causing the build configuration to fail.

This small fix simply uses the `STRING` type for these installation prefix parameters (e.g., `SVF_INSTALL_INCLUDEDIR`) instead, ensuring they are always correctly interpreted as **relative paths** (relative to the overall installation prefix).

NB: I would still argue defaulting to the installation prefix for public header files being `include/SVF` instead of the bare `include`, and/or properly describing the possible build parameters in the setup guide. Should I add that to the [Wiki page for that](https://github.com/svf-tools/SVF/wiki/Setup-Guide#getting-started)? If so, is my understanding correct that anyone can modify the wiki without requiring explicit permissions?