### PR TITLE
fix logical error

### DIFF
--- a/svf/include/AE/Core/AddressValue.h
+++ b/svf/include/AE/Core/AddressValue.h
@@ -217,7 +217,7 @@ public:
     /// Check bit value of val start with 0x7F000000, filter by 0xFF000000
     static inline bool isVirtualMemAddress(u32_t val)
     {
-        return (val & 0xff000000) == AddressMask && val != AddressMask + 0;
+        return (val & 0xff000000) == AddressMask;
     }
 
 };


### PR DESCRIPTION
We don't need to detect wthether the addr is null in 'isVirtualMemAddress'. we will detect it later. and we can not detect it here since if we detect it here
inline void store(u32_t addr, const AbstractValue &val)
    {
        assert(isVirtualMemAddress(addr) && "not virtual address?");
        u32_t objId = getIDFromAddr(addr);
        if (isNullMem(addr)) return;
        _addrToAbsVal[objId] = val;
    }
in store function. the isVirtualMemAddress will be false if the addr is null, so the program would abort. That's not what we want, and we detect isNullMem in store function, so the function is safe.
and we will detect null dereference in store statement, so we can detect it .