### PR TITLE
Fix isSameThisPtrInConstructor for LLVM 15+ opaque pointers

### DIFF
--- a/svf-llvm/lib/CHGBuilder.cpp
+++ b/svf-llvm/lib/CHGBuilder.cpp
@@ -174,10 +174,9 @@ void CHGBuilder::connectInheritEdgeViaCall(const Function* caller, const CallBas
         if (cs->arg_size() < 1 || (cs->arg_size() < 2 && cs->paramHasAttr(0, llvm::Attribute::StructRet)))
             return;
         const Value* csThisPtr = cppUtil::getVCallThisPtr(cs);
-        //const Argument* consThisPtr = getConstructorThisPtr(caller);
-        //bool samePtr = isSameThisPtrInConstructor(consThisPtr, csThisPtr);
-        bool samePtrTrue = true;
-        if (csThisPtr != nullptr && samePtrTrue)
+        const Argument* consThisPtr = getConstructorThisPtr(caller);
+        bool samePtr = isSameThisPtrInConstructor(consThisPtr, csThisPtr);
+        if (csThisPtr != nullptr && samePtr)
         {
             struct DemangledName basename = demangle(callee->getName().str());
             if (!LLVMUtil::isCallSite(csThisPtr)  &&


### PR DESCRIPTION
Fixes #1773

Rewrite isSameThisPtrInConstructor to support opaque pointer mode by:

Handling O0's alloca/store/load pattern for primary base class
Distinguishing base class (gep i8) from member field (gep %struct)
Fixing getConstructorThisPtr to handle sret attribute