### PR TITLE
Fix(#1765): Use thunk function as placeholder when it can't be resolved

### DIFF
--- a/svf-llvm/lib/CHGBuilder.cpp
+++ b/svf-llvm/lib/CHGBuilder.cpp
@@ -739,12 +739,10 @@ void CHGBuilder::addFuncToFuncVector(CHNode::FuncVector &v, const Function *lf)
 {
     if (cppUtil::isCPPThunkFunction(lf))
     {
-        if (const auto* tf = cppUtil::getThunkTarget(lf))
-        {
-            const FunObjVar* pFunction =
-                llvmModuleSet()->getFunObjVar(tf);
-            v.push_back(pFunction);
-        }
+        const auto* tf = cppUtil::getThunkTarget(lf);
+        const FunObjVar* pFunction =
+            llvmModuleSet()->getFunObjVar(tf ? tf : lf);
+        v.push_back(pFunction);
     }
     else
     {


### PR DESCRIPTION
This commit use thunk function itself as an acceptable choice when actual callee can not be resolved, which could be caused by empty function body of itself.

Issue: https://github.com/SVF-tools/SVF/issues/1765