### PR TITLE
semi-sparse loop handling, cycle helpers, and dense fixes

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -117,6 +117,11 @@ jobs:
         run:
           ctest -R ae_recursion_tests -VV
 
+      - name: ctest ae_semi_sparse
+        working-directory: ${{github.workspace}}/Release-build
+        run:
+          ctest -R semi_sparse -VV
+
       - name: ctest cfl_tests
         working-directory: ${{github.workspace}}/Release-build
         run:

--- a/svf/include/AE/Core/AbstractState.h
+++ b/svf/include/AE/Core/AbstractState.h
@@ -352,7 +352,7 @@ public:
     /// freed addresses intact. Used when building a cycle snapshot so the
     /// ValVar set is controlled by the caller rather than whatever was
     /// cached at the seed node.
-    void clearVars()
+    void clearValVars()
     {
         _varToAbsVal.clear();
     }

--- a/svf/include/AE/Svfexe/AbstractInterpretation.h
+++ b/svf/include/AE/Svfexe/AbstractInterpretation.h
@@ -149,6 +149,11 @@ public:
         svfStateMgr->updateAbstractState(node, state);
     }
 
+    inline bool hasAbsValue(const SVFVar* var, const ICFGNode* node)
+    {
+        return svfStateMgr->hasAbstractValue(var, node);
+    }
+
     inline const AbstractValue& getAbsValue(const SVFVar* var, const ICFGNode* node)
     {
         return svfStateMgr->getAbstractValue(var, node);
@@ -183,22 +188,26 @@ private:
     // ---- Semi-sparse cycle helpers ----
     // ValVars whose def-site is inside the cycle but NOT cycle_head do not
     // flow through cycle_head's merge in semi-sparse mode, so the around-merge
-    // widening cannot widen them. handleLoopOrRecursion adds one extra step
-    // per iter that gathers them, widens/narrows across iterations, and
-    // scatters the result back to each def-site.
+    // widening cannot observe them.  getFullCycleHeadState pulls these ValVars
+    // into a single AbstractState snapshot so widen/narrow can treat ValVars
+    // and ObjVars uniformly; after widen/narrow we scatter the ValVars back
+    // to their def-sites.
 
-    /// Snapshot cycle ValVars' current values from their def-sites.
-    /// Skips any ValVar without a genuinely stored value to avoid the
-    /// top-fallback from contaminating def-sites when the snapshot is
-    /// later written back by widen/narrow.
-    Map<const ValVar*, AbstractValue> getCycleAbsValues(const Set<const ValVar*>& valVars);
+    /// Build a full cycle-head AbstractState: the ObjVars currently at
+    /// cycle_head combined with every cycle ValVar pulled from its
+    /// def-site.  Skips ValVars without a stored value to avoid the
+    /// top-fallback contamination.  In dense mode this is equivalent to
+    /// trace[cycle_head] since ValVars already live there.
+    AbstractState getFullCycleHeadState(const ICFGCycleWTO* cycle);
 
-    /// Widen the cycle state of `prev` and `cur` at `cycle_head`.
-    bool widenCycleState(const Map<const ValVar*, AbstractValue>& prev, const Map<const ValVar*, AbstractValue>& cur,
-                         AbstractState& prev_head_state, AbstractState& cur_head_state);
-    /// Narrow the cycle state of `prev` and `cur` at `cycle_head`.
-    bool narrowCycleState(const Map<const ValVar*, AbstractValue>& prev, const Map<const ValVar*, AbstractValue>& cur,
-                          AbstractState& prev_head_state, AbstractState& cur_head_state);
+    /// Widen prev with cur; write the widened state to trace[cycle_head]
+    /// and scatter its ValVars back to their def-sites.  Returns true
+    /// when the widened result equals prev (fixpoint).
+    bool widenCycleState(const AbstractState& prev, const AbstractState& cur,
+                         const ICFGCycleWTO* cycle);
+    /// Narrow prev with cur; write the narrowed state back and scatter.
+    bool narrowCycleState(const AbstractState& prev, const AbstractState& cur,
+                          const ICFGCycleWTO* cycle);
 
     /// Handle a function body via worklist-driven WTO traversal starting from funEntry
     void handleFunction(const ICFGNode* funEntry, const CallICFGNode* caller = nullptr);

--- a/svf/include/AE/Svfexe/AbstractInterpretation.h
+++ b/svf/include/AE/Svfexe/AbstractInterpretation.h
@@ -180,6 +180,28 @@ private:
     /// Handle a WTO cycle (loop or recursive function) using widening/narrowing iteration
     virtual void handleLoopOrRecursion(const ICFGCycleWTO* cycle, const CallICFGNode* caller = nullptr);
 
+    // ---- Semi-sparse cycle helpers ----
+    // ValVars whose def-site is inside the cycle but NOT cycle_head do not
+    // flow through cycle_head's merge in semi-sparse mode, so the around-merge
+    // widening cannot widen them. handleLoopOrRecursion adds one extra step
+    // per iter that gathers them, widens/narrows across iterations, and
+    // scatters the result back to each def-site.
+
+    /// Return the full abstract state at cycle_head: ObjVars from the trace
+    /// plus every cycle ValVar collected from its def-site. In dense mode
+    /// this is simply trace[cycle_head]. In semi-sparse mode the collected
+    /// ValVars are also scattered back to their def-sites for consistency.
+    AbstractState getFullCycleHeadState(const ICFGCycleWTO* cycle);
+
+    /// Push the ValVars in `snap` back to their def-sites. No-op in dense.
+    void scatterCycleValVars(const AbstractState& snap, const ICFGCycleWTO* cycle);
+    /// Widen the cycle state of `prev` and `cur` at `cycle_head`.
+    bool widenCycleState(AbstractState& prev, const AbstractState& cur,
+                         const ICFGNode* cycle_head, const ICFGCycleWTO* cycle);
+    /// Narrow the cycle state of `prev` and `cur` at `cycle_head`.
+    bool narrowCycleState(AbstractState& prev, const AbstractState& cur,
+                          const ICFGNode* cycle_head, const ICFGCycleWTO* cycle);
+
     /// Handle a function body via worklist-driven WTO traversal starting from funEntry
     void handleFunction(const ICFGNode* funEntry, const CallICFGNode* caller = nullptr);
 

--- a/svf/include/AE/Svfexe/AbstractInterpretation.h
+++ b/svf/include/AE/Svfexe/AbstractInterpretation.h
@@ -196,11 +196,11 @@ private:
     /// Push the ValVars in `snap` back to their def-sites. No-op in dense.
     void scatterCycleValVars(const AbstractState& snap, const ICFGCycleWTO* cycle);
     /// Widen the cycle state of `prev` and `cur` at `cycle_head`.
-    bool widenCycleState(AbstractState& prev, const AbstractState& cur,
-                         const ICFGNode* cycle_head, const ICFGCycleWTO* cycle);
+    bool widenCycleState(const Map<const ValVar*, AbstractValue>& prev, const Map<const ValVar*, AbstractValue>& cur,
+                         AbstractState& prev_head_state, AbstractState& cur_head_state);
     /// Narrow the cycle state of `prev` and `cur` at `cycle_head`.
-    bool narrowCycleState(AbstractState& prev, const AbstractState& cur,
-                          const ICFGNode* cycle_head, const ICFGCycleWTO* cycle);
+    bool narrowCycleState(const Map<const ValVar*, AbstractValue>& prev, const Map<const ValVar*, AbstractValue>& cur,
+                          AbstractState& prev_head_state, AbstractState& cur_head_state);
 
     /// Handle a function body via worklist-driven WTO traversal starting from funEntry
     void handleFunction(const ICFGNode* funEntry, const CallICFGNode* caller = nullptr);

--- a/svf/include/AE/Svfexe/AbstractInterpretation.h
+++ b/svf/include/AE/Svfexe/AbstractInterpretation.h
@@ -187,14 +187,12 @@ private:
     // per iter that gathers them, widens/narrows across iterations, and
     // scatters the result back to each def-site.
 
-    /// Return the full abstract state at cycle_head: ObjVars from the trace
-    /// plus every cycle ValVar collected from its def-site. In dense mode
-    /// this is simply trace[cycle_head]. In semi-sparse mode the collected
-    /// ValVars are also scattered back to their def-sites for consistency.
-    AbstractState getFullCycleHeadState(const ICFGCycleWTO* cycle);
+    /// Snapshot cycle ValVars' current values from their def-sites.
+    /// Skips any ValVar without a genuinely stored value to avoid the
+    /// top-fallback from contaminating def-sites when the snapshot is
+    /// later written back by widen/narrow.
+    Map<const ValVar*, AbstractValue> getCycleAbsValues(const Set<const ValVar*>& valVars);
 
-    /// Push the ValVars in `snap` back to their def-sites. No-op in dense.
-    void scatterCycleValVars(const AbstractState& snap, const ICFGCycleWTO* cycle);
     /// Widen the cycle state of `prev` and `cur` at `cycle_head`.
     bool widenCycleState(const Map<const ValVar*, AbstractValue>& prev, const Map<const ValVar*, AbstractValue>& cur,
                          AbstractState& prev_head_state, AbstractState& cur_head_state);

--- a/svf/include/AE/Svfexe/AbstractStateManager.h
+++ b/svf/include/AE/Svfexe/AbstractStateManager.h
@@ -66,6 +66,19 @@ public:
     /// Dispatch to ValVar or ObjVar overload (checks ObjVar first due to inheritance).
     const AbstractValue& getAbstractValue(const SVFVar* var, const ICFGNode* node);
 
+    /// Check whether a ValVar has a real stored value reachable by
+    /// getAbstractValue.  Unlike getAbstractValue, this is side-effect free
+    /// and does NOT treat the final top-fallback as "present" — so callers
+    /// that plan to write the fetched value back (e.g. cycle widen/narrow)
+    /// can distinguish a genuine stored value from the top sentinel.
+    bool hasAbstractValue(const ValVar* var, const ICFGNode* node) const;
+
+    /// Check whether an ObjVar has a stored value at node.
+    bool hasAbstractValue(const ObjVar* var, const ICFGNode* node) const;
+
+    /// Dispatch to ValVar or ObjVar overload.
+    bool hasAbstractValue(const SVFVar* var, const ICFGNode* node) const;
+
     /// Write a top-level variable's abstract value into abstractTrace[node].
     void updateAbstractValue(const ValVar* var, const AbstractValue& val, const ICFGNode* node);
 

--- a/svf/include/AE/Svfexe/AbstractStateManager.h
+++ b/svf/include/AE/Svfexe/AbstractStateManager.h
@@ -176,11 +176,6 @@ public:
     /// Given an ObjVar and its use-site ICFGNode, find the definition-site ICFGNode.
     const ICFGNode* getDefSiteOfObjVar(const ObjVar* obj, const ICFGNode* node) const;
 
-    // ===----------------------------------------------------------------------===//
-    //  Cycle ValVar Access API
-    // ===----------------------------------------------------------------------===//
-    Map<const ValVar*, AbstractValue> getCycleAbsValues(const Set<const ValVar*>& valVars);
-
 private:
     SVFIR* svfir;
     SVFG* svfg;

--- a/svf/include/AE/Svfexe/AbstractStateManager.h
+++ b/svf/include/AE/Svfexe/AbstractStateManager.h
@@ -163,6 +163,11 @@ public:
     /// Given an ObjVar and its use-site ICFGNode, find the definition-site ICFGNode.
     const ICFGNode* getDefSiteOfObjVar(const ObjVar* obj, const ICFGNode* node) const;
 
+    // ===----------------------------------------------------------------------===//
+    //  Cycle ValVar Access API
+    // ===----------------------------------------------------------------------===//
+    Map<const ValVar*, AbstractValue> getCycleAbsValues(const Set<const ValVar*>& valVars);
+
 private:
     SVFIR* svfir;
     SVFG* svfg;

--- a/svf/include/AE/Svfexe/PreAnalysis.h
+++ b/svf/include/AE/Svfexe/PreAnalysis.h
@@ -80,10 +80,10 @@ public:
 
     /// Look up the ValVar id set of a WTO cycle. Returns nullptr if the
     /// cycle is unknown (e.g. dense mode, where the map is never built).
-    const Set<NodeID>* getCycleValVars(const ICFGCycleWTO* cycle) const
+    const Set<const ValVar*> getCycleValVars(const ICFGCycleWTO* cycle) const
     {
         auto it = cycleToValVars.find(cycle);
-        return it == cycleToValVars.end() ? nullptr : &it->second;
+        return it == cycleToValVars.end() ? Set<const ValVar*>() : it->second;
     }
 
 private:
@@ -98,7 +98,7 @@ private:
     /// Pre-computed (semi-sparse only) map from a WTO cycle to the IDs of
     /// every ValVar whose def-site is inside that cycle, including all
     /// nested sub-cycles. Empty in dense mode.
-    Map<const ICFGCycleWTO*, Set<NodeID>> cycleToValVars;
+    Map<const ICFGCycleWTO*, Set<const ValVar*>> cycleToValVars;
 };
 
 } // End namespace SVF

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -884,97 +884,67 @@ void AbstractInterpretation::handleFunCall(const CallICFGNode *callNode)
 // (initCycleValVars), bottom-up so nested cycles are handled before their
 // enclosing cycle.
 
