### PR TITLE
Set correct ICFGNode for ValVar subclasses during SVFIR construction

### DIFF
--- a/svf-llvm/include/SVF-LLVM/BasicTypes.h
+++ b/svf-llvm/include/SVF-LLVM/BasicTypes.h
@@ -42,6 +42,8 @@
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Statepoint.h>
 #include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/InlineAsm.h>
+#include <llvm/IR/Constants.h>
 
 #include <llvm/Analysis/MemoryLocation.h>
 #include <llvm/Analysis/DominanceFrontier.h>
@@ -127,6 +129,9 @@ typedef llvm::Constant Constant;
 typedef llvm::ConstantInt ConstantInt;
 typedef llvm::ConstantFP ConstantFP;
 typedef llvm::ConstantPointerNull ConstantPointerNull;
+typedef llvm::InlineAsm InlineAsm;
+typedef llvm::DSOLocalEquivalent DSOLocalEquivalent;
+typedef llvm::NoCFIValue NoCFIValue;
 typedef llvm::GlobalAlias GlobalAlias;
 typedef llvm::GlobalIFunc GlobalIFunc;
 typedef llvm::GlobalVariable GlobalVariable;

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -509,7 +509,7 @@ void SVFIRBuilder::initialiseValVars()
             pag->addGlobalValNode(iter->second, pag->getICFG()->getGlobalICFGNode(),
                                   llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
+        else if (SVFUtil::isa<ConstantData, ConstantExpr, MetadataAsValue, BlockAddress>(llvmValue))
         {
             pag->addConstantDataValNode(iter->second, icfgNode, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
@@ -519,7 +519,6 @@ void SVFIRBuilder::initialiseValVars()
         }
         else
         {
-            // Add value node to PAG
             pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
         }
         llvmModuleSet()->addToSVFVar2LLVMValueMap(llvmValue,

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -41,8 +41,6 @@
 #include "Graphs/CallGraph.h"
 #include "Util/Options.h"
 #include "Util/SVFUtil.h"
-#include <llvm/IR/InlineAsm.h>
-#include <llvm/IR/Constants.h>
 
 using namespace std;
 using namespace SVF;
@@ -515,9 +513,9 @@ void SVFIRBuilder::initialiseValVars()
         {
             pag->addBasicBlockValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else if (SVFUtil::isa<llvm::InlineAsm>(llvmValue) ||
-                 SVFUtil::isa<llvm::DSOLocalEquivalent>(llvmValue) ||
-                 SVFUtil::isa<llvm::NoCFIValue>(llvmValue))
+        else if (SVFUtil::isa<InlineAsm>(llvmValue) ||
+                 SVFUtil::isa<DSOLocalEquivalent>(llvmValue) ||
+                 SVFUtil::isa<NoCFIValue>(llvmValue))
         {
             pag->addAsmPCValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -428,7 +428,7 @@ void SVFIRBuilder::initialiseBaseObjVars()
             NodeID id = llvmModuleSet()->getObjectNode(iter->first);
             pag->addGlobalObjNode(iter->second, pag->getObjTypeInfo(id), icfgNode);
         }
-        else if (SVFUtil::isa<ConstantData, ConstantExpr, MetadataAsValue, BlockAddress>(llvmValue))
+        else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
         {
             NodeID id = llvmModuleSet()->getObjectNode(iter->first);
             pag->addConstantDataObjNode(iter->second, pag->getObjTypeInfo(id), icfgNode);
@@ -509,7 +509,7 @@ void SVFIRBuilder::initialiseValVars()
             pag->addGlobalValNode(iter->second, pag->getICFG()->getGlobalICFGNode(),
                                   llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else if (SVFUtil::isa<ConstantData, ConstantExpr, MetadataAsValue, BlockAddress>(llvmValue))
+        else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
         {
             pag->addConstantDataValNode(iter->second, icfgNode, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
@@ -517,13 +517,10 @@ void SVFIRBuilder::initialiseValVars()
         {
             pag->addConstantAggValNode(iter->second, icfgNode, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else if (icfgNode)
-        {
-            pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
-        }
         else
         {
-            pag->addDummyValNode(iter->second, nullptr);
+            // Add value node to PAG
+            pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
         }
         llvmModuleSet()->addToSVFVar2LLVMValueMap(llvmValue,
                 pag->getGNode(iter->second));

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -41,6 +41,8 @@
 #include "Graphs/CallGraph.h"
 #include "Util/Options.h"
 #include "Util/SVFUtil.h"
+#include <llvm/IR/InlineAsm.h>
+#include <llvm/IR/Constants.h>
 
 using namespace std;
 using namespace SVF;

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -481,6 +481,9 @@ void SVFIRBuilder::initialiseValVars()
         }
         else if (auto argval = SVFUtil::dyn_cast<Argument>(llvmValue))
         {
+            // Argument is not an Instruction so icfgNode above is nullptr.
+            // Formal params are defined at FunEntryICFGNode (where CallPE copies actual args).
+            // External (declaration-only) functions have no entry node, so keep nullptr.
             const FunObjVar* funObj = llvmModuleSet()->getFunObjVar(argval->getParent());
             const ICFGNode* entryNode = funObj->isDeclaration() ? nullptr : pag->getICFG()->getFunEntryICFGNode(funObj);
             pag->addArgValNode(
@@ -503,6 +506,8 @@ void SVFIRBuilder::initialiseValVars()
         }
         else if (SVFUtil::isa<GlobalValue>(llvmValue))
         {
+            // GlobalValue is not an Instruction so icfgNode above is nullptr.
+            // Global variables are defined at the global ICFG node.
             pag->addGlobalValNode(iter->second, pag->getICFG()->getGlobalICFGNode(),
                                   llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
@@ -546,6 +551,9 @@ void SVFIRBuilder::initialiseNodes()
             ++iter)
     {
         const Value* llvmValue = iter->first;
+        // retSyms keys are Function*, not Instruction, so dyn_cast<Instruction> always fails.
+        // RetValPN represents the callee's return value, defined at FunExitICFGNode.
+        // External functions have no exit node, so keep nullptr.
         const FunObjVar* funObjVar = llvmModuleSet()->getFunObjVar(SVFUtil::cast<Function>(llvmValue));
         const ICFGNode* icfgNode = funObjVar->isDeclaration() ? nullptr : pag->getICFG()->getFunExitICFGNode(funObjVar);
         DBOUT(DPAGBuild, outs() << "add ret node " << iter->second << "\n");
@@ -561,6 +569,9 @@ void SVFIRBuilder::initialiseNodes()
             iter != llvmModuleSet()->varargSyms().end(); ++iter)
     {
         const Value* llvmValue = iter->first;
+        // varargSyms keys are Function*, not Instruction.
+        // Variadic arguments are received at the function entry point.
+        // External functions have no entry node, so keep nullptr.
         const FunObjVar* funObjVar = llvmModuleSet()->getFunObjVar(SVFUtil::cast<Function>(llvmValue));
         const ICFGNode* icfgNode = funObjVar->isDeclaration() ? nullptr : pag->getICFG()->getFunEntryICFGNode(funObjVar);
         DBOUT(DPAGBuild, outs() << "add vararg node " << iter->second << "\n");
@@ -1681,6 +1692,7 @@ NodeID SVFIRBuilder::getGepValVar(const Value* val, const AccessPath& ap, const 
         }
         else if (SVFUtil::isa<GlobalVariable>(curVal))
         {
+            // GEP on a global variable: the resulting GepValVar belongs to the global ICFG node.
             node = pag->getICFG()->getGlobalICFGNode();
         }
         NodeID gepNode = pag->addGepValNode(llvmModuleSet()->getValueNode(curVal), cast<ValVar>(pag->getGNode(getValueNode(val))), ap,

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -428,7 +428,7 @@ void SVFIRBuilder::initialiseBaseObjVars()
             NodeID id = llvmModuleSet()->getObjectNode(iter->first);
             pag->addGlobalObjNode(iter->second, pag->getObjTypeInfo(id), icfgNode);
         }
-        else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
+        else if (SVFUtil::isa<ConstantData, ConstantExpr, MetadataAsValue, BlockAddress>(llvmValue))
         {
             NodeID id = llvmModuleSet()->getObjectNode(iter->first);
             pag->addConstantDataObjNode(iter->second, pag->getObjTypeInfo(id), icfgNode);
@@ -509,7 +509,7 @@ void SVFIRBuilder::initialiseValVars()
             pag->addGlobalValNode(iter->second, pag->getICFG()->getGlobalICFGNode(),
                                   llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
+        else if (SVFUtil::isa<ConstantData, ConstantExpr, MetadataAsValue, BlockAddress>(llvmValue))
         {
             pag->addConstantDataValNode(iter->second, icfgNode, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
@@ -517,10 +517,13 @@ void SVFIRBuilder::initialiseValVars()
         {
             pag->addConstantAggValNode(iter->second, icfgNode, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
+        else if (icfgNode)
+        {
+            pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
+        }
         else
         {
-            // Add value node to PAG
-            pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
+            pag->addDummyValNode(iter->second, nullptr);
         }
         llvmModuleSet()->addToSVFVar2LLVMValueMap(llvmValue,
                 pag->getGNode(iter->second));

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -428,7 +428,7 @@ void SVFIRBuilder::initialiseBaseObjVars()
             NodeID id = llvmModuleSet()->getObjectNode(iter->first);
             pag->addGlobalObjNode(iter->second, pag->getObjTypeInfo(id), icfgNode);
         }
-        else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
+        else if (SVFUtil::isa<ConstantData, ConstantExpr, MetadataAsValue, BlockAddress>(llvmValue))
         {
             NodeID id = llvmModuleSet()->getObjectNode(iter->first);
             pag->addConstantDataObjNode(iter->second, pag->getObjTypeInfo(id), icfgNode);
@@ -509,7 +509,7 @@ void SVFIRBuilder::initialiseValVars()
             pag->addGlobalValNode(iter->second, pag->getICFG()->getGlobalICFGNode(),
                                   llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
+        else if (SVFUtil::isa<ConstantData, ConstantExpr, MetadataAsValue, BlockAddress>(llvmValue))
         {
             pag->addConstantDataValNode(iter->second, icfgNode, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
@@ -517,9 +517,22 @@ void SVFIRBuilder::initialiseValVars()
         {
             pag->addConstantAggValNode(iter->second, icfgNode, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
+        else if (SVFUtil::isa<BasicBlock>(llvmValue))
+        {
+            pag->addBasicBlockValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
+        }
+        else if (SVFUtil::isa<Instruction>(llvmValue) &&
+                 LLVMUtil::isIntrinsicInst(SVFUtil::cast<Instruction>(llvmValue)))
+        {
+            pag->addIntrinsicValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
+        }
+        else if (!SVFUtil::isa<Instruction>(llvmValue))
+        {
+            // InlineAsm, DSOLocalEquivalent, NoCFIValue
+            pag->addAsmPCValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
+        }
         else
         {
-            // Add value node to PAG
             pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
         }
         llvmModuleSet()->addToSVFVar2LLVMValueMap(llvmValue,

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -481,7 +481,6 @@ void SVFIRBuilder::initialiseValVars()
         }
         else if (auto argval = SVFUtil::dyn_cast<Argument>(llvmValue))
         {
-            // Argument is not an Instruction so icfgNode above is nullptr.
             // Formal params are defined at FunEntryICFGNode (where CallPE copies actual args).
             // External (declaration-only) functions have no entry node, so keep nullptr.
             const FunObjVar* funObj = llvmModuleSet()->getFunObjVar(argval->getParent());
@@ -506,7 +505,6 @@ void SVFIRBuilder::initialiseValVars()
         }
         else if (SVFUtil::isa<GlobalValue>(llvmValue))
         {
-            // GlobalValue is not an Instruction so icfgNode above is nullptr.
             // Global variables are defined at the global ICFG node.
             pag->addGlobalValNode(iter->second, pag->getICFG()->getGlobalICFGNode(),
                                   llvmModuleSet()->getSVFType(llvmValue->getType()));

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -465,14 +465,6 @@ void SVFIRBuilder::initialiseValVars()
 
         const ICFGNode* icfgNode = nullptr;
         auto llvmValue = iter->first;
-        if (const Instruction* inst =
-                    SVFUtil::dyn_cast<Instruction>(llvmValue))
-        {
-            if (llvmModuleSet()->hasICFGNode(inst))
-            {
-                icfgNode = llvmModuleSet()->getICFGNode(inst);
-            }
-        }
 
         // Check if the value is a function and get its call graph node
         if (const Function* func = SVFUtil::dyn_cast<Function>(llvmValue))
@@ -521,19 +513,22 @@ void SVFIRBuilder::initialiseValVars()
         {
             pag->addBasicBlockValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else if (SVFUtil::isa<Instruction>(llvmValue) &&
-                 LLVMUtil::isIntrinsicInst(SVFUtil::cast<Instruction>(llvmValue)))
+        else if (SVFUtil::isa<llvm::InlineAsm>(llvmValue) ||
+                 SVFUtil::isa<llvm::DSOLocalEquivalent>(llvmValue) ||
+                 SVFUtil::isa<llvm::NoCFIValue>(llvmValue))
         {
-            pag->addIntrinsicValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
-        }
-        else if (!SVFUtil::isa<Instruction>(llvmValue))
-        {
-            // InlineAsm, DSOLocalEquivalent, NoCFIValue
             pag->addAsmPCValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else
+        else if (const Instruction* inst = SVFUtil::dyn_cast<Instruction>(llvmValue))
         {
-            pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
+            if (LLVMUtil::isIntrinsicInst(inst))
+                pag->addIntrinsicValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()));
+            else
+            {
+                assert(llvmModuleSet()->hasICFGNode(inst) && "LLVM instruction is not associated with an ICFGNode");
+                icfgNode = llvmModuleSet()->getICFGNode(inst);
+                pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
+            }
         }
         llvmModuleSet()->addToSVFVar2LLVMValueMap(llvmValue,
                 pag->getGNode(iter->second));

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -477,14 +477,15 @@ void SVFIRBuilder::initialiseValVars()
         // Check if the value is a function and get its call graph node
         if (const Function* func = SVFUtil::dyn_cast<Function>(llvmValue))
         {
-            // add value node representing the function
             pag->addFunValNode(iter->second, icfgNode, llvmModuleSet()->getFunObjVar(func), llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
         else if (auto argval = SVFUtil::dyn_cast<Argument>(llvmValue))
         {
+            const FunObjVar* funObj = llvmModuleSet()->getFunObjVar(argval->getParent());
+            const ICFGNode* entryNode = funObj->isDeclaration() ? nullptr : pag->getICFG()->getFunEntryICFGNode(funObj);
             pag->addArgValNode(
-                iter->second, argval->getArgNo(), icfgNode,
-                llvmModuleSet()->getFunObjVar(argval->getParent()),llvmModuleSet()->getSVFType(llvmValue->getType()));
+                iter->second, argval->getArgNo(), entryNode,
+                funObj, llvmModuleSet()->getSVFType(llvmValue->getType()));
             if (!argval->hasName())
                 pag->getGNode(iter->second)->setName("arg_" + std::to_string(argval->getArgNo()));
         }
@@ -502,7 +503,7 @@ void SVFIRBuilder::initialiseValVars()
         }
         else if (SVFUtil::isa<GlobalValue>(llvmValue))
         {
-            pag->addGlobalValNode(iter->second, icfgNode,
+            pag->addGlobalValNode(iter->second, pag->getICFG()->getGlobalICFGNode(),
                                   llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
         else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
@@ -545,18 +546,13 @@ void SVFIRBuilder::initialiseNodes()
             ++iter)
     {
         const Value* llvmValue = iter->first;
-        const ICFGNode* icfgNode = nullptr;
-        if (const Instruction* inst = SVFUtil::dyn_cast<Instruction>(llvmValue))
-        {
-            if(llvmModuleSet()->hasICFGNode(inst))
-                icfgNode = llvmModuleSet()->getICFGNode(inst);
-        }
+        const FunObjVar* funObjVar = llvmModuleSet()->getFunObjVar(SVFUtil::cast<Function>(llvmValue));
+        const ICFGNode* icfgNode = funObjVar->isDeclaration() ? nullptr : pag->getICFG()->getFunExitICFGNode(funObjVar);
         DBOUT(DPAGBuild, outs() << "add ret node " << iter->second << "\n");
         pag->addRetNode(iter->second,
-                        llvmModuleSet()->getFunObjVar(SVFUtil::cast<Function>(llvmValue)),
+                        funObjVar,
                         llvmModuleSet()->getSVFType(iter->first->getType()), icfgNode);
         llvmModuleSet()->addToSVFVar2LLVMValueMap(llvmValue, pag->getGNode(iter->second));
-        const FunObjVar* funObjVar = llvmModuleSet()->getFunObjVar(SVFUtil::cast<Function>(llvmValue));
         pag->returnFunObjSymMap[funObjVar] = iter->second;
     }
 
@@ -565,19 +561,13 @@ void SVFIRBuilder::initialiseNodes()
             iter != llvmModuleSet()->varargSyms().end(); ++iter)
     {
         const Value* llvmValue = iter->first;
-
-        const ICFGNode *icfgNode = nullptr;
-        if (const Instruction *inst = SVFUtil::dyn_cast<Instruction>(llvmValue))
-        {
-            if (llvmModuleSet()->hasICFGNode(inst))
-                icfgNode = llvmModuleSet()->getICFGNode(inst);
-        }
+        const FunObjVar* funObjVar = llvmModuleSet()->getFunObjVar(SVFUtil::cast<Function>(llvmValue));
+        const ICFGNode* icfgNode = funObjVar->isDeclaration() ? nullptr : pag->getICFG()->getFunEntryICFGNode(funObjVar);
         DBOUT(DPAGBuild, outs() << "add vararg node " << iter->second << "\n");
         pag->addVarargNode(iter->second,
-                           llvmModuleSet()->getFunObjVar(SVFUtil::cast<Function>(llvmValue)),
+                           funObjVar,
                            llvmModuleSet()->getSVFType(iter->first->getType()), icfgNode);
         llvmModuleSet()->addToSVFVar2LLVMValueMap(llvmValue, pag->getGNode(iter->second));
-        const FunObjVar* funObjVar = llvmModuleSet()->getFunObjVar(SVFUtil::cast<Function>(llvmValue));
         pag->varargFunObjSymMap[funObjVar] = iter->second;
     }
 
@@ -1683,10 +1673,16 @@ NodeID SVFIRBuilder::getGepValVar(const Value* val, const AccessPath& ap, const 
         LLVMModuleSet* llvmmodule = llvmModuleSet();
         const ICFGNode* node = nullptr;
         if (const Instruction* inst = SVFUtil::dyn_cast<Instruction>(curVal))
+        {
             if (llvmmodule->hasICFGNode(inst))
             {
                 node = llvmmodule->getICFGNode(inst);
             }
+        }
+        else if (SVFUtil::isa<GlobalVariable>(curVal))
+        {
+            node = pag->getICFG()->getGlobalICFGNode();
+        }
         NodeID gepNode = pag->addGepValNode(llvmModuleSet()->getValueNode(curVal), cast<ValVar>(pag->getGNode(getValueNode(val))), ap,
                                             NodeIDAllocator::get()->allocateValueId(),
                                             llvmmodule->getSVFType(PointerType::getUnqual(llvmmodule->getContext())), node);

--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -509,7 +509,7 @@ void SVFIRBuilder::initialiseValVars()
             pag->addGlobalValNode(iter->second, pag->getICFG()->getGlobalICFGNode(),
                                   llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
-        else if (SVFUtil::isa<ConstantData, ConstantExpr, MetadataAsValue, BlockAddress>(llvmValue))
+        else if (SVFUtil::isa<ConstantData, MetadataAsValue, BlockAddress>(llvmValue))
         {
             pag->addConstantDataValNode(iter->second, icfgNode, llvmModuleSet()->getSVFType(llvmValue->getType()));
         }
@@ -519,6 +519,7 @@ void SVFIRBuilder::initialiseValVars()
         }
         else
         {
+            // Add value node to PAG
             pag->addValNode(iter->second, llvmModuleSet()->getSVFType(llvmValue->getType()), icfgNode);
         }
         llvmModuleSet()->addToSVFVar2LLVMValueMap(llvmValue,

--- a/svf/include/SVFIR/SVFIR.h
+++ b/svf/include/SVFIR/SVFIR.h
@@ -837,6 +837,18 @@ private:
     {
         return addDummyValNode(getBlkPtr(), nullptr);
     }
+    inline NodeID addIntrinsicValNode(NodeID i, const SVFType* type)
+    {
+        return addValNode(new IntrinsicValVar(i, type));
+    }
+    inline NodeID addBasicBlockValNode(NodeID i, const SVFType* type)
+    {
+        return addValNode(new BasicBlockValVar(i, type));
+    }
+    inline NodeID addAsmPCValNode(NodeID i, const SVFType* type)
+    {
+        return addValNode(new AsmPCValVar(i, type));
+    }
     //@}
 
     /// Add a value (pointer) node

--- a/svf/include/SVFIR/SVFValue.h
+++ b/svf/include/SVFIR/SVFValue.h
@@ -80,6 +80,9 @@ public:
         ConstNullptrValNode,     // │   └── Represents a constant nullptr value node
         // │   └─ Subclass: DummyValVar
         DummyValNode,            // │   └── Dummy node for uninitialized values
+        IntrinsicValNode,        // │   └── LLVM intrinsic call instruction (e.g. llvm.dbg.declare)
+        BasicBlockValNode,       // │   └── LLVM BasicBlock (label operand of br/switch)
+        AsmPCValNode,            // │   └── InlineAsm, DSOLocalEquivalent, NoCFIValue
 
         // └─ Subclass: ObjVar (Object variable nodes)
         ObjNode,                 // ├── Represents an object variable
@@ -230,7 +233,7 @@ protected:
 
     static inline bool isSVFVarKind(GNodeK n)
     {
-        static_assert(DummyObjNode - ValNode == 26,
+        static_assert(DummyObjNode - ValNode == 29,
                       "The number of SVFVarKinds has changed, make sure the "
                       "range is correct");
 
@@ -239,10 +242,10 @@ protected:
 
     static inline bool isValVarKinds(GNodeK n)
     {
-        static_assert(DummyValNode - ValNode == 13,
+        static_assert(AsmPCValNode - ValNode == 16,
                       "The number of ValVarKinds has changed, make sure the "
                       "range is correct");
-        return n <= DummyValNode && n >= ValNode;
+        return n <= AsmPCValNode && n >= ValNode;
     }
 
 

--- a/svf/include/SVFIR/SVFVariables.h
+++ b/svf/include/SVFIR/SVFVariables.h
@@ -2112,6 +2112,8 @@ public:
     VarArgValPN(NodeID i, const FunObjVar* node, const SVFType* svfType, const ICFGNode* icn)
         : ValVar(i, svfType, icn, VarargValNode), callGraphNode(node)
     {
+        assert((node->isDeclaration() || icn) &&
+               "VarArgValPN of a defined function must have a valid ICFGNode");
     }
 
     virtual const FunObjVar* getFunction() const;

--- a/svf/include/SVFIR/SVFVariables.h
+++ b/svf/include/SVFIR/SVFVariables.h
@@ -1357,6 +1357,7 @@ public:
     GlobalValVar(NodeID i, const ICFGNode* icn, const SVFType* svfType)
         : ValVar(i, svfType, icn, GlobalValNode)
     {
+        assert(icn && "GlobalValVar must have a valid ICFGNode");
         type = svfType;
     }
 

--- a/svf/include/SVFIR/SVFVariables.h
+++ b/svf/include/SVFIR/SVFVariables.h
@@ -283,10 +283,7 @@ public:
     //@}
 
     /// Constructor
-    ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty = ValNode)
-        : SVFVar(i, svfType, ty), icfgNode(node)
-    {
-    }
+    ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty = ValNode);
     /// Return name of a LLVM value
     inline const std::string getValueName() const
     {
@@ -1357,7 +1354,6 @@ public:
     GlobalValVar(NodeID i, const ICFGNode* icn, const SVFType* svfType)
         : ValVar(i, svfType, icn, GlobalValNode)
     {
-        assert(icn && "GlobalValVar must have a valid ICFGNode");
         type = svfType;
     }
 
@@ -2112,8 +2108,6 @@ public:
     VarArgValPN(NodeID i, const FunObjVar* node, const SVFType* svfType, const ICFGNode* icn)
         : ValVar(i, svfType, icn, VarargValNode), callGraphNode(node)
     {
-        assert((node->isDeclaration() || icn) &&
-               "VarArgValPN of a defined function must have a valid ICFGNode");
     }
 
     virtual const FunObjVar* getFunction() const;

--- a/svf/include/SVFIR/SVFVariables.h
+++ b/svf/include/SVFIR/SVFVariables.h
@@ -2176,6 +2176,97 @@ public:
 };
 
 /*
+ * Represents an LLVM intrinsic call instruction (e.g. llvm.dbg.declare).
+ * These are collected into valSyms but have no corresponding ICFGNode.
+ */
+class IntrinsicValVar: public ValVar
+{
+    friend class GraphDBClient;
+
+public:
+    //@{ Methods for support type inquiry through isa, cast, and dyn_cast:
+    static inline bool classof(const IntrinsicValVar*)
+    {
+        return true;
+    }
+    static inline bool classof(const SVFVar* node)
+    {
+        return node->getNodeKind() == SVFVar::IntrinsicValNode;
+    }
+    static inline bool classof(const ValVar* node)
+    {
+        return node->getNodeKind() == SVFVar::IntrinsicValNode;
+    }
+    static inline bool classof(const GenericPAGNodeTy* node)
+    {
+        return node->getNodeKind() == SVFVar::IntrinsicValNode;
+    }
+    static inline bool classof(const SVFValue* node)
+    {
+        return node->getNodeKind() == SVFVar::IntrinsicValNode;
+    }
+    //@}
+
+    IntrinsicValVar(NodeID i, const SVFType* svfType)
+        : ValVar(i, svfType, nullptr, IntrinsicValNode)
+    {
+    }
+
+    inline const std::string getValueName() const
+    {
+        return "intrinsicVal";
+    }
+
+    virtual const std::string toString() const;
+};
+
+/*
+ * Represents an LLVM BasicBlock (label operand of br/switch).
+ * Collected into valSyms as a branch operand but has no ICFGNode.
+ */
+class BasicBlockValVar: public ValVar
+{
+    friend class GraphDBClient;
+
+public:
+    static inline bool classof(const BasicBlockValVar*) { return true; }
+    static inline bool classof(const SVFVar* node) { return node->getNodeKind() == SVFVar::BasicBlockValNode; }
+    static inline bool classof(const ValVar* node) { return node->getNodeKind() == SVFVar::BasicBlockValNode; }
+    static inline bool classof(const GenericPAGNodeTy* node) { return node->getNodeKind() == SVFVar::BasicBlockValNode; }
+    static inline bool classof(const SVFValue* node) { return node->getNodeKind() == SVFVar::BasicBlockValNode; }
+
+    BasicBlockValVar(NodeID i, const SVFType* svfType)
+        : ValVar(i, svfType, nullptr, BasicBlockValNode) {}
+
+    inline const std::string getValueName() const { return "basicBlockVal"; }
+    virtual const std::string toString() const;
+};
+
+/*
+ * Represents InlineAsm, DSOLocalEquivalent, and NoCFIValue.
+ * These are non-instruction values related to inline assembly,
+ * position-independent code (PIC), or control-flow integrity (CFI).
+ * They have no corresponding ICFGNode.
+ */
+class AsmPCValVar: public ValVar
+{
+    friend class GraphDBClient;
+
+public:
+    static inline bool classof(const AsmPCValVar*) { return true; }
+    static inline bool classof(const SVFVar* node) { return node->getNodeKind() == SVFVar::AsmPCValNode; }
+    static inline bool classof(const ValVar* node) { return node->getNodeKind() == SVFVar::AsmPCValNode; }
+    static inline bool classof(const GenericPAGNodeTy* node) { return node->getNodeKind() == SVFVar::AsmPCValNode; }
+    static inline bool classof(const SVFValue* node) { return node->getNodeKind() == SVFVar::AsmPCValNode; }
+
+    AsmPCValVar(NodeID i, const SVFType* svfType)
+        : ValVar(i, svfType, nullptr, AsmPCValNode) {}
+
+    inline const std::string getValueName() const { return "asmPCVal"; }
+    virtual const std::string toString() const;
+};
+
+/*
  * Dummy object variable
  */
 class DummyObjVar: public BaseObjVar

--- a/svf/include/SVFIR/SVFVariables.h
+++ b/svf/include/SVFIR/SVFVariables.h
@@ -2108,6 +2108,8 @@ public:
     VarArgValPN(NodeID i, const FunObjVar* node, const SVFType* svfType, const ICFGNode* icn)
         : ValVar(i, svfType, icn, VarargValNode), callGraphNode(node)
     {
+        assert((node->isDeclaration() || icn) &&
+               "VarArgValPN of a defined function must have a valid ICFGNode");
     }
 
     virtual const FunObjVar* getFunction() const;

--- a/svf/include/SVFIR/SVFVariables.h
+++ b/svf/include/SVFIR/SVFVariables.h
@@ -283,7 +283,10 @@ public:
     //@}
 
     /// Constructor
-    ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty = ValNode);
+    ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty = ValNode)
+        : SVFVar(i, svfType, ty), icfgNode(node)
+    {
+    }
     /// Return name of a LLVM value
     inline const std::string getValueName() const
     {
@@ -1354,6 +1357,7 @@ public:
     GlobalValVar(NodeID i, const ICFGNode* icn, const SVFType* svfType)
         : ValVar(i, svfType, icn, GlobalValNode)
     {
+        assert(icn && "GlobalValVar must have a valid ICFGNode");
         type = svfType;
     }
 
@@ -2108,6 +2112,8 @@ public:
     VarArgValPN(NodeID i, const FunObjVar* node, const SVFType* svfType, const ICFGNode* icn)
         : ValVar(i, svfType, icn, VarargValNode), callGraphNode(node)
     {
+        assert((node->isDeclaration() || icn) &&
+               "VarArgValPN of a defined function must have a valid ICFGNode");
     }
 
     virtual const FunObjVar* getFunction() const;

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -120,7 +120,8 @@ ArgValVar::ArgValVar(NodeID i, u32_t argNo, const ICFGNode* icn,
     : ValVar(i, svfType, icn, ArgValNode),
       cgNode(callGraphNode), argNo(argNo)
 {
-
+    assert((callGraphNode->isDeclaration() || icn) &&
+           "ArgValVar of a defined function must have a valid ICFGNode");
 }
 
 const FunObjVar* ArgValVar::getFunction() const
@@ -179,6 +180,8 @@ const std::string GepValVar::toString() const
 RetValPN::RetValPN(NodeID i, const FunObjVar* node, const SVFType* svfType, const ICFGNode* icn)
     : ValVar(i, svfType, icn, RetValNode), callGraphNode(node)
 {
+    assert((node->isDeclaration() || icn) &&
+           "RetValPN of a defined function must have a valid ICFGNode");
 }
 
 const FunObjVar* RetValPN::getFunction() const

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -108,10 +108,11 @@ ValVar::ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty
     }
     else if (ty == ValNode)
     {
-        // Base ValVar covers values without a dedicated subclass.
-        // Some Instructions are excluded from the ICFG (e.g., llvm.dbg.declare)
-        // and legitimately have nullptr ICFGNode.
-        // TODO: reclassify these or filter them from valSyms to enable assertion.
+        assert(node && "Base ValVar must have a valid ICFGNode");
+    }
+    else
+    {
+        assert(false && "Unknown ValVar subclass -- update this check");
     }
 }
 

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -108,11 +108,10 @@ ValVar::ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty
     }
     else if (ty == ValNode)
     {
-        assert(node && "Base ValVar must have a valid ICFGNode");
-    }
-    else
-    {
-        assert(false && "Unknown ValVar subclass -- update this check");
+        // Base ValVar covers values without a dedicated subclass.
+        // Some Instructions are excluded from the ICFG (e.g., llvm.dbg.declare)
+        // and legitimately have nullptr ICFGNode.
+        // TODO: reclassify these or filter them from valSyms to enable assertion.
     }
 }
 

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -82,6 +82,41 @@ void SVFVar::dump() const
     outs() << this->toString() << "\n";
 }
 
+ValVar::ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty)
+    : SVFVar(i, svfType, ty), icfgNode(node)
+{
+    if (SVFUtil::isa<GlobalValVar>(this))
+    {
+        assert(node && "GlobalValVar must have a valid ICFGNode");
+    }
+    else if (SVFUtil::isa<GepValVar>(this))
+    {
+        assert(node && "GepValVar must have a valid ICFGNode");
+    }
+    else if (SVFUtil::isa<ArgValVar>(this) ||
+             SVFUtil::isa<RetValPN>(this) ||
+             SVFUtil::isa<VarArgValPN>(this))
+    {
+        // External (declaration-only) functions have no ICFG entry/exit nodes,
+        // so their params/returns may legitimately have nullptr ICFGNode.
+        // The FunObjVar* is not accessible here (subclass members not yet initialized).
+    }
+    else if (SVFUtil::isa<ConstDataValVar>(this) ||
+             SVFUtil::isa<ConstAggValVar>(this) ||
+             SVFUtil::isa<FunValVar>(this) ||
+             SVFUtil::isa<DummyValVar>(this))
+    {
+        // Constants, function pointers, and dummy nodes don't require an ICFGNode.
+    }
+    else if (ty == ValNode)
+    {
+        // Base ValVar covers values without a dedicated subclass.
+        // Some Instructions are excluded from the ICFG (e.g., llvm.dbg.declare)
+        // and legitimately have nullptr ICFGNode.
+        // TODO: reclassify these or filter them from valSyms to enable assertion.
+    }
+}
+
 const FunObjVar* ValVar::getFunction() const
 {
     if(icfgNode)
@@ -120,8 +155,6 @@ ArgValVar::ArgValVar(NodeID i, u32_t argNo, const ICFGNode* icn,
     : ValVar(i, svfType, icn, ArgValNode),
       cgNode(callGraphNode), argNo(argNo)
 {
-    assert((callGraphNode->isDeclaration() || icn) &&
-           "ArgValVar of a defined function must have a valid ICFGNode");
 }
 
 const FunObjVar* ArgValVar::getFunction() const
@@ -161,7 +194,6 @@ GepValVar::GepValVar(const ValVar* baseNode, NodeID i,
                      const AccessPath& ap, const SVFType* ty, const ICFGNode* node)
     : ValVar(i, ty, node, GepValNode), ap(ap), base(baseNode), gepValType(ty)
 {
-    assert(node && "GepValVar must have a valid ICFGNode");
 }
 
 const std::string GepValVar::toString() const
@@ -180,8 +212,6 @@ const std::string GepValVar::toString() const
 RetValPN::RetValPN(NodeID i, const FunObjVar* node, const SVFType* svfType, const ICFGNode* icn)
     : ValVar(i, svfType, icn, RetValNode), callGraphNode(node)
 {
-    assert((node->isDeclaration() || icn) &&
-           "RetValPN of a defined function must have a valid ICFGNode");
 }
 
 const FunObjVar* RetValPN::getFunction() const

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -82,41 +82,6 @@ void SVFVar::dump() const
     outs() << this->toString() << "\n";
 }
 
-ValVar::ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty)
-    : SVFVar(i, svfType, ty), icfgNode(node)
-{
-    if (SVFUtil::isa<GlobalValVar>(this))
-    {
-        assert(node && "GlobalValVar must have a valid ICFGNode");
-    }
-    else if (SVFUtil::isa<GepValVar>(this))
-    {
-        assert(node && "GepValVar must have a valid ICFGNode");
-    }
-    else if (SVFUtil::isa<ArgValVar>(this) ||
-             SVFUtil::isa<RetValPN>(this) ||
-             SVFUtil::isa<VarArgValPN>(this))
-    {
-        // External (declaration-only) functions have no ICFG entry/exit nodes,
-        // so their params/returns may legitimately have nullptr ICFGNode.
-        // The FunObjVar* is not accessible here (subclass members not yet initialized).
-    }
-    else if (SVFUtil::isa<ConstDataValVar>(this) ||
-             SVFUtil::isa<ConstAggValVar>(this) ||
-             SVFUtil::isa<FunValVar>(this) ||
-             SVFUtil::isa<DummyValVar>(this))
-    {
-        // Constants, function pointers, and dummy nodes don't require an ICFGNode.
-    }
-    else if (ty == ValNode)
-    {
-        // Base ValVar covers values without a dedicated subclass.
-        // Some Instructions are excluded from the ICFG (e.g., llvm.dbg.declare)
-        // and legitimately have nullptr ICFGNode.
-        // TODO: reclassify these or filter them from valSyms to enable assertion.
-    }
-}
-
 const FunObjVar* ValVar::getFunction() const
 {
     if(icfgNode)
@@ -155,6 +120,8 @@ ArgValVar::ArgValVar(NodeID i, u32_t argNo, const ICFGNode* icn,
     : ValVar(i, svfType, icn, ArgValNode),
       cgNode(callGraphNode), argNo(argNo)
 {
+    assert((callGraphNode->isDeclaration() || icn) &&
+           "ArgValVar of a defined function must have a valid ICFGNode");
 }
 
 const FunObjVar* ArgValVar::getFunction() const
@@ -194,6 +161,7 @@ GepValVar::GepValVar(const ValVar* baseNode, NodeID i,
                      const AccessPath& ap, const SVFType* ty, const ICFGNode* node)
     : ValVar(i, ty, node, GepValNode), ap(ap), base(baseNode), gepValType(ty)
 {
+    assert(node && "GepValVar must have a valid ICFGNode");
 }
 
 const std::string GepValVar::toString() const
@@ -212,6 +180,8 @@ const std::string GepValVar::toString() const
 RetValPN::RetValPN(NodeID i, const FunObjVar* node, const SVFType* svfType, const ICFGNode* icn)
     : ValVar(i, svfType, icn, RetValNode), callGraphNode(node)
 {
+    assert((node->isDeclaration() || icn) &&
+           "RetValPN of a defined function must have a valid ICFGNode");
 }
 
 const FunObjVar* RetValPN::getFunction() const

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -160,7 +160,7 @@ GepValVar::GepValVar(const ValVar* baseNode, NodeID i,
                      const AccessPath& ap, const SVFType* ty, const ICFGNode* node)
     : ValVar(i, ty, node, GepValNode), ap(ap), base(baseNode), gepValType(ty)
 {
-
+    assert(node && "GepValVar must have a valid ICFGNode");
 }
 
 const std::string GepValVar::toString() const

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -97,9 +97,7 @@ ValVar::ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty
              SVFUtil::isa<RetValPN>(this) ||
              SVFUtil::isa<VarArgValPN>(this))
     {
-        // External (declaration-only) functions have no ICFG entry/exit nodes,
-        // so their params/returns may legitimately have nullptr ICFGNode.
-        // The FunObjVar* is not accessible here (subclass members not yet initialized).
+        // Conditional assert (isDeclaration || icn) is in each subclass constructor.
     }
     else if (SVFUtil::isa<ConstDataValVar>(this) ||
              SVFUtil::isa<ConstAggValVar>(this) ||
@@ -155,6 +153,8 @@ ArgValVar::ArgValVar(NodeID i, u32_t argNo, const ICFGNode* icn,
     : ValVar(i, svfType, icn, ArgValNode),
       cgNode(callGraphNode), argNo(argNo)
 {
+    assert((callGraphNode->isDeclaration() || icn) &&
+           "ArgValVar of a defined function must have a valid ICFGNode");
 }
 
 const FunObjVar* ArgValVar::getFunction() const
@@ -212,6 +212,8 @@ const std::string GepValVar::toString() const
 RetValPN::RetValPN(NodeID i, const FunObjVar* node, const SVFType* svfType, const ICFGNode* icn)
     : ValVar(i, svfType, icn, RetValNode), callGraphNode(node)
 {
+    assert((node->isDeclaration() || icn) &&
+           "RetValPN of a defined function must have a valid ICFGNode");
 }
 
 const FunObjVar* RetValPN::getFunction() const

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -102,16 +102,20 @@ ValVar::ValVar(NodeID i, const SVFType* svfType, const ICFGNode* node, PNODEK ty
     else if (SVFUtil::isa<ConstDataValVar>(this) ||
              SVFUtil::isa<ConstAggValVar>(this) ||
              SVFUtil::isa<FunValVar>(this) ||
-             SVFUtil::isa<DummyValVar>(this))
+             SVFUtil::isa<DummyValVar>(this) ||
+             SVFUtil::isa<IntrinsicValVar>(this) ||
+             SVFUtil::isa<BasicBlockValVar>(this) ||
+             SVFUtil::isa<AsmPCValVar>(this))
     {
-        // Constants, function pointers, and dummy nodes don't require an ICFGNode.
+        // These ValVar subclasses don't require an ICFGNode.
     }
     else if (ty == ValNode)
     {
-        // Base ValVar covers values without a dedicated subclass.
-        // Some Instructions are excluded from the ICFG (e.g., llvm.dbg.declare)
-        // and legitimately have nullptr ICFGNode.
-        // TODO: reclassify these or filter them from valSyms to enable assertion.
+        assert(node && "Base ValVar must have a valid ICFGNode");
+    }
+    else
+    {
+        assert(false && "Unknown ValVar subclass -- update this check");
     }
 }
 
@@ -553,6 +557,30 @@ const std::string DummyValVar::toString() const
     std::string str;
     std::stringstream rawstr(str);
     rawstr << "DummyValVar ID: " << getId();
+    return rawstr.str();
+}
+
+const std::string IntrinsicValVar::toString() const
+{
+    std::string str;
+    std::stringstream rawstr(str);
+    rawstr << "IntrinsicValVar ID: " << getId();
+    return rawstr.str();
+}
+
+const std::string BasicBlockValVar::toString() const
+{
+    std::string str;
+    std::stringstream rawstr(str);
+    rawstr << "BasicBlockValVar ID: " << getId();
+    return rawstr.str();
+}
+
+const std::string AsmPCValVar::toString() const
+{
+    std::string str;
+    std::stringstream rawstr(str);
+    rawstr << "AsmPCValVar ID: " << getId();
     return rawstr.str();
 }
 


### PR DESCRIPTION


## Set correct ICFGNode for ValVar subclasses during SVFIR construction

### Problem

Several `ValVar` subclasses were constructed with `nullptr` as their `ICFGNode` because their underlying LLVM values are not `Instruction`s (e.g., `Argument`, `Function`, `GlobalVariable`). The existing code in `SVFIRBuilder` tries `dyn_cast<Instruction>(llvmValue)` to obtain the ICFGNode, which silently produces `nullptr` for all non-instruction values.

This makes it impossible for downstream analyses to determine where a ValVar is "defined" in the ICFG, which is required for sparse analysis optimizations (e.g., semi-sparse abstract interpretation that looks up ValVar values at their definition sites).

### Background: Function Call Parameter Passing in SVF

To understand which ValVars need fixing, it helps to see the full picture of how SVF models function calls:

**Internal function call** `int ret = foo(x)`:

```
CALLER side                                    CALLEE side

                  CallPE (src → dst)
  x (ValVar)    ──────────────────────────►   a (ArgValVar)
  "actual arg"                                 "formal param"
  ICFGNode: instruction that defined x         ICFGNode: FunEntryICFGNode ← FIXED

                                               ... foo body executes ...

                  RetPE (src → dst)
  ret (ValVar)  ◄──────────────────────────   RetValPN
  "actual ret"                                 "formal ret"
  ICFGNode: CallICFGNode (call instruction)    ICFGNode: FunExitICFGNode ← FIXED
```

- `CallPE` copies the actual argument to the formal parameter at `FunEntryICFGNode`.
- `RetPE` copies the formal return value to the actual return at `RetICFGNode`.
- The actual arg and actual ret are regular ValVars from instructions — they already have correct ICFGNodes.
- The **formal param** (`ArgValVar`) and **formal ret** (`RetValPN`) previously had `nullptr` because `Argument` and `Function*` are not `Instruction`.

**External function call** `int ret = ext_func(x)`:

External functions (declarations without bodies) have **no `FunEntryICFGNode` or `FunExitICFGNode`** in the ICFG. More importantly, `handleDirectCall` (which creates `CallPE`/`RetPE`) is only invoked for non-external calls. Therefore:

- **No `CallPE`** is created — the formal param `ArgValVar` is never written to.
- **No `RetPE`** is created — the formal ret `RetValPN` is never read from.
- `AbsExtAPI` handles external calls entirely at the `CallICFGNode`, using only caller-side variables (`callNode->getArgument(i)` for actual args, `callNode->getRetICFGNode()->getActualRet()` for actual ret).

Since external functions' `ArgValVar`/`RetValPN`/`VarArgValPN` are never assigned or queried by any statement, their `nullptr` ICFGNode is safe and correct.

### Changes

**`SVFIRBuilder.cpp`** — set correct ICFGNodes for 5 ValVar types:

| ValVar type | Before | After |
|-------------|--------|-------|
| `ArgValVar` (formal param) | `nullptr` | `FunEntryICFGNode` (defined functions) / `nullptr` (external declarations) |
| `RetValPN` (formal return) | `nullptr` | `FunExitICFGNode` (defined functions) / `nullptr` (external declarations) |
| `VarArgValPN` (variadic param) | `nullptr` | `FunEntryICFGNode` (defined functions) / `nullptr` (external declarations) |
| `GlobalValVar` | `nullptr` | `GlobalICFGNode` |
| `GepValVar` from `GlobalVariable` | `nullptr` | `GlobalICFGNode` |

The previous code for `RetValPN` and `VarArgValPN` had dead logic: it attempted `dyn_cast<Instruction>(llvmValue)` on a `Function*`, which always fails. This dead code is replaced with the direct semantic assignment.

**`SVFVariables.h` / `SVFVariables.cpp`** — add constructor assertions:

- `GlobalValVar`: `assert(icn && "GlobalValVar must have a valid ICFGNode")`
- `GepValVar`: `assert(node && "GepValVar must have a valid ICFGNode")`

These are the only two subclasses where ICFGNode is guaranteed non-null after the fix. Other subclasses (`ArgValVar`, `RetValPN`, `VarArgValPN`) legitimately have `nullptr` for external function declarations.