### PR TITLE
fix: guard against negative/out-of-bounds struct indices in computeGepOffset

### DIFF
--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -677,8 +677,17 @@ bool SVFIRBuilder::computeGepOffset(const User *V, AccessPath& ap)
         else if (const StructType *ST = SVFUtil::dyn_cast<StructType>(gepTy))
         {
             assert(op && "non-const offset accessing a struct");
-            //The actual index
-            APOffset idx = (u32_t)LLVMUtil::getIntegerValue(op).first;
+            // guard against negative or out-of-bounds struct indices
+            // (e.g. rust hashbrown bucket back-offset: gep { ... }, ptr %p, i64 -1)
+            // a negative i64 wraps to a huge uint64_t that overflows u32_t,
+            // creating an invalid field index that severs points-to tracking
+            uint64_t rawIdx = LLVMUtil::getIntegerValue(op).first;
+            if (rawIdx >= ST->getNumElements())
+            {
+                isConst = false;
+                continue;
+            }
+            APOffset idx = (u32_t)rawIdx;
             u32_t offset = pag->getFlattenedElemIdx(llvmModuleSet()->getSVFType(ST), idx);
             ap.setFldIdx(ap.getConstantStructFldIdx() + offset);
         }


### PR DESCRIPTION
## Problem

When a GEP instruction uses a negative constant index on a struct type (e.g. `getelementptr { i32, [1 x i32], ptr }, ptr %p, i64 -1`), [computeGepOffset](cci:1://file:///home/oscar/Projects/pointeranalysis/SVF/svf-llvm/lib/SVFIRBuilder.cpp:636:0-710:1) interprets the index as a `uint64_t` value of `18446744073709551615`, which then overflows when cast to `u32_t` (becoming `4294967295`). This invalid field index is passed to `getFlattenedElemIdx`, creating an incorrect GEP edge that severs the points-to chain.

## Root Cause

In `SVFIRBuilder::computeGepOffset`, the `StructType` handler at line 681:

```cpp
APOffset idx = (u32_t)LLVMUtil::getIntegerValue(op).first;
```

A negative `i64` constant (like `-1`) wraps to a huge `uint64_t` that overflows the `u32_t` cast, producing an invalid flattened field index.

## Fix

Add a bounds check before the cast: if the raw index exceeds the struct's element count, fall back to a variable-offset (field-insensitive) GEP (`isConst = false`). This preserves conservative aliasing over the base object rather than dropping points-to set links entirely.

## Motivation

This pattern is common in Rust's `hashbrown` crate (used by `std::collections::HashMap`), where bucket management uses back-offsetting struct pointers like:

```llvm
%10 = getelementptr inbounds { i32, [1 x i32], ptr }, ptr %self2, i64 -1
```

Without this fix, SVF loses all points-to tracking through these GEP edges, causing false negatives in downstream pointer analyses.