-AbstractState AbstractInterpretation::getFullCycleHeadState(const ICFGCycleWTO* cycle)
-{
-    const ICFGNode* cycle_head = cycle->head()->getICFGNode();
-    AbstractState snap;
-    if (hasAbsState(cycle_head))
-        snap = getAbsState(cycle_head);
-
-    const Set<NodeID>* ids = preAnalysis->getCycleValVars(cycle);
-    if (!ids)
-        return snap;  // dense mode: snap already has everything
-
-    // Semi-sparse: drop any stale ValVar entries cached at cycle_head,
-    // then pull each cycle ValVar from its def-site.
-    snap.clearVars();
-
-    auto& trace = svfStateMgr->getTrace();
-    for (NodeID id : *ids)
-    {
-        const ValVar* v = SVFUtil::dyn_cast<ValVar>(svfir->getSVFVar(id));
-        if (!v) continue;
-        const ICFGNode* defSite = v->getICFGNode();
-        if (!defSite) continue;
-        auto tit = trace.find(defSite);
-        if (tit == trace.end()) continue;
-        const auto& dmap = tit->second.getVarToVal();
-        auto dit = dmap.find(id);
-        if (dit == dmap.end()) continue;
-        snap[id] = dit->second;
-    }
-
-    // Scatter the collected ValVars back to def-sites for consistency.
-    scatterCycleValVars(snap, cycle);
-    return snap;
-}
-
-void AbstractInterpretation::scatterCycleValVars(
-    const AbstractState& snap, const ICFGCycleWTO* cycle)
-{
-    const Set<NodeID>* ids = preAnalysis->getCycleValVars(cycle);
-    if (!ids) return;
-    auto& trace = svfStateMgr->getTrace();
-    for (NodeID id : *ids)
-    {
-        const ValVar* v = SVFUtil::dyn_cast<ValVar>(svfir->getSVFVar(id));
-        if (!v) continue;
-        const ICFGNode* defSite = v->getICFGNode();
-        if (!defSite) continue;
-        auto kv = snap.getVarToVal().find(id);
-        if (kv == snap.getVarToVal().end()) continue;
-        trace[defSite][id] = kv->second;
-    }
-}
-
 // --- Cycle state helpers (dense/sparse unified) ---
 
 bool AbstractInterpretation::widenCycleState(
-    AbstractState& prev, const AbstractState& cur,
-    const ICFGNode* cycle_head, const ICFGCycleWTO* cycle)
+    const Map<const ValVar*, AbstractValue>& prev_head_valVars, const Map<const ValVar*, AbstractValue>& cur_head_valVars,
+    AbstractState& prev_head_state, AbstractState& cur_head_state)
 {
-    AbstractState next = prev.widening(cur);
-    // Always write the widened result to trace, even at fixpoint.
-    // At fixpoint (next == prev), this restores cycle_head to the
-    // pre-merge widened state.  The subsequent narrowing phase then
-    // sees the widened values, runs the body at least once with the
-    // narrowed head state, and correctly updates cycle-body nodes.
-    // Without this write, the narrowing phase would immediately
-    // reach fixpoint (head already has the merged/narrowed value)
-    // and never re-process the body — leaving body nodes with stale
-    // widened values that leak to loop-exit successors.
-    bool fixpoint = (next == prev);
-    prev = std::move(next);
-    svfStateMgr->getTrace()[cycle_head] = prev;
-    if (Options::AESparsity() == AESparsity::SemiSparse)
-        scatterCycleValVars(prev, cycle);
-    return fixpoint;
+    // Widen ValVars with the same "conservative" semantics as
+    // AbstractState::widening: iterate over prev's keys, and only widen
+    // those that are ALSO in cur.  Keys in prev but missing from cur are
+    // left unchanged (neither widened nor cleared).  This matches dense
+    // mode and prevents TOP/bottom contamination of body def-sites.
+    bool valvar_fixpoint = true;
+    for (const auto& [valVar, preVal] : prev_head_valVars)
+    {
+        auto it = cur_head_valVars.find(valVar);
+        if (it == cur_head_valVars.end())
+        {
+            // Missing in cur: preserve prev's value at the def-site
+            // (equivalent to `es[key] = prev[key]` in AbstractState::widening).
+            updateAbsValue(valVar, preVal, valVar->getICFGNode());
+            continue;
+        }
+        AbstractValue widened = preVal;
+        widened.widen_with(it->second);
+        updateAbsValue(valVar, widened, valVar->getICFGNode());
+        if (!widened.equals(preVal))
+            valvar_fixpoint = false;
+    }
+    // Widen the AbstractState. cur_head_state is a reference to
+    // trace[cycle_head]; assigning the widened result back updates the
+    // trace in-place so subsequent body processing sees the widened state.
+    cur_head_state = prev_head_state.widening(cur_head_state);
+    return valvar_fixpoint && (prev_head_state == cur_head_state);
 }
 
 bool AbstractInterpretation::narrowCycleState(
-    AbstractState& prev, const AbstractState& cur,
-    const ICFGNode* cycle_head, const ICFGCycleWTO* cycle)
+    const Map<const ValVar*, AbstractValue>& prev_head_valVars, const Map<const ValVar*, AbstractValue>& cur_head_valVars,
+    AbstractState& prev_head_state, AbstractState& cur_head_state)
 {
-    if (!shouldApplyNarrowing(cycle_head->getFun()))
-        return true;  // narrowing disabled for this function
-    AbstractState next = prev.narrowing(cur);
-    if (next == prev)
-        return true;  // fixpoint
-    prev = std::move(next);
-    svfStateMgr->getTrace()[cycle_head] = prev;
-    if (Options::AESparsity() == AESparsity::SemiSparse)
-        scatterCycleValVars(prev, cycle);
-    return false;
+    // Narrow ValVars with the same conservative semantics as
+    // AbstractState::narrowing: iterate over prev's keys, narrow only those
+    // also in cur.  Keys in prev but missing from cur are preserved.
+    bool valvar_fixpoint = true;
+    for (const auto& [valVar, preVal] : prev_head_valVars)
+    {
+        auto it = cur_head_valVars.find(valVar);
+        if (it == cur_head_valVars.end())
+        {
+            updateAbsValue(valVar, preVal, valVar->getICFGNode());
+            continue;
+        }
+        AbstractValue narrowed = preVal;
+        narrowed.narrow_with(it->second);
+        updateAbsValue(valVar, narrowed, valVar->getICFGNode());
+        if (!narrowed.equals(preVal))
+            valvar_fixpoint = false;
+    }
+    // Narrow the AbstractState. cur_head_state is a reference to
+    // trace[cycle_head]; assigning the narrowed result back updates trace.
+    cur_head_state = prev_head_state.narrowing(cur_head_state);
+    return valvar_fixpoint && (prev_head_state == cur_head_state);
 }
 
 
