### PR TITLE
Add check for empty caller arguments in CHGBuilder::connectInheritEdgeViaCall

### DIFF
--- a/svf-llvm/lib/CHGBuilder.cpp
+++ b/svf-llvm/lib/CHGBuilder.cpp
@@ -173,6 +173,9 @@ void CHGBuilder::connectInheritEdgeViaCall(const Function* caller, const CallBas
     {
         if (cs->arg_size() < 1 || (cs->arg_size() < 2 && cs->paramHasAttr(0, llvm::Attribute::StructRet)))
             return;
+        if(caller->arg_size() == 0){
+            return;
+        }
         const Value* csThisPtr = cppUtil::getVCallThisPtr(cs);
         const Argument* consThisPtr = getConstructorThisPtr(caller);
         bool samePtr = isSameThisPtrInConstructor(consThisPtr, csThisPtr);


### PR DESCRIPTION
Constructors or destructors does not necessarily have arguments. This causes an assertion error in getConstructorThisPtr where the arguments are queried. The result of getConstructorThisPtr is used to check if the "This" pointers are the same. And because the function connectInheritEdgeViaCall returns if this is not the case, we can simply return early and avoid the error.

For posterity: this issue arose when running SVF on 483.Xalancbmk for the destructor of XSLTinit. 