### PR TITLE
Fix abort in ObjTypeInference::inferObjType

### DIFF
--- a/svf-llvm/lib/ObjTypeInference.cpp
+++ b/svf-llvm/lib/ObjTypeInference.cpp
@@ -160,7 +160,11 @@ const Type *ObjTypeInference::inferObjType(const Value *var)
                         const Value* dst = cs->getArgOperand(0);
                         const Value* src = cs->getArgOperand(1);
                         if(calledFun->getName().find("iconv") != std::string::npos)
+                        {
+                            if(var == cs->getArgOperand(0))
+                                return res;
                             dst = cs->getArgOperand(3), src = cs->getArgOperand(1);
+                        }
 
                         if (var == dst) return inferPointsToType(src);
                         else if (var == src) return inferPointsToType(dst);


### PR DESCRIPTION
# Problem
I encountered the abort message in this [line](https://github.com/SVF-tools/SVF/blob/12a270f04a1890d337f418a58b208f2a965a4cae/svf-llvm/lib/ObjTypeInference.cpp#L167) when using a valid IR.

In my case, the source of the problem was that `var` was the first argument of an `iconv` call.

# Fix
Return `res` if `var` is the first argument of an `iconv`call.