@@ -1000,15 +970,16 @@ void AbstractInterpretation::handleLoopOrRecursion(const ICFGCycleWTO* cycle, co
             // Save state before processing head.  getFullCycleHeadState
             // handles both dense (returns trace[cycle_head] as-is) and
             // semi-sparse (collects ValVars from def-sites) uniformly.
-            AbstractState prev_head_state = getFullCycleHeadState(cycle);
+            const Map<const ValVar*, AbstractValue>& prev_head_valVars = svfStateMgr->getCycleAbsValues(preAnalysis->getCycleValVars(cycle));
+            AbstractState prev_head_state = svfStateMgr->getAbstractState(cycle_head);
 
             if (mergeStatesFromPredecessors(cycle_head))
                 handleICFGNode(cycle_head);
-            AbstractState cur_head_state = getFullCycleHeadState(cycle);
+            const Map<const ValVar*, AbstractValue>& cur_head_valVars = svfStateMgr->getCycleAbsValues(preAnalysis->getCycleValVars(cycle));
 
             if (increasing)
             {
-                if (widenCycleState(prev_head_state, cur_head_state, cycle_head, cycle))
+                if (widenCycleState(prev_head_valVars, cur_head_valVars, prev_head_state, svfStateMgr->getAbstractState(cycle_head)))
                 {
                     increasing = false;
                     continue;
@@ -1016,7 +987,7 @@ void AbstractInterpretation::handleLoopOrRecursion(const ICFGCycleWTO* cycle, co
             }
             else
             {
-                if (narrowCycleState(prev_head_state, cur_head_state, cycle_head, cycle))
+                if (narrowCycleState(prev_head_valVars, cur_head_valVars, prev_head_state, svfStateMgr->getAbstractState(cycle_head)))
                     break;
             }
         }

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -886,6 +886,23 @@ void AbstractInterpretation::handleFunCall(const CallICFGNode *callNode)
 
 // --- Cycle state helpers (dense/sparse unified) ---
 
+Map<const ValVar*, AbstractValue> AbstractInterpretation::getCycleAbsValues(
+    const Set<const ValVar*>& valVars)
+{
+    Map<const ValVar*, AbstractValue> snap;
+    for (const ValVar* v : valVars)
+    {
+        const ICFGNode* defSite = v->getICFGNode();
+        // Only snapshot ValVars that genuinely have a stored value.
+        // getAbsValue would otherwise top-fallback for uninitialised
+        // ValVars, and that top, written back to def-sites by widen/narrow,
+        // contaminates body nodes and defeats precision.
+        if (!defSite || !svfStateMgr->hasAbstractValue(v, defSite)) continue;
+        snap[v] = svfStateMgr->getAbstractValue(v, defSite);
+    }
+    return snap;
+}
+
 bool AbstractInterpretation::widenCycleState(
     const Map<const ValVar*, AbstractValue>& prev_head_valVars, const Map<const ValVar*, AbstractValue>& cur_head_valVars,
     AbstractState& prev_head_state, AbstractState& cur_head_state)
@@ -967,15 +984,14 @@ void AbstractInterpretation::handleLoopOrRecursion(const ICFGCycleWTO* cycle, co
     {
         if (cur_iter >= widen_delay)
         {
-            // Save state before processing head.  getFullCycleHeadState
             // handles both dense (returns trace[cycle_head] as-is) and
             // semi-sparse (collects ValVars from def-sites) uniformly.
-            const Map<const ValVar*, AbstractValue>& prev_head_valVars = svfStateMgr->getCycleAbsValues(preAnalysis->getCycleValVars(cycle));
+            const Map<const ValVar*, AbstractValue>& prev_head_valVars = getCycleAbsValues(preAnalysis->getCycleValVars(cycle));
             AbstractState prev_head_state = svfStateMgr->getAbstractState(cycle_head);
 
             if (mergeStatesFromPredecessors(cycle_head))
                 handleICFGNode(cycle_head);
-            const Map<const ValVar*, AbstractValue>& cur_head_valVars = svfStateMgr->getCycleAbsValues(preAnalysis->getCycleValVars(cycle));
+            const Map<const ValVar*, AbstractValue>& cur_head_valVars = getCycleAbsValues(preAnalysis->getCycleValVars(cycle));
 
             if (increasing)
             {

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -886,82 +886,76 @@ void AbstractInterpretation::handleFunCall(const CallICFGNode *callNode)
 
 // --- Cycle state helpers (dense/sparse unified) ---
 
-Map<const ValVar*, AbstractValue> AbstractInterpretation::getCycleAbsValues(
-    const Set<const ValVar*>& valVars)
+AbstractState AbstractInterpretation::getFullCycleHeadState(const ICFGCycleWTO* cycle)
 {
-    Map<const ValVar*, AbstractValue> snap;
-    for (const ValVar* v : valVars)
+    const ICFGNode* cycle_head = cycle->head()->getICFGNode();
+    AbstractState snap;
+    if (hasAbsState(cycle_head))
+        snap = getAbsState(cycle_head);
+
+    if (Options::AESparsity() == AESparsity::SemiSparse)
     {
-        const ICFGNode* defSite = v->getICFGNode();
-        // Only snapshot ValVars that genuinely have a stored value.
-        // getAbsValue would otherwise top-fallback for uninitialised
-        // ValVars, and that top, written back to def-sites by widen/narrow,
-        // contaminates body nodes and defeats precision.
-        if (!defSite || !svfStateMgr->hasAbstractValue(v, defSite)) continue;
-        snap[v] = svfStateMgr->getAbstractValue(v, defSite);
+        const Set<const ValVar*>& valVars = preAnalysis->getCycleValVars(cycle);
+        if (valVars.empty())
+            return snap;  // dense path / no cycle ValVars: snap is already complete
+
+        // Semi-sparse: drop any stale ValVar entries cached at cycle_head and
+        // pull each cycle ValVar from its def-site.  ValVars without a stored
+        // value are skipped to avoid the top-fallback contamination.
+        snap.clearValVars();
+        for (const ValVar* v : valVars)
+        {
+            const ICFGNode* defSite = v->getICFGNode();
+            if (!defSite || !hasAbsValue(v, defSite)) continue;
+            snap[v->getId()] = getAbsValue(v, defSite);
+        }
+        return snap;
     }
-    return snap;
+    else
+    {
+        return snap;
+    }
 }
 
+
 bool AbstractInterpretation::widenCycleState(
-    const Map<const ValVar*, AbstractValue>& prev_head_valVars, const Map<const ValVar*, AbstractValue>& cur_head_valVars,
-    AbstractState& prev_head_state, AbstractState& cur_head_state)
+    const AbstractState& prev, const AbstractState& cur, const ICFGCycleWTO* cycle)
 {
-    // Widen ValVars with the same "conservative" semantics as
-    // AbstractState::widening: iterate over prev's keys, and only widen
-    // those that are ALSO in cur.  Keys in prev but missing from cur are
-    // left unchanged (neither widened nor cleared).  This matches dense
-    // mode and prevents TOP/bottom contamination of body def-sites.
-    bool valvar_fixpoint = true;
-    for (const auto& [valVar, preVal] : prev_head_valVars)
+    AbstractState prev_copy = prev;
+    AbstractState next = prev_copy.widening(cur);
+    // Always write back (even at fixpoint) so cycle_head's trace holds the
+    // widened state for the upcoming narrowing phase.
+    const ICFGNode* cycle_head = cycle->head()->getICFGNode();
+    svfStateMgr->getTrace()[cycle_head] = next;
+    if (Options::AESparsity() == AESparsity::SemiSparse)
     {
-        auto it = cur_head_valVars.find(valVar);
-        if (it == cur_head_valVars.end())
+        for (const auto& [id, val] : next.getVarToVal())
         {
-            // Missing in cur: preserve prev's value at the def-site
-            // (equivalent to `es[key] = prev[key]` in AbstractState::widening).
-            updateAbsValue(valVar, preVal, valVar->getICFGNode());
-            continue;
+            updateAbsValue(svfir->getSVFVar(id), val, cycle_head);
         }
-        AbstractValue widened = preVal;
-        widened.widen_with(it->second);
-        updateAbsValue(valVar, widened, valVar->getICFGNode());
-        if (!widened.equals(preVal))
-            valvar_fixpoint = false;
     }
-    // Widen the AbstractState. cur_head_state is a reference to
-    // trace[cycle_head]; assigning the widened result back updates the
-    // trace in-place so subsequent body processing sees the widened state.
-    cur_head_state = prev_head_state.widening(cur_head_state);
-    return valvar_fixpoint && (prev_head_state == cur_head_state);
+    return next == prev;
 }
 
 bool AbstractInterpretation::narrowCycleState(
-    const Map<const ValVar*, AbstractValue>& prev_head_valVars, const Map<const ValVar*, AbstractValue>& cur_head_valVars,
-    AbstractState& prev_head_state, AbstractState& cur_head_state)
+    const AbstractState& prev, const AbstractState& cur, const ICFGCycleWTO* cycle)
 {
-    // Narrow ValVars with the same conservative semantics as
-    // AbstractState::narrowing: iterate over prev's keys, narrow only those
-    // also in cur.  Keys in prev but missing from cur are preserved.
-    bool valvar_fixpoint = true;
-    for (const auto& [valVar, preVal] : prev_head_valVars)
+    const ICFGNode* cycle_head = cycle->head()->getICFGNode();
+    if (!shouldApplyNarrowing(cycle_head->getFun()))
+        return true;
+    AbstractState prev_copy = prev;
+    AbstractState next = prev_copy.narrowing(cur);
+    if (next == prev)
+        return true;  // fixpoint
+    svfStateMgr->getTrace()[cycle_head] = next;
+    if (Options::AESparsity() == AESparsity::SemiSparse)
     {
-        auto it = cur_head_valVars.find(valVar);
-        if (it == cur_head_valVars.end())
+        for (const auto& [id, val] : next.getVarToVal())
         {
-            updateAbsValue(valVar, preVal, valVar->getICFGNode());
-            continue;
+            updateAbsValue(svfir->getSVFVar(id), val, cycle_head);
         }
-        AbstractValue narrowed = preVal;
-        narrowed.narrow_with(it->second);
-        updateAbsValue(valVar, narrowed, valVar->getICFGNode());
-        if (!narrowed.equals(preVal))
-            valvar_fixpoint = false;
     }
-    // Narrow the AbstractState. cur_head_state is a reference to
-    // trace[cycle_head]; assigning the narrowed result back updates trace.
-    cur_head_state = prev_head_state.narrowing(cur_head_state);
-    return valvar_fixpoint && (prev_head_state == cur_head_state);
+    return false;
 }
 
 
@@ -984,18 +978,17 @@ void AbstractInterpretation::handleLoopOrRecursion(const ICFGCycleWTO* cycle, co
     {
         if (cur_iter >= widen_delay)
         {
-            // handles both dense (returns trace[cycle_head] as-is) and
-            // semi-sparse (collects ValVars from def-sites) uniformly.
-            const Map<const ValVar*, AbstractValue>& prev_head_valVars = getCycleAbsValues(preAnalysis->getCycleValVars(cycle));
-            AbstractState prev_head_state = svfStateMgr->getAbstractState(cycle_head);
+            // getFullCycleHeadState handles dense (returns trace[cycle_head])
+            // and semi-sparse (collects ValVars from def-sites) uniformly.
+            AbstractState prev = getFullCycleHeadState(cycle);
 
             if (mergeStatesFromPredecessors(cycle_head))
                 handleICFGNode(cycle_head);
-            const Map<const ValVar*, AbstractValue>& cur_head_valVars = getCycleAbsValues(preAnalysis->getCycleValVars(cycle));
+            AbstractState cur = getFullCycleHeadState(cycle);
 
             if (increasing)
             {
-                if (widenCycleState(prev_head_valVars, cur_head_valVars, prev_head_state, svfStateMgr->getAbstractState(cycle_head)))
+                if (widenCycleState(prev, cur, cycle))
                 {
                     increasing = false;
                     continue;
@@ -1003,7 +996,7 @@ void AbstractInterpretation::handleLoopOrRecursion(const ICFGCycleWTO* cycle, co
             }
             else
             {
-                if (narrowCycleState(prev_head_valVars, cur_head_valVars, prev_head_state, svfStateMgr->getAbstractState(cycle_head)))
+                if (narrowCycleState(prev, cur, cycle))
                     break;
             }
         }

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -205,6 +205,7 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
 {
     // Collect all feasible predecessor states, then merge at the end.
     AbstractState merged;
+    bool hasFeasiblePred = false;
 
     for (auto& edge : node->getInEdges())
     {
@@ -218,16 +219,21 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
             {
                 AbstractState predState = getAbsState(pred);
                 if (isBranchFeasible(intraCfgEdge, predState))
+                {
                     merged.joinWith(predState);
+                    hasFeasiblePred = true;
+                }
             }
             else
             {
                 merged.joinWith(getAbsState(pred));
+                hasFeasiblePred = true;
             }
         }
         else if (SVFUtil::isa<CallCFGEdge>(edge))
         {
             merged.joinWith(getAbsState(pred));
+            hasFeasiblePred = true;
         }
         else if (SVFUtil::isa<RetCFGEdge>(edge))
         {
@@ -235,6 +241,7 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
             {
             case TOP:
                 merged.joinWith(getAbsState(pred));
+                hasFeasiblePred = true;
                 break;
             case WIDEN_ONLY:
             case WIDEN_NARROW:
@@ -242,14 +249,17 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
                 const RetICFGNode* returnSite = SVFUtil::dyn_cast<RetICFGNode>(node);
                 const CallICFGNode* callSite = returnSite->getCallICFGNode();
                 if (hasAbsState(callSite))
+                {
                     merged.joinWith(getAbsState(pred));
+                    hasFeasiblePred = true;
+                }
                 break;
             }
             }
         }
     }
 
-    if (merged.getVarToVal().empty() && merged.getLocToVal().empty())
+    if (!hasFeasiblePred)
         return false;
 
     updateAbsState(node, merged);
@@ -859,6 +869,115 @@ void AbstractInterpretation::handleFunCall(const CallICFGNode *callNode)
 ///       int factorial(int n) { return n <= 1 ? 1 : n * factorial(n-1); }
 ///       factorial(5) -> returns [10000, 10000] (precise after narrowing)
 
+// ---------------------------------------------------------------------------
+// Semi-sparse cycle helpers
+// ---------------------------------------------------------------------------
+//
+// In semi-sparse mode, ValVars live at their def-sites and do not flow
+// through the cycle-head merge. The around-merge widening at cycle_head
+// therefore cannot observe ValVar growth across iterations (e.g. an
+// ArgValVar that a recursive CallPE keeps overwriting at the FunEntry).
+//
+// To fix that, handleLoopOrRecursion runs an extra cross-iter widening on
+// a snapshot that pulls every cycle ValVar into cycle_head's state. The set
+// of ValVar IDs per cycle is precomputed once after PreAnalysis::initWTO()
+// (initCycleValVars), bottom-up so nested cycles are handled before their
+// enclosing cycle.
+
+AbstractState AbstractInterpretation::getFullCycleHeadState(const ICFGCycleWTO* cycle)
+{
+    const ICFGNode* cycle_head = cycle->head()->getICFGNode();
+    AbstractState snap;
+    if (hasAbsState(cycle_head))
+        snap = getAbsState(cycle_head);
+
+    const Set<NodeID>* ids = preAnalysis->getCycleValVars(cycle);
+    if (!ids)
+        return snap;  // dense mode: snap already has everything
+
+    // Semi-sparse: drop any stale ValVar entries cached at cycle_head,
+    // then pull each cycle ValVar from its def-site.
+    snap.clearVars();
+
+    auto& trace = svfStateMgr->getTrace();
+    for (NodeID id : *ids)
+    {
+        const ValVar* v = SVFUtil::dyn_cast<ValVar>(svfir->getSVFVar(id));
+        if (!v) continue;
+        const ICFGNode* defSite = v->getICFGNode();
+        if (!defSite) continue;
+        auto tit = trace.find(defSite);
+        if (tit == trace.end()) continue;
+        const auto& dmap = tit->second.getVarToVal();
+        auto dit = dmap.find(id);
+        if (dit == dmap.end()) continue;
+        snap[id] = dit->second;
+    }
+
+    // Scatter the collected ValVars back to def-sites for consistency.
+    scatterCycleValVars(snap, cycle);
+    return snap;
+}
+
+void AbstractInterpretation::scatterCycleValVars(
+    const AbstractState& snap, const ICFGCycleWTO* cycle)
+{
+    const Set<NodeID>* ids = preAnalysis->getCycleValVars(cycle);
+    if (!ids) return;
+    auto& trace = svfStateMgr->getTrace();
+    for (NodeID id : *ids)
+    {
+        const ValVar* v = SVFUtil::dyn_cast<ValVar>(svfir->getSVFVar(id));
+        if (!v) continue;
+        const ICFGNode* defSite = v->getICFGNode();
+        if (!defSite) continue;
+        auto kv = snap.getVarToVal().find(id);
+        if (kv == snap.getVarToVal().end()) continue;
+        trace[defSite][id] = kv->second;
+    }
+}
+
+// --- Cycle state helpers (dense/sparse unified) ---
+
+bool AbstractInterpretation::widenCycleState(
+    AbstractState& prev, const AbstractState& cur,
+    const ICFGNode* cycle_head, const ICFGCycleWTO* cycle)
+{
+    AbstractState next = prev.widening(cur);
+    // Always write the widened result to trace, even at fixpoint.
+    // At fixpoint (next == prev), this restores cycle_head to the
+    // pre-merge widened state.  The subsequent narrowing phase then
+    // sees the widened values, runs the body at least once with the
+    // narrowed head state, and correctly updates cycle-body nodes.
+    // Without this write, the narrowing phase would immediately
+    // reach fixpoint (head already has the merged/narrowed value)
+    // and never re-process the body — leaving body nodes with stale
+    // widened values that leak to loop-exit successors.
+    bool fixpoint = (next == prev);
+    prev = std::move(next);
+    svfStateMgr->getTrace()[cycle_head] = prev;
+    if (Options::AESparsity() == AESparsity::SemiSparse)
+        scatterCycleValVars(prev, cycle);
+    return fixpoint;
+}
+
+bool AbstractInterpretation::narrowCycleState(
+    AbstractState& prev, const AbstractState& cur,
+    const ICFGNode* cycle_head, const ICFGCycleWTO* cycle)
+{
+    if (!shouldApplyNarrowing(cycle_head->getFun()))
+        return true;  // narrowing disabled for this function
+    AbstractState next = prev.narrowing(cur);
+    if (next == prev)
+        return true;  // fixpoint
+    prev = std::move(next);
+    svfStateMgr->getTrace()[cycle_head] = prev;
+    if (Options::AESparsity() == AESparsity::SemiSparse)
+        scatterCycleValVars(prev, cycle);
+    return false;
+}
+
+
 void AbstractInterpretation::handleLoopOrRecursion(const ICFGCycleWTO* cycle, const CallICFGNode* caller)
 {
     const ICFGNode* cycle_head = cycle->head()->getICFGNode();
@@ -874,35 +993,30 @@ void AbstractInterpretation::handleLoopOrRecursion(const ICFGCycleWTO* cycle, co
     // Iterate until fixpoint with widening/narrowing on the cycle head.
     bool increasing = true;
     u32_t widen_delay = Options::WidenDelay();
-    auto& abstractTrace = svfStateMgr->getTrace();
     for (u32_t cur_iter = 0;; cur_iter++)
     {
         if (cur_iter >= widen_delay)
         {
-            // Save state before processing head
-            AbstractState prev_head_state = abstractTrace[cycle_head];
+            // Save state before processing head.  getFullCycleHeadState
+            // handles both dense (returns trace[cycle_head] as-is) and
+            // semi-sparse (collects ValVars from def-sites) uniformly.
+            AbstractState prev_head_state = getFullCycleHeadState(cycle);
 
-            // Process cycle head: merge from predecessors, then execute statements
             if (mergeStatesFromPredecessors(cycle_head))
                 handleICFGNode(cycle_head);
-            AbstractState cur_head_state = abstractTrace[cycle_head];
+            AbstractState cur_head_state = getFullCycleHeadState(cycle);
 
             if (increasing)
             {
-                abstractTrace[cycle_head] = prev_head_state.widening(cur_head_state);
-                if (abstractTrace[cycle_head] == prev_head_state)
+                if (widenCycleState(prev_head_state, cur_head_state, cycle_head, cycle))
                 {
-                    // Widening fixpoint reached; switch to narrowing phase.
                     increasing = false;
                     continue;
                 }
             }
             else
             {
-                if (!shouldApplyNarrowing(cycle_head->getFun()))
-                    break;
-                abstractTrace[cycle_head] = prev_head_state.narrowing(cur_head_state);
-                if (abstractTrace[cycle_head] == prev_head_state)
+                if (narrowCycleState(prev_head_state, cur_head_state, cycle_head, cycle))
                     break;
             }
         }

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -520,3 +520,26 @@ const ICFGNode* AbstractStateManager::getDefSiteOfObjVar(const ObjVar* obj, cons
         return edge->getSrcNode();
     return nullptr;
 }
+
+Map<const ValVar*, AbstractValue> AbstractStateManager::getCycleAbsValues(const Set<const ValVar*>& valVars)
+{
+    Map<const ValVar*, AbstractValue> snap;
+    for (const ValVar* v : valVars)
+    {
+        const ICFGNode* defSite = v->getICFGNode();
+        if (!defSite) continue;
+        // Skip ValVars whose def-site hasn't been processed yet, or whose
+        // value hasn't been stored there.  Using getAbstractValue here would
+        // return IntervalValue::top() as a fallback, which when later written
+        // back to the def-site via updateAbsValue contaminates every body
+        // node and defeats widening/narrowing precision (e.g. breaks
+        // semi-sparse recursion tests).
+        auto it = abstractTrace.find(defSite);
+        if (it == abstractTrace.end()) continue;
+        const auto& varMap = it->second.getVarToVal();
+        auto kv = varMap.find(v->getId());
+        if (kv == varMap.end()) continue;
+        snap[v] = kv->second;
+    }
+    return snap;
+}

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -586,18 +586,3 @@ const ICFGNode* AbstractStateManager::getDefSiteOfObjVar(const ObjVar* obj, cons
     return nullptr;
 }
 
-Map<const ValVar*, AbstractValue> AbstractStateManager::getCycleAbsValues(const Set<const ValVar*>& valVars)
-{
-    Map<const ValVar*, AbstractValue> snap;
-    for (const ValVar* v : valVars)
-    {
-        const ICFGNode* defSite = v->getICFGNode();
-        // Only snapshot ValVars that genuinely have a stored value.
-        // getAbstractValue would otherwise top-fallback for uninitialised
-        // ValVars, and that top, written back to def-sites by widen/narrow,
-        // contaminates body nodes and defeats precision.
-        if (!defSite || !hasAbstractValue(v, defSite)) continue;
-        snap[v] = getAbstractValue(v, defSite);
-    }
-    return snap;
-}

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -174,6 +174,71 @@ const AbstractValue& AbstractStateManager::getAbstractValue(const SVFVar* var, c
 }
 
 // ===----------------------------------------------------------------------===//
+//  hasAbstractValue — side-effect-free existence check
+//
+//  Mirrors the lookup chain in getAbstractValue but stops short of the
+//  top-fallback.  Returns false when getAbstractValue would only be able
+//  to return top as a default.
+// ===----------------------------------------------------------------------===//
+
+bool AbstractStateManager::hasAbstractValue(const ValVar* var, const ICFGNode* node) const
+{
+    // Constants are always "present" (their value is intrinsic).
+    if (SVFUtil::isa<ConstIntValVar>(var) || SVFUtil::isa<ConstFPValVar>(var) ||
+            SVFUtil::isa<ConstNullPtrValVar>(var) || SVFUtil::isa<ConstDataValVar>(var))
+        return true;
+
+    u32_t id = var->getId();
+    bool semiSparse = Options::AESparsity() == AbstractInterpretation::AESparsity::SemiSparse;
+
+    // Dense mode: stored at the current node.
+    if (!semiSparse)
+    {
+        auto it = abstractTrace.find(node);
+        if (it != abstractTrace.end() &&
+                (it->second.inVarToValTable(id) || it->second.inVarToAddrsTable(id)))
+            return true;
+    }
+
+    // Semi-sparse (and dense fall-through): check the def-site.
+    const ICFGNode* defNode = var->getICFGNode();
+    if (defNode)
+    {
+        auto it = abstractTrace.find(defNode);
+        if (it != abstractTrace.end() && it->second.getVarToVal().count(id))
+            return true;
+
+        // Fallback for call-result ValVars: value lives at the RetICFGNode.
+        if (const CallICFGNode* callNode = SVFUtil::dyn_cast<CallICFGNode>(defNode))
+        {
+            const RetICFGNode* retNode = callNode->getRetICFGNode();
+            auto rit = abstractTrace.find(retNode);
+            if (rit != abstractTrace.end() && rit->second.getVarToVal().count(id))
+                return true;
+        }
+    }
+    return false;
+}
+
+bool AbstractStateManager::hasAbstractValue(const ObjVar* var, const ICFGNode* node) const
+{
+    auto it = abstractTrace.find(node);
+    if (it == abstractTrace.end())
+        return false;
+    u32_t objId = var->getId();
+    return it->second.getLocToVal().count(objId) != 0;
+}
+
+bool AbstractStateManager::hasAbstractValue(const SVFVar* var, const ICFGNode* node) const
+{
+    if (const ObjVar* objVar = SVFUtil::dyn_cast<ObjVar>(var))
+        return hasAbstractValue(objVar, node);
+    if (const ValVar* valVar = SVFUtil::dyn_cast<ValVar>(var))
+        return hasAbstractValue(valVar, node);
+    return false;
+}
+
+// ===----------------------------------------------------------------------===//
 //  Update Abstract Value
 // ===----------------------------------------------------------------------===//
 
@@ -527,19 +592,12 @@ Map<const ValVar*, AbstractValue> AbstractStateManager::getCycleAbsValues(const 
     for (const ValVar* v : valVars)
     {
         const ICFGNode* defSite = v->getICFGNode();
-        if (!defSite) continue;
-        // Skip ValVars whose def-site hasn't been processed yet, or whose
-        // value hasn't been stored there.  Using getAbstractValue here would
-        // return IntervalValue::top() as a fallback, which when later written
-        // back to the def-site via updateAbsValue contaminates every body
-        // node and defeats widening/narrowing precision (e.g. breaks
-        // semi-sparse recursion tests).
-        auto it = abstractTrace.find(defSite);
-        if (it == abstractTrace.end()) continue;
-        const auto& varMap = it->second.getVarToVal();
-        auto kv = varMap.find(v->getId());
-        if (kv == varMap.end()) continue;
-        snap[v] = kv->second;
+        // Only snapshot ValVars that genuinely have a stored value.
+        // getAbstractValue would otherwise top-fallback for uninitialised
+        // ValVars, and that top, written back to def-sites by widen/narrow,
+        // contaminates body nodes and defeats precision.
+        if (!defSite || !hasAbstractValue(v, defSite)) continue;
+        snap[v] = getAbstractValue(v, defSite);
     }
     return snap;
 }

--- a/svf/lib/AE/Svfexe/PreAnalysis.cpp
+++ b/svf/lib/AE/Svfexe/PreAnalysis.cpp
@@ -129,7 +129,7 @@ void PreAnalysis::initCycleValVars()
     // map when we reach their enclosing cycle.
     for (const ICFGCycleWTO* cycle : cycles)
     {
-        Set<NodeID>& out = cycleToValVars[cycle];
+        Set<const ValVar*>& out = cycleToValVars[cycle];
 
         // Gather every ICFG node in this cycle (head + body singletons).
         // For nested sub-cycles, merge their already-computed sets instead.
@@ -154,7 +154,7 @@ void PreAnalysis::initCycleValVars()
                 else if (const MultiOpndStmt* m = SVFUtil::dyn_cast<MultiOpndStmt>(stmt))
                     lhs = m->getRes();
                 if (lhs)
-                    out.insert(lhs->getId());
+                    out.insert(lhs);
             }
             // FunEntryICFGNode owns ArgValVars (formal parameters) that have
             // no defining stmt at the entry — the CallPE lives on the caller
@@ -164,7 +164,7 @@ void PreAnalysis::initCycleValVars()
             {
                 for (const SVFVar* fp : fe->getFormalParms())
                     if (const ValVar* v = SVFUtil::dyn_cast<ValVar>(fp))
-                        out.insert(v->getId());
+                        out.insert(v);
             }
         }
     }


### PR DESCRIPTION
Based on upstream/master (post #1809 merge). Changes on top:

- Add getFullCycleHeadState, scatterCycleValVars, widenCycleState, narrowCycleState for semi-sparse loop support. Update handleLoopOrRecursion to use unified cycle helpers.
- widenCycleState always writes to trace (even at fixpoint) so the narrowing phase correctly re-processes cycle-body nodes.
- Inline setTopToObjInRecursion into skipRecursionWithTop; remove duplicate return-value-to-top code.
- Fix dense getAbstractValue: fall through to def-site lookup when ValVar is absent at current node (matches upstream behaviour).
- Use hasFeasiblePred flag in mergeStatesFromPredecessors instead of checking merged state emptiness (which fails in semi-sparse when ValVar maps are empty but predecessors are reachable).
- Add AbstractState::updateAddrStateOnly; delete utils in destructor.
- Pass IntervalValue by const ref in handleMemcpy/handleMemset.
- Re-add semi-sparse CI test step.