### PR TITLE
Draft Full sparse  (should talk about functions)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,9 @@ target_link_options(
 # =================================================================================
 
 # (1) Generate config.h into <build_tree>/include/SVF/Util; (2) Install it under <install_prefix>/include/SVF/Util
+# SVF_BUILD_DIR is consumed by the template (@SVF_BUILD_DIR@) and by ExtAPI.cpp
+# at compile time to locate extapi.bc in a dev-build tree.
+set(SVF_BUILD_DIR "${SVF_BINARY_DIR}")
 configure_file(${SVF_SOURCE_DIR}/cmake/SVFConfigHdr.cmake.in ${SVF_BINARY_DIR}/include/Util/config.h @ONLY)
 install(FILES ${SVF_BINARY_DIR}/include/Util/config.h DESTINATION ${SVF_INSTALL_INCLUDEDIR}/Util)
 

--- a/svf-llvm/tools/AE/ae.cpp
+++ b/svf-llvm/tools/AE/ae.cpp
@@ -894,6 +894,10 @@ int main(int argc, char** argv)
         ae.addDetector(std::make_unique<NullptrDerefDetector>());
     ae.runOnModule(pag->getICFG());
 
+    // Destroy the AE singleton (and its SVFG, if any) before globals are
+    // released — otherwise ~SVFG runs during static destruction with
+    // dangling LLVM pointers and crashes in Sparse mode.
+    AbstractInterpretation::releaseAEInstance();
     AndersenWaveDiff::releaseAndersenWaveDiff();
     LLVMModuleSet::releaseLLVMModuleSet();
 

--- a/svf/include/AE/Svfexe/AbstractInterpretation.h
+++ b/svf/include/AE/Svfexe/AbstractInterpretation.h
@@ -88,9 +88,6 @@ public:
         WIDEN_NARROW
     };
 
-    /// Constructor
-    AbstractInterpretation();
-
     virtual void runOnModule(ICFG* icfg);
 
     /// Destructor
@@ -105,12 +102,18 @@ public:
     /// Get all entry point functions (functions without callers)
     std::deque<const FunObjVar*> collectProgEntryFuns();
 
+    /// Factory: returns the singleton instance.  The concrete class is
+    /// chosen once, on first call, from `Options::AESparsity()`:
+    /// semi-sparse / sparse builds a `SparseAbstractInterpretation`,
+    /// dense builds the base.  Must be called only after the option
+    /// parser has run.
+    static AbstractInterpretation& getAEInstance();
 
-    static AbstractInterpretation& getAEInstance()
-    {
-        static AbstractInterpretation instance;
-        return instance;
-    }
+    /// Tear down the singleton eagerly.  Callers must invoke this before
+    /// releasing LLVM / Andersen globals, otherwise `~SVFG` (owned by
+    /// `AbstractStateManager`) runs during static destruction with stale
+    /// LLVM IR pointers and crashes.
+    static void releaseAEInstance();
 
     void addDetector(std::unique_ptr<AEDetector> detector)
     {
@@ -167,6 +170,31 @@ public:
     /// Propagate an ObjVar's abstract value from defSite to all its use-sites.
     void propagateObjVarAbsVal(const ObjVar* var, const ICFGNode* defSite);
 
+protected:
+    /// Factory-only construction.  External callers must use getAEInstance();
+    /// `SparseAbstractInterpretation` reaches this via its own ctor.
+    AbstractInterpretation();
+
+    // ---- Cycle helpers overridden by SparseAbstractInterpretation ----
+    // The dense versions write only to trace[cycle_head].  The semi-sparse
+    // subclass adds def-site scatter on top for body ValVars.
+
+    /// Build a full cycle-head AbstractState.  Dense default: trace[cycle_head]
+    /// as-is.  Semi-sparse subclass: also pull cycle ValVars from def-sites.
+    virtual AbstractState getFullCycleHeadState(const ICFGCycleWTO* cycle);
+
+    /// Widen prev with cur; write the widened state to trace[cycle_head].
+    /// Returns true when next == prev (fixpoint).  Semi-sparse subclass
+    /// additionally scatters ValVars to their def-sites.
+    virtual bool widenCycleState(const AbstractState& prev, const AbstractState& cur,
+                                 const ICFGCycleWTO* cycle);
+
+    /// Narrow prev with cur; write the narrowed state back.  Returns true
+    /// when narrowing is disabled or the narrowed state equals prev.
+    /// Semi-sparse subclass scatters the narrowed ValVars on non-fixpoint.
+    virtual bool narrowCycleState(const AbstractState& prev, const AbstractState& cur,
+                                  const ICFGCycleWTO* cycle);
+
 private:
     /// Initialize abstract state for the global ICFG node and process global statements
     virtual void handleGlobalNode();
@@ -176,38 +204,16 @@ private:
     /// abstractTrace[node]. Returns true if at least one predecessor had state.
     bool mergeStatesFromPredecessors(const ICFGNode* node);
 
-    /// Returns true if the branch is reachable; narrows as in-place.
-    bool isBranchFeasible(const IntraCFGEdge* edge, AbstractState& as);
+    /// Returns true if the branch is reachable.
+    /// See isCmpBranchFeasible for narrowingDelta semantics.
+    bool isBranchFeasible(const IntraCFGEdge* edge, AbstractState& as,
+                          Map<NodeID, AbstractValue>* narrowingDelta = nullptr);
 
     /// Handle a call site node: dispatch to ext-call, direct-call, or indirect-call handling
     virtual void handleCallSite(const ICFGNode* node);
 
     /// Handle a WTO cycle (loop or recursive function) using widening/narrowing iteration
     virtual void handleLoopOrRecursion(const ICFGCycleWTO* cycle, const CallICFGNode* caller = nullptr);
-
-    // ---- Semi-sparse cycle helpers ----
-    // ValVars whose def-site is inside the cycle but NOT cycle_head do not
-    // flow through cycle_head's merge in semi-sparse mode, so the around-merge
-    // widening cannot observe them.  getFullCycleHeadState pulls these ValVars
-    // into a single AbstractState snapshot so widen/narrow can treat ValVars
-    // and ObjVars uniformly; after widen/narrow we scatter the ValVars back
-    // to their def-sites.
-
-    /// Build a full cycle-head AbstractState: the ObjVars currently at
-    /// cycle_head combined with every cycle ValVar pulled from its
-    /// def-site.  Skips ValVars without a stored value to avoid the
-    /// top-fallback contamination.  In dense mode this is equivalent to
-    /// trace[cycle_head] since ValVars already live there.
-    AbstractState getFullCycleHeadState(const ICFGCycleWTO* cycle);
-
-    /// Widen prev with cur; write the widened state to trace[cycle_head]
-    /// and scatter its ValVars back to their def-sites.  Returns true
-    /// when the widened result equals prev (fixpoint).
-    bool widenCycleState(const AbstractState& prev, const AbstractState& cur,
-                         const ICFGCycleWTO* cycle);
-    /// Narrow prev with cur; write the narrowed state back and scatter.
-    bool narrowCycleState(const AbstractState& prev, const AbstractState& cur,
-                          const ICFGCycleWTO* cycle);
 
     /// Handle a function body via worklist-driven WTO traversal starting from funEntry
     void handleFunction(const ICFGNode* funEntry, const CallICFGNode* caller = nullptr);
@@ -218,11 +224,19 @@ private:
     /// Dispatch an SVF statement (Addr/Binary/Cmp/Load/Store/Copy/Gep/Select/Phi/Call/Ret) to its handler
     virtual void handleSVFStatement(const SVFStmt* stmt);
 
-    /// Returns true if the cmp-conditional branch is feasible; narrows as in-place.
-    bool isCmpBranchFeasible(const IntraCFGEdge* edge, AbstractState& as);
+    /// Returns true if the cmp-conditional branch is feasible.
+    /// Narrowing behaviour:
+    ///   - Dense/Semi: mutates `as._addrToAbsVal` in place (existing path).
+    ///   - Full-sparse: if `narrowingDelta` is non-null, populates it with
+    ///     per-obj narrowed intervals instead of mutating `as`. Caller folds
+    ///     the delta into `pathRefinedAt` on the successor.
+    bool isCmpBranchFeasible(const IntraCFGEdge* edge, AbstractState& as,
+                             Map<NodeID, AbstractValue>* narrowingDelta = nullptr);
 
-    /// Returns true if the switch branch is feasible; narrows as in-place.
-    bool isSwitchBranchFeasible(const IntraCFGEdge* edge, AbstractState& as);
+    /// Returns true if the switch branch is feasible.
+    /// See isCmpBranchFeasible for delta-output semantics.
+    bool isSwitchBranchFeasible(const IntraCFGEdge* edge, AbstractState& as,
+                                Map<NodeID, AbstractValue>* narrowingDelta = nullptr);
 
     void updateStateOnAddr(const AddrStmt *addr);
 
@@ -246,16 +260,12 @@ private:
 
     void updateStateOnPhi(const PhiStmt *phi);
 
-    /// protected data members, also used in subclasses
-    SVFIR* svfir;
     /// Execution State, used to store the Interval Value of every SVF variable
     AEAPI* api{nullptr};
 
     ICFG* icfg;
     CallGraph* callGraph;
     AEStat* stat;
-
-    PreAnalysis* preAnalysis{nullptr};
 
     AbsExtAPI* getUtils()
     {
@@ -272,18 +282,22 @@ private:
 
     bool skipRecursiveCall(const CallICFGNode* callNode);
     const FunObjVar* getCallee(const CallICFGNode* callNode);
-    bool shouldApplyNarrowing(const FunObjVar* fun);
 
     // there data should be shared with subclasses
     Map<std::string, std::function<void(const CallICFGNode*)>> func_map;
 
-    AbstractStateManager* svfStateMgr{nullptr}; // state management (owns abstractTrace)
     Set<const ICFGNode*> allAnalyzedNodes; // All nodes ever analyzed (across all entry points)
     std::string moduleName;
 
     std::vector<std::unique_ptr<AEDetector>> detectors;
     AbsExtAPI* utils;
 
+protected:
+    /// Data and helpers reachable from SparseAbstractInterpretation.
+    SVFIR* svfir;
+    PreAnalysis* preAnalysis{nullptr};
+    AbstractStateManager* svfStateMgr{nullptr}; // state management (owns abstractTrace)
 
+    bool shouldApplyNarrowing(const FunObjVar* fun);
 };
 }

--- a/svf/include/AE/Svfexe/AbstractStateManager.h
+++ b/svf/include/AE/Svfexe/AbstractStateManager.h
@@ -33,6 +33,7 @@ namespace SVF
 class GepStmt;
 class AddrStmt;
 class SVFG;
+class SVFGBuilder;
 class AndersenWaveDiff;
 
 /// Manages abstract states across ICFG nodes and provides a unified API
@@ -176,10 +177,42 @@ public:
     /// Given an ObjVar and its use-site ICFGNode, find the definition-site ICFGNode.
     const ICFGNode* getDefSiteOfObjVar(const ObjVar* obj, const ICFGNode* node) const;
 
+    /// Full-sparse per-kind MSSA def-anchor transfers (Phase A of
+    /// plan/plan-per-kind-transfers.md). Each is a no-op if the given ICFG
+    /// node carries no SVFG node of the matching kind; called unconditionally
+    /// from the WTO driver. Their job is to populate
+    /// trace[N]._addrToAbsVal[obj] for every obj served by a def-anchor
+    /// hosted at N, so that readers reaching N via getDefSiteOfObjVar find
+    /// a value there regardless of whether merge has been gated.
+    void runMSSAPHITransferAt(const ICFGNode* N);
+    void runFormalINTransferAt(const ICFGNode* N);
+    void runActualOUTTransferAt(const ICFGNode* N);
+
+    /// Full-sparse branch-refinement overlay. Keyed by ICFG node, maps
+    /// per-obj narrowed interval accumulated along the path into that node.
+    /// Populated by mergeStatesFromPredecessors folding each feasible
+    /// edge's narrowingDelta (from isBranchFeasible) via per-obj meet.
+    /// Read by getAbstractValue(ObjVar*, useNode) which composes the
+    /// overlay with the def-anchor base value via meet at read time.
+    ///
+    /// Rationale: branch refinement is the one "def-like" effect MSSA does
+    /// not model (cmp is not a def in SSA). An overlay handles it at the
+    /// AE layer without polluting def-anchor traces or adding SVFG nodes.
+    Map<const ICFGNode*, Map<NodeID, AbstractValue>>& getPathRefinedAt()
+    {
+        return pathRefinedAt;
+    }
+
 private:
     SVFIR* svfir;
+    // SVFG is owned by svfgBuilder's internal unique_ptr; `svfg` is a view
+    // pointer into it.  Keeping the builder alive here prevents the
+    // unique_ptr from destroying the graph when the builder goes out of
+    // scope (the root cause of a Sparse-mode ~AbstractStateManager crash).
+    std::unique_ptr<SVFGBuilder> svfgBuilder;
     SVFG* svfg;
     Map<const ICFGNode*, AbstractState> abstractTrace;
+    Map<const ICFGNode*, Map<NodeID, AbstractValue>> pathRefinedAt;
 };
 
 } // namespace SVF

--- a/svf/include/AE/Svfexe/AbstractStateManager.h
+++ b/svf/include/AE/Svfexe/AbstractStateManager.h
@@ -214,6 +214,20 @@ private:
     AndersenWaveDiff* pta;
     Map<const ICFGNode*, AbstractState> abstractTrace;
     Map<const ICFGNode*, Map<NodeID, AbstractValue>> pathRefinedAt;
+
+    /// Flow-insensitive overlay for GepObjVar values (Phase D).
+    /// MSSA tracks neither GepObjVar def chains nor LDMU/CHI annotations
+    /// on field-precise ids, so the per-node trace + def-site routing
+    /// cannot reach AE-refined GEP fields.  This single global map
+    /// (keyed by GepObjVar's NodeID — already encodes (base, offset)
+    /// uniquely via SVFIR::getGepObjVar) holds the join of every write
+    /// to each AE-precise GEP field across the program.  All Sparse
+    /// reads for a GepObjVar consult this overlay first.
+    ///
+    /// Trade-off: flow-insensitive — `a[3]=7; a[3]=11` joins to [7,11]
+    /// instead of strong-updating to 11.  Acceptable when measured on
+    /// real programs against BFS / Dense.
+    Map<NodeID, AbstractValue> gepOverlay;
 };
 
 } // namespace SVF

--- a/svf/include/AE/Svfexe/AbstractStateManager.h
+++ b/svf/include/AE/Svfexe/AbstractStateManager.h
@@ -211,6 +211,7 @@ private:
     // scope (the root cause of a Sparse-mode ~AbstractStateManager crash).
     std::unique_ptr<SVFGBuilder> svfgBuilder;
     SVFG* svfg;
+    AndersenWaveDiff* pta;
     Map<const ICFGNode*, AbstractState> abstractTrace;
     Map<const ICFGNode*, Map<NodeID, AbstractValue>> pathRefinedAt;
 };

--- a/svf/include/AE/Svfexe/PreAnalysis.h
+++ b/svf/include/AE/Svfexe/PreAnalysis.h
@@ -95,7 +95,7 @@ private:
 
     Map<const FunObjVar*, const ICFGWTO*> funcToWTO;
 
-    /// Pre-computed (semi-sparse only) map from a WTO cycle to the IDs of
+    /// Pre-computed (semi-sparse / sparse) map from a WTO cycle to the IDs of
     /// every ValVar whose def-site is inside that cycle, including all
     /// nested sub-cycles. Empty in dense mode.
     Map<const ICFGCycleWTO*, Set<const ValVar*>> cycleToValVars;

--- a/svf/include/AE/Svfexe/SparseAbstractInterpretation.h
+++ b/svf/include/AE/Svfexe/SparseAbstractInterpretation.h
@@ -1,0 +1,68 @@
+//===- SparseAbstractInterpretation.h -- Sparse Abstract Execution------//
+//
+//                     SVF: Static Value-Flow Analysis
+//
+// Copyright (C) <2013->  <Yulei Sui>
+//
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef INCLUDE_AE_SVFEXE_SPARSEABSTRACTINTERPRETATION_H_
+#define INCLUDE_AE_SVFEXE_SPARSEABSTRACTINTERPRETATION_H_
+
+#include "AE/Svfexe/AbstractInterpretation.h"
+
+namespace SVF
+{
+
+/// Abstract Interpretation driver for sparse modes (currently semi-sparse).
+///
+/// ValVars whose def-site is inside a cycle but NOT at cycle_head do not
+/// flow through cycle_head's merge in semi-sparse mode, so the around-merge
+/// widening cannot observe them.  This subclass overrides the three cycle
+/// helpers in AbstractInterpretation:
+///
+///   * getFullCycleHeadState   — in addition to the base's trace read,
+///                               pulls cycle ValVars from their def-sites
+///                               into the transient AbstractState.
+///   * widenCycleState         — after the base widens and writes trace,
+///                               scatters the widened ValVars back to their
+///                               def-sites so body nodes observe them.
+///   * narrowCycleState        — same scatter on non-fixpoint narrowing.
+///
+/// Selected once, at first call to AbstractInterpretation::getAEInstance(),
+/// when Options::AESparsity() == SemiSparse.
+class SparseAbstractInterpretation : public AbstractInterpretation
+{
+public:
+    SparseAbstractInterpretation() = default;
+    ~SparseAbstractInterpretation() override = default;
+
+protected:
+    AbstractState getFullCycleHeadState(const ICFGCycleWTO* cycle) override;
+
+    bool widenCycleState(const AbstractState& prev,
+                         const AbstractState& cur,
+                         const ICFGCycleWTO* cycle) override;
+
+    bool narrowCycleState(const AbstractState& prev,
+                          const AbstractState& cur,
+                          const ICFGCycleWTO* cycle) override;
+};
+
+} // namespace SVF
+
+#endif /* INCLUDE_AE_SVFEXE_SPARSEABSTRACTINTERPRETATION_H_ */

--- a/svf/lib/AE/Core/AbstractState.cpp
+++ b/svf/lib/AE/Core/AbstractState.cpp
@@ -103,10 +103,14 @@ AbstractState AbstractState::narrowing(const AbstractState& other)
 /// domain join with other, important! other widen this.
 void AbstractState::joinWith(const AbstractState& other)
 {
-    // In semi-sparse mode, skip ValVar (_varToAbsVal) merge — ValVars are
-    // pulled on demand from def-sites via getAbstractValue.
-    // In dense mode, merge everything.
-    if (Options::AESparsity() != AbstractInterpretation::AESparsity::SemiSparse)
+    u32_t sparsity = Options::AESparsity();
+    bool skipValVarMerge =
+        sparsity == AbstractInterpretation::AESparsity::SemiSparse ||
+        sparsity == AbstractInterpretation::AESparsity::Sparse;
+
+    // ValVar merge: skipped in semi-sparse and full-sparse (values live at
+    // SVFG def-sites and are pulled on demand).
+    if (!skipValVarMerge)
     {
         for (auto it = other._varToAbsVal.begin(); it != other._varToAbsVal.end(); ++it)
         {
@@ -122,17 +126,30 @@ void AbstractState::joinWith(const AbstractState& other)
             }
         }
     }
-    for (auto it = other._addrToAbsVal.begin(); it != other._addrToAbsVal.end(); ++it)
+    // ObjVar (_addrToAbsVal) merge: skipped in full-sparse only.  Under
+    // full-sparse, values live at their MSSA def-anchors (Store / MSSAPHI /
+    // FormalIN / ActualOUT / ExtAPI-writes) and are filled by the matching
+    // per-kind transfer at the def-anchor's own ICFG visit (see
+    // AbstractStateManager::run{MSSAPHI,FormalIN,ActualOUT}TransferAt).  The
+    // reader routes through getDefSiteOfObjVar to find the anchor, so
+    // propagating copies at every ICFG node is redundant and memory-heavy.
+    // Dense and Semi-Sparse keep merge unchanged.
+    bool skipObjVarMerge =
+        sparsity == AbstractInterpretation::AESparsity::Sparse;
+    if (!skipObjVarMerge)
     {
-        auto key = it->first;
-        auto oit = _addrToAbsVal.find(key);
-        if (oit != _addrToAbsVal.end())
+        for (auto it = other._addrToAbsVal.begin(); it != other._addrToAbsVal.end(); ++it)
         {
-            oit->second.join_with(it->second);
-        }
-        else
-        {
-            _addrToAbsVal.emplace(key, it->second);
+            auto key = it->first;
+            auto oit = _addrToAbsVal.find(key);
+            if (oit != _addrToAbsVal.end())
+            {
+                oit->second.join_with(it->second);
+            }
+            else
+            {
+                _addrToAbsVal.emplace(key, it->second);
+            }
         }
     }
     _freedAddrs.insert(other._freedAddrs.begin(), other._freedAddrs.end());

--- a/svf/lib/AE/Svfexe/AEStat.cpp
+++ b/svf/lib/AE/Svfexe/AEStat.cpp
@@ -22,6 +22,7 @@
 
 #include "AE/Svfexe/AEStat.h"
 #include "AE/Svfexe/AbstractInterpretation.h"
+#include "AE/Svfexe/AbstractStateManager.h"
 #include "SVFIR/SVFIR.h"
 
 using namespace SVF;
@@ -30,13 +31,6 @@ using namespace SVFUtil;
 // count the size of memory map
 void AEStat::countStateSize()
 {
-    if (count == 0)
-    {
-        generalNumMap["ES_Var_AVG_Num"] = 0;
-        generalNumMap["ES_Loc_AVG_Num"] = 0;
-        generalNumMap["ES_Var_Addr_AVG_Num"] = 0;
-        generalNumMap["ES_Loc_Addr_AVG_Num"] = 0;
-    }
     ++count;
 }
 
@@ -44,13 +38,25 @@ void AEStat::countStateSize()
 void AEStat::finializeStat()
 {
     memUsage = getMemUsage();
-    if (count > 0)
+
+    // Total number of entries across every cached AbstractState in the trace.
+    // This is the "state size" retained at the end of analysis — used for
+    // mode comparison (Dense vs Semi vs Full sparse).
+    u64_t totalVar = 0;
+    u64_t totalLoc = 0;
+    u32_t traceNodes = 0;
+    for (const auto& kv : _ae->svfStateMgr->getTrace())
     {
-        generalNumMap["ES_Var_AVG_Num"] /= count;
-        generalNumMap["ES_Loc_AVG_Num"] /= count;
-        generalNumMap["ES_Var_Addr_AVG_Num"] /= count;
-        generalNumMap["ES_Loc_Addr_AVG_Num"] /= count;
+        totalVar += kv.second.getVarToVal().size();
+        totalLoc += kv.second.getLocToVal().size();
+        ++traceNodes;
     }
+    generalNumMap["ES_Var_TOTAL"] = totalVar;
+    generalNumMap["ES_Loc_TOTAL"] = totalLoc;
+    generalNumMap["ES_Var_AVG_Num"] = traceNodes ? totalVar / traceNodes : 0;
+    generalNumMap["ES_Loc_AVG_Num"] = traceNodes ? totalLoc / traceNodes : 0;
+    generalNumMap["ES_Trace_Node_Num"] = traceNodes;
+
     generalNumMap["SVF_STMT_NUM"] = count;
 
     u32_t totalICFGNodes = _ae->svfir->getICFG()->nodeNum;

--- a/svf/lib/AE/Svfexe/AbsExtAPI.cpp
+++ b/svf/lib/AE/Svfexe/AbsExtAPI.cpp
@@ -606,7 +606,21 @@ void AbsExtAPI::handleMemcpy(const ValVar *dst,
             for (const auto &srcAddr: expr_src.getAddrs())
             {
                 u32_t objId = as.getIDFromAddr(srcAddr);
-                if (as.inAddrToValTable(objId) || as.inAddrToAddrsTable(objId))
+                // Route the source read through the sparsity-aware reader
+                // so full-sparse can locate the value at its MSSA def-anchor
+                // (or at globalICFGNode for statically-initialised globals)
+                // rather than in `as` (whose _addrToAbsVal is gated in
+                // full-sparse).
+                const SVFVar* srcSvfVar = PAG::getPAG()->getGNode(objId);
+                const ObjVar* srcObjVar =
+                    SVFUtil::dyn_cast<ObjVar>(srcSvfVar);
+                if (srcObjVar)
+                {
+                    AbstractValue v =
+                        mgr->getAbstractValue(srcObjVar, node);
+                    as.store(dstAddr, v);
+                }
+                else if (as.inAddrToValTable(objId) || as.inAddrToAddrsTable(objId))
                 {
                     as.store(dstAddr, as.load(srcAddr));
                 }

--- a/svf/lib/AE/Svfexe/AbsExtAPI.cpp
+++ b/svf/lib/AE/Svfexe/AbsExtAPI.cpp
@@ -371,7 +371,12 @@ std::string AbsExtAPI::strRead(const ValVar* rhs, const ICFGNode* node)
         AbstractValue val;
         for (const auto &addr: expr0.getAddrs())
         {
-            val.join_with(as.load(addr));
+            NodeID objId = as.getIDFromAddr(addr);
+            const SVFVar* svfVar = PAG::getPAG()->getGNode(objId);
+            if (const ObjVar* objVar = SVFUtil::dyn_cast<ObjVar>(svfVar))
+                val.join_with(mgr->getAbstractValue(objVar, node));
+            else
+                val.join_with(as.load(addr));
         }
         if (!val.getInterval().is_numeral())
         {
@@ -522,7 +527,12 @@ IntervalValue AbsExtAPI::getStrlen(const ValVar *strValue, const ICFGNode* node)
             AbstractValue val;
             for (const auto &addr: expr0.getAddrs())
             {
-                val.join_with(as.load(addr));
+                NodeID objId = as.getIDFromAddr(addr);
+                const SVFVar* svfVar = PAG::getPAG()->getGNode(objId);
+                if (const ObjVar* objVar = SVFUtil::dyn_cast<ObjVar>(svfVar))
+                    val.join_with(mgr->getAbstractValue(objVar, node));
+                else
+                    val.join_with(as.load(addr));
             }
             if (val.getInterval().is_numeral() &&
                     (char) val.getInterval().getIntNumeral() == '\0')
@@ -666,7 +676,15 @@ void AbsExtAPI::handleMemset(const ValVar *dst,
         for (const auto &addr: lhs_gep.getAddrs())
         {
             u32_t objId = as.getIDFromAddr(addr);
-            if (as.inAddrToValTable(objId))
+            const SVFVar* svfVar = PAG::getPAG()->getGNode(objId);
+            const ObjVar* objVar = SVFUtil::dyn_cast<ObjVar>(svfVar);
+            if (objVar)
+            {
+                AbstractValue tmp = mgr->getAbstractValue(objVar, node);
+                tmp.join_with(elem);
+                as.store(addr, tmp);
+            }
+            else if (as.inAddrToValTable(objId))
             {
                 AbstractValue tmp = as.load(addr);
                 tmp.join_with(elem);

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -732,12 +732,14 @@ bool AbstractInterpretation::handleICFGNode(const ICFGNode* node)
     // No-op for Dense/Semi; under Sparse each call populates
     // trace[node]._addrToAbsVal[obj] for every obj served by a matching
     // SVFG def node hosted at `node` (FormalIN at function entries, MSSAPHI
-    // at block joins). ActualOUT is deferred until after handleCallSite so
-    // the ExtAPI handler path has already written its values and the normal
-    // callee branch has had its FunExit analysed. See
-    // plan/plan-per-kind-transfers.md §"Driver integration".
+    // at block joins). ActualOUT is fired when we visit the RetICFGNode
+    // (its post-merge hook), NOT the CallICFGNode: APOUT VFG nodes are
+    // hosted at the retNode, and committing at callNode time would get
+    // wiped when retNode's own merge runs next in WTO order.
     svfStateMgr->runFormalINTransferAt(node);
     svfStateMgr->runMSSAPHITransferAt(node);
+    if (SVFUtil::isa<RetICFGNode>(node))
+        svfStateMgr->runActualOUTTransferAt(node);
 
     // Handle SVF statements
     for (const SVFStmt *stmt: node->getSVFStmts())
@@ -749,7 +751,6 @@ bool AbstractInterpretation::handleICFGNode(const ICFGNode* node)
     if (const CallICFGNode* callNode = SVFUtil::dyn_cast<CallICFGNode>(node))
     {
         handleCallSite(callNode);
-        svfStateMgr->runActualOUTTransferAt(callNode);
     }
 
     // Run detectors

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -27,6 +27,7 @@
 //
 
 #include "AE/Svfexe/AbstractInterpretation.h"
+#include "AE/Svfexe/SparseAbstractInterpretation.h"
 #include "AE/Svfexe/AbsExtAPI.h"
 #include "SVFIR/SVFIR.h"
 #include "Util/Options.h"
@@ -35,6 +36,7 @@
 #include "WPA/Andersen.h"
 #include <cmath>
 #include <deque>
+#include <memory>
 
 using namespace SVF;
 using namespace SVFUtil;
@@ -71,6 +73,36 @@ void AbstractInterpretation::runOnModule(ICFG *_icfg)
 AbstractInterpretation::AbstractInterpretation()
 {
     stat = new AEStat(this);
+}
+
+/// Factory: first call allocates the concrete subclass based on
+/// Options::AESparsity(); all subsequent calls return the same instance.
+/// Must only be called after the option parser has populated AESparsity.
+namespace
+{
+// File-scope singleton so `releaseAEInstance()` can destroy it before
+// LLVM / Andersen globals go down (avoids a ~SVFG use-after-free in
+// static destruction order).
+AbstractInterpretation* g_aeInstance = nullptr;
+}
+
+AbstractInterpretation& AbstractInterpretation::getAEInstance()
+{
+    if (!g_aeInstance)
+    {
+        u32_t sparsity = Options::AESparsity();
+        if (sparsity == AESparsity::SemiSparse || sparsity == AESparsity::Sparse)
+            g_aeInstance = new SparseAbstractInterpretation();
+        else
+            g_aeInstance = new AbstractInterpretation();
+    }
+    return *g_aeInstance;
+}
+
+void AbstractInterpretation::releaseAEInstance()
+{
+    delete g_aeInstance;
+    g_aeInstance = nullptr;
 }
 
 
@@ -206,6 +238,54 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
     // Collect all feasible predecessor states, then merge at the end.
     AbstractState merged;
     bool hasFeasiblePred = false;
+    bool sparse = Options::AESparsity() == AESparsity::Sparse;
+
+    // Full-sparse: accumulate predecessor path-refinements into this node's
+    // overlay. An obj's refinement holds at `node` only if EVERY feasible
+    // incoming path contributes a refinement for it (either inherited from
+    // pred's overlay or supplied by this edge's narrowingDelta). If even
+    // one pred has no refinement for an obj, the result is "unrefined at
+    // node" (equivalent to top for that obj — overlay entry dropped).
+    // Across multi-pred, the retained refinements are join'd (interval
+    // union) since the path-sensitive info is now disjunctive.
+    //
+    // Strategy: per pred collect that pred's contribution (inherited
+    // overlay + this edge's narrowingDelta) into `perPredOverlay`, then
+    // fold into `incomingOverlay` by *intersection of keys* (an obj is
+    // kept only if present in every perPredOverlay) with per-obj join.
+    Map<NodeID, AbstractValue> incomingOverlay;  // running result
+    bool sawAnyPred = false;
+    auto mergePredContribution = [&](Map<NodeID, AbstractValue>& perPred)
+    {
+        if (!sparse) return;
+        if (!sawAnyPred)
+        {
+            incomingOverlay = std::move(perPred);
+            sawAnyPred = true;
+            return;
+        }
+        // Intersection-with-join: keep only keys present in both,
+        // join their values.
+        Map<NodeID, AbstractValue> next;
+        for (auto& [objId, v] : incomingOverlay)
+        {
+            auto it = perPred.find(objId);
+            if (it == perPred.end()) continue;
+            AbstractValue merged = v;
+            merged.join_with(it->second);
+            next.emplace(objId, std::move(merged));
+        }
+        incomingOverlay = std::move(next);
+    };
+    auto snapshotPred = [&](const ICFGNode* pred) -> Map<NodeID, AbstractValue>
+    {
+        Map<NodeID, AbstractValue> snap;
+        if (!sparse) return snap;
+        auto pit = svfStateMgr->getPathRefinedAt().find(pred);
+        if (pit != svfStateMgr->getPathRefinedAt().end())
+            snap = pit->second;
+        return snap;
+    };
 
     for (auto& edge : node->getInEdges())
     {
@@ -218,22 +298,48 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
             if (intraCfgEdge->getCondition())
             {
                 AbstractState predState = getAbsState(pred);
-                if (isBranchFeasible(intraCfgEdge, predState))
+                // Full-sparse: collect per-obj narrowing into a delta
+                // instead of mutating predState (whose _addrToAbsVal is
+                // empty anyway under gated merge). The delta is folded
+                // into pathRefinedAt[node] for the reader to compose.
+                Map<NodeID, AbstractValue> narrowingDelta;
+                Map<NodeID, AbstractValue>* deltaPtr =
+                    sparse ? &narrowingDelta : nullptr;
+                if (isBranchFeasible(intraCfgEdge, predState, deltaPtr))
                 {
                     merged.joinWith(predState);
                     hasFeasiblePred = true;
+                    // This pred's overlay contribution = inherited overlay
+                    // tightened by this edge's narrowingDelta (per-obj meet).
+                    auto perPred = snapshotPred(pred);
+                    if (sparse)
+                    {
+                        for (auto& [objId, val] : narrowingDelta)
+                        {
+                            auto pit = perPred.find(objId);
+                            if (pit == perPred.end())
+                                perPred[objId] = val;
+                            else
+                                pit->second.meet_with(val);
+                        }
+                    }
+                    mergePredContribution(perPred);
                 }
             }
             else
             {
                 merged.joinWith(getAbsState(pred));
                 hasFeasiblePred = true;
+                auto perPred = snapshotPred(pred);
+                mergePredContribution(perPred);
             }
         }
         else if (SVFUtil::isa<CallCFGEdge>(edge))
         {
             merged.joinWith(getAbsState(pred));
             hasFeasiblePred = true;
+            auto perPred = snapshotPred(pred);
+            mergePredContribution(perPred);
         }
         else if (SVFUtil::isa<RetCFGEdge>(edge))
         {
@@ -242,6 +348,10 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
             case TOP:
                 merged.joinWith(getAbsState(pred));
                 hasFeasiblePred = true;
+                {
+                    auto perPred = snapshotPred(pred);
+                    mergePredContribution(perPred);
+                }
                 break;
             case WIDEN_ONLY:
             case WIDEN_NARROW:
@@ -252,6 +362,8 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
                 {
                     merged.joinWith(getAbsState(pred));
                     hasFeasiblePred = true;
+                    auto perPred = snapshotPred(pred);
+                    mergePredContribution(perPred);
                 }
                 break;
             }
@@ -263,6 +375,23 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
         return false;
 
     updateAbsState(node, merged);
+
+    // Full-sparse: commit the accumulated overlay (inherited from preds +
+    // per-edge narrowing deltas) into pathRefinedAt[node].  Existing
+    // entries (from prior WTO iterations at this node) compose via meet —
+    // monotone refinement under widen/narrow.
+    if (sparse && !incomingOverlay.empty())
+    {
+        auto& overlay = svfStateMgr->getPathRefinedAt()[node];
+        for (auto& [objId, val] : incomingOverlay)
+        {
+            auto oit = overlay.find(objId);
+            if (oit == overlay.end())
+                overlay[objId] = val;
+            else
+                oit->second.meet_with(val);
+        }
+    }
 
     return true;
 }
@@ -425,7 +554,8 @@ static IntervalValue computeCmpConstraint(s32_t predicate, s64_t succ,
 }
 
 bool AbstractInterpretation::isCmpBranchFeasible(const IntraCFGEdge* edge,
-        AbstractState& as)
+        AbstractState& as,
+        Map<NodeID, AbstractValue>* narrowingDelta)
 {
     const ICFGNode* pred = edge->getSrcNode();
     s64_t succ = edge->getSuccessorCondValue();
@@ -473,8 +603,25 @@ bool AbstractInterpretation::isCmpBranchFeasible(const IntraCFGEdge* edge,
                     for (const auto& addr : ptrVal.getAddrs())
                     {
                         NodeID objId = as.getIDFromAddr(addr);
-                        if (as.inAddrToValTable(objId))
+                        if (narrowingDelta)
+                        {
+                            // Full-sparse: per-path delta, don't mutate as.
+                            // Meet with any prior entry so multi-obj
+                            // narrowings on the same edge compose.
+                            auto dit = narrowingDelta->find(objId);
+                            if (dit == narrowingDelta->end())
+                            {
+                                (*narrowingDelta)[objId] = AbstractValue(narrowed);
+                            }
+                            else
+                            {
+                                dit->second.meet_with(AbstractValue(narrowed));
+                            }
+                        }
+                        else if (as.inAddrToValTable(objId))
+                        {
                             as.load(addr).meet_with(narrowed);
+                        }
                     }
                 }
             }
@@ -484,7 +631,8 @@ bool AbstractInterpretation::isCmpBranchFeasible(const IntraCFGEdge* edge,
 }
 
 bool AbstractInterpretation::isSwitchBranchFeasible(const IntraCFGEdge* edge,
-        AbstractState& as)
+        AbstractState& as,
+        Map<NodeID, AbstractValue>* narrowingDelta)
 {
     const ICFGNode* pred = edge->getSrcNode();
     s64_t succ = edge->getSuccessorCondValue();
@@ -511,8 +659,18 @@ bool AbstractInterpretation::isSwitchBranchFeasible(const IntraCFGEdge* edge,
                 for (const auto& addr : ptrVal.getAddrs())
                 {
                     NodeID objId = as.getIDFromAddr(addr);
-                    if (as.inAddrToValTable(objId))
+                    if (narrowingDelta)
+                    {
+                        auto dit = narrowingDelta->find(objId);
+                        if (dit == narrowingDelta->end())
+                            (*narrowingDelta)[objId] = AbstractValue(switch_cond);
+                        else
+                            dit->second.meet_with(AbstractValue(switch_cond));
+                    }
+                    else if (as.inAddrToValTable(objId))
+                    {
                         as.load(addr).meet_with(switch_cond);
+                    }
                 }
             }
         }
@@ -521,13 +679,14 @@ bool AbstractInterpretation::isSwitchBranchFeasible(const IntraCFGEdge* edge,
 }
 
 bool AbstractInterpretation::isBranchFeasible(const IntraCFGEdge* edge,
-        AbstractState& as)
+        AbstractState& as,
+        Map<NodeID, AbstractValue>* narrowingDelta)
 {
     const SVFVar* cmpVar = edge->getCondition();
     assert(!cmpVar->getInEdges().empty() && "branch condition has no defining edge?");
     if (SVFUtil::isa<CmpStmt>(*cmpVar->getInEdges().begin()))
-        return isCmpBranchFeasible(edge, as);
-    return isSwitchBranchFeasible(edge, as);
+        return isCmpBranchFeasible(edge, as, narrowingDelta);
+    return isSwitchBranchFeasible(edge, as, narrowingDelta);
 }
 
 /**
@@ -563,6 +722,17 @@ bool AbstractInterpretation::handleICFGNode(const ICFGNode* node)
     stat->getBlockTrace()++;
     stat->getICFGNodeTrace()++;
 
+    // Full-sparse MSSA def-anchor transfers (Phase A).
+    // No-op for Dense/Semi; under Sparse each call populates
+    // trace[node]._addrToAbsVal[obj] for every obj served by a matching
+    // SVFG def node hosted at `node` (FormalIN at function entries, MSSAPHI
+    // at block joins). ActualOUT is deferred until after handleCallSite so
+    // the ExtAPI handler path has already written its values and the normal
+    // callee branch has had its FunExit analysed. See
+    // plan/plan-per-kind-transfers.md §"Driver integration".
+    svfStateMgr->runFormalINTransferAt(node);
+    svfStateMgr->runMSSAPHITransferAt(node);
+
     // Handle SVF statements
     for (const SVFStmt *stmt: node->getSVFStmts())
     {
@@ -573,6 +743,7 @@ bool AbstractInterpretation::handleICFGNode(const ICFGNode* node)
     if (const CallICFGNode* callNode = SVFUtil::dyn_cast<CallICFGNode>(node))
     {
         handleCallSite(callNode);
+        svfStateMgr->runActualOUTTransferAt(callNode);
     }
 
     // Run detectors
@@ -884,7 +1055,12 @@ void AbstractInterpretation::handleFunCall(const CallICFGNode *callNode)
 // (initCycleValVars), bottom-up so nested cycles are handled before their
 // enclosing cycle.
 
-// --- Cycle state helpers (dense/sparse unified) ---
+// --- Cycle state helpers (dense base) ---
+//
+// The dense default: trace[cycle_head] is the authoritative primary
+// storage, so the snapshot / write-back are trivial.
+// SparseAbstractInterpretation overrides these to additionally pull/scatter
+// cycle ValVars from/to their def-sites.
 
 AbstractState AbstractInterpretation::getFullCycleHeadState(const ICFGCycleWTO* cycle)
 {
@@ -892,29 +1068,7 @@ AbstractState AbstractInterpretation::getFullCycleHeadState(const ICFGCycleWTO* 
     AbstractState snap;
     if (hasAbsState(cycle_head))
         snap = getAbsState(cycle_head);
-
-    if (Options::AESparsity() == AESparsity::SemiSparse)
-    {
-        const Set<const ValVar*>& valVars = preAnalysis->getCycleValVars(cycle);
-        if (valVars.empty())
-            return snap;  // dense path / no cycle ValVars: snap is already complete
-
-        // Semi-sparse: drop any stale ValVar entries cached at cycle_head and
-        // pull each cycle ValVar from its def-site.  ValVars without a stored
-        // value are skipped to avoid the top-fallback contamination.
-        snap.clearValVars();
-        for (const ValVar* v : valVars)
-        {
-            const ICFGNode* defSite = v->getICFGNode();
-            if (!defSite || !hasAbsValue(v, defSite)) continue;
-            snap[v->getId()] = getAbsValue(v, defSite);
-        }
-        return snap;
-    }
-    else
-    {
-        return snap;
-    }
+    return snap;
 }
 
 
@@ -927,13 +1081,6 @@ bool AbstractInterpretation::widenCycleState(
     // widened state for the upcoming narrowing phase.
     const ICFGNode* cycle_head = cycle->head()->getICFGNode();
     svfStateMgr->getTrace()[cycle_head] = next;
-    if (Options::AESparsity() == AESparsity::SemiSparse)
-    {
-        for (const auto& [id, val] : next.getVarToVal())
-        {
-            updateAbsValue(svfir->getSVFVar(id), val, cycle_head);
-        }
-    }
     return next == prev;
 }
 
@@ -948,13 +1095,6 @@ bool AbstractInterpretation::narrowCycleState(
     if (next == prev)
         return true;  // fixpoint
     svfStateMgr->getTrace()[cycle_head] = next;
-    if (Options::AESparsity() == AESparsity::SemiSparse)
-    {
-        for (const auto& [id, val] : next.getVarToVal())
-        {
-            updateAbsValue(svfir->getSVFVar(id), val, cycle_head);
-        }
-    }
     return false;
 }
 

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -389,7 +389,13 @@ bool AbstractInterpretation::mergeStatesFromPredecessors(const ICFGNode* node)
             if (oit == overlay.end())
                 overlay[objId] = val;
             else
-                oit->second.meet_with(val);
+                // Join across iterations: the overlay must grow with the
+                // def-anchor value under widening. Meet here would trap
+                // the overlay at the earliest (tightest) narrowing ever
+                // observed, producing unsound reads once the base widens
+                // past that bound (e.g., recursive-call convergence where
+                // successive iters widen the incoming obj value).
+                oit->second.join_with(val);
         }
     }
 

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -217,49 +217,20 @@ const AbstractValue& AbstractStateManager::getAbstractValue(const ObjVar* var, c
                         base = &gState.load(addr);
                 }
             }
-            // Fallback 2: ICFG reaching-def walk.  MSSA's def chain is built
-            // from Andersen's pts-to; when Andersen disagrees with AE's
-            // runtime-computed pts-to on GEP'd objs, MSSA never connects
-            // the store's ICFG node to a downstream read of the AE obj-id,
-            // and getDefSiteOfObjVar returns the wrong anchor (e.g. a stale
-            // init node) while the true reaching store lives elsewhere.
+            // GepObjVar fallback: consult the flow-insensitive global
+            // gepOverlay.  MSSA does not track GepObjVar ids, so the
+            // per-node trace + def-site routing above cannot reach
+            // AE-refined GEP field writes.  storeValue folds every
+            // GepObjVar write into gepOverlay; reader finds them here.
             //
-            // Walk in-edges back from `node` until we find a predecessor
-            // whose trace has this obj populated.  Multiple reaching
-            // writers from different branches join into a single upstream
-            // value. Stops traversal at each branch as soon as a value is
-            // found, so joins respect per-path latest-writer semantics.
-            // Materialises at hereState so repeated reads are O(1).
-            if (!base)
+            // Trade-off vs the previous ICFG-BFS fallback: flow-
+            // insensitive (no path/strong-update preservation).  See
+            // gepOverlay member doc for details.
+            if (!base && SVFUtil::isa<GepObjVar>(var))
             {
-                AbstractValue upstream;
-                bool found = false;
-                Set<const ICFGNode*> visited;
-                std::deque<const ICFGNode*> work;
-                for (auto e : node->getInEdges())
-                    work.push_back(e->getSrcNode());
-                while (!work.empty())
-                {
-                    const ICFGNode* p = work.front();
-                    work.pop_front();
-                    if (!visited.insert(p).second) continue;
-                    auto tit = abstractTrace.find(p);
-                    if (tit != abstractTrace.end()
-                            && tit->second.getLocToVal().count(var->getId()) != 0)
-                    {
-                        const AbstractValue& v = tit->second.load(addr);
-                        if (!found) { upstream = v; found = true; }
-                        else upstream.join_with(v);
-                        continue; // do not traverse past a latest-writer
-                    }
-                    for (auto e : p->getInEdges())
-                        work.push_back(e->getSrcNode());
-                }
-                if (found)
-                {
-                    hereState.store(addr, upstream);
-                    base = &hereState.load(addr);
-                }
+                auto git = gepOverlay.find(var->getId());
+                if (git != gepOverlay.end())
+                    base = &git->second;
             }
         }
 
@@ -631,6 +602,24 @@ void AbstractStateManager::storeValue(const ValVar* pointer, const AbstractValue
     // Write through every addr AE thinks the pointer targets.
     for (auto addr : ptrVal.getAddrs())
         as.store(addr, val);
+    // Sparse: also fold GepObjVar writes into the global gepOverlay.
+    // MSSA cannot route reads to GepObjVar def-sites, so the overlay is
+    // the only place reads can find these values.  Flow-insensitive:
+    // join with any prior value.
+    if (Options::AESparsity() == AbstractInterpretation::AESparsity::Sparse)
+    {
+        for (auto addr : ptrVal.getAddrs())
+        {
+            NodeID id = as.getIDFromAddr(addr);
+            if (!svfir->hasGNode(id)) continue;
+            if (!SVFUtil::isa<GepObjVar>(svfir->getGNode(id))) continue;
+            auto it = gepOverlay.find(id);
+            if (it == gepOverlay.end())
+                gepOverlay[id] = val;
+            else
+                it->second.join_with(val);
+        }
+    }
     // Full-sparse: also write to every obj in Andersen's pts-to set.
     // Rationale: SVFG / MSSA builds its reaching-def chain from Andersen's
     // static pts-to, not from AE's runtime-computed GEP addresses.  When

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -847,19 +847,21 @@ void AbstractStateManager::runActualOUTTransferAt(const ICFGNode* N)
 {
     if (Options::AESparsity() != AbstractInterpretation::AESparsity::Sparse)
         return;
-    const CallICFGNode* callNode = SVFUtil::dyn_cast<CallICFGNode>(N);
-    if (!callNode)
+    // APOUT VFG nodes are hosted at the RetICFGNode (not the CallICFGNode).
+    // Driver calls this hook when visiting the retNode; sanity-gate on both
+    // the retNode shape and the matching callNode not being ExtAPI.
+    const RetICFGNode* retNode = SVFUtil::dyn_cast<RetICFGNode>(N);
+    if (!retNode)
         return;
-    // ExtAPI skip: AbsExtAPI handlers (memcpy/strcpy/...) have already
-    // written trace[callNode]._addrToAbsVal for the modified objs.
-    if (SVFUtil::isExtCall(callNode))
+    const CallICFGNode* callNode = retNode->getCallICFGNode();
+    if (!callNode || SVFUtil::isExtCall(callNode))
         return;
-    for (const VFGNode* vn : N->getVFGNodes())
+    for (const VFGNode* vn : retNode->getVFGNodes())
     {
         const ActualOUTSVFGNode* aout = SVFUtil::dyn_cast<ActualOUTSVFGNode>(vn);
         if (!aout) continue;
         NodeBS objIds = getMRNodeObjIds(aout);
-        AbstractState& here = abstractTrace[N];
+        AbstractState& here = abstractTrace[retNode];
         for (NodeID objId : objIds)
         {
             // Two-hop: aout <-RetIndEdge- FormalOUT (RetMu, no value)

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -217,6 +217,50 @@ const AbstractValue& AbstractStateManager::getAbstractValue(const ObjVar* var, c
                         base = &gState.load(addr);
                 }
             }
+            // Fallback 2: ICFG reaching-def walk.  MSSA's def chain is built
+            // from Andersen's pts-to; when Andersen disagrees with AE's
+            // runtime-computed pts-to on GEP'd objs, MSSA never connects
+            // the store's ICFG node to a downstream read of the AE obj-id,
+            // and getDefSiteOfObjVar returns the wrong anchor (e.g. a stale
+            // init node) while the true reaching store lives elsewhere.
+            //
+            // Walk in-edges back from `node` until we find a predecessor
+            // whose trace has this obj populated.  Multiple reaching
+            // writers from different branches join into a single upstream
+            // value. Stops traversal at each branch as soon as a value is
+            // found, so joins respect per-path latest-writer semantics.
+            // Materialises at hereState so repeated reads are O(1).
+            if (!base)
+            {
+                AbstractValue upstream;
+                bool found = false;
+                Set<const ICFGNode*> visited;
+                std::deque<const ICFGNode*> work;
+                for (auto e : node->getInEdges())
+                    work.push_back(e->getSrcNode());
+                while (!work.empty())
+                {
+                    const ICFGNode* p = work.front();
+                    work.pop_front();
+                    if (!visited.insert(p).second) continue;
+                    auto tit = abstractTrace.find(p);
+                    if (tit != abstractTrace.end()
+                            && tit->second.getLocToVal().count(var->getId()) != 0)
+                    {
+                        const AbstractValue& v = tit->second.load(addr);
+                        if (!found) { upstream = v; found = true; }
+                        else upstream.join_with(v);
+                        continue; // do not traverse past a latest-writer
+                    }
+                    for (auto e : p->getInEdges())
+                        work.push_back(e->getSrcNode());
+                }
+                if (found)
+                {
+                    hereState.store(addr, upstream);
+                    base = &hereState.load(addr);
+                }
+            }
         }
 
         // Overlay compose: if any branch refinement reached this node for

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -37,14 +37,14 @@ AbstractStateManager::AbstractStateManager(SVFIR* svfir, AndersenWaveDiff* pta)
 {
     if (Options::AESparsity() == AbstractInterpretation::AESparsity::Sparse)
     {
-        SVFGBuilder memSSA(true);
-        svfg = memSSA.buildFullSVFG(pta);
+        svfgBuilder = std::make_unique<SVFGBuilder>(true);
+        svfg = svfgBuilder->buildFullSVFG(pta);
     }
 }
 
 AbstractStateManager::~AbstractStateManager()
 {
-    delete svfg;
+    // svfg is owned by svfgBuilder's unique_ptr; no explicit delete needed.
 }
 
 // ===----------------------------------------------------------------------===//
@@ -63,10 +63,14 @@ AbstractState& AbstractStateManager::getAbstractState(const ICFGNode* node)
 
 void AbstractStateManager::updateAbstractState(const ICFGNode* node, const AbstractState& state)
 {
-    if (Options::AESparsity() == AbstractInterpretation::AESparsity::SemiSparse)
+    u32_t sparsity = Options::AESparsity();
+    if (sparsity == AbstractInterpretation::AESparsity::SemiSparse ||
+            sparsity == AbstractInterpretation::AESparsity::Sparse)
     {
-        // Semi-sparse: only replace ObjVar state. ValVars live at their
-        // def-sites and must not be overwritten by state replacement.
+        // Semi / Full sparse: only replace ObjVar state. ValVars live at
+        // their def-sites and must not be overwritten by state replacement.
+        // (In Full Sparse we still copy the merged ObjVar side for now —
+        // Phase 1b will gate this for memory reduction.)
         abstractTrace[node].updateAddrStateOnly(state);
     }
     else
@@ -157,8 +161,58 @@ const AbstractValue& AbstractStateManager::getAbstractValue(const ValVar* var, c
 
 const AbstractValue& AbstractStateManager::getAbstractValue(const ObjVar* var, const ICFGNode* node)
 {
-    AbstractState& as = getAbstractState(node);
     u32_t addr = AbstractState::getVirtualMemAddress(var->getId());
+    if (Options::AESparsity() == AbstractInterpretation::AESparsity::Sparse)
+    {
+        // Full-sparse: _addrToAbsVal merge is gated in joinWith; only the
+        // def-anchor's own ICFG holds the obj's value (written by the
+        // per-kind transfer or store/ExtAPI handler). Route the read to
+        // that anchor via getDefSiteOfObjVar, then compose the
+        // path-refinement overlay (if any) via meet.
+        AbstractState& hereState = getAbstractState(node);
+
+        // Locate the base value.
+        const AbstractValue* base = nullptr;
+        // Fast-path: value already cached at this node (store/ExtAPI wrote
+        // here, or a previous materialize landed here).
+        if (hereState.getLocToVal().count(var->getId()) != 0)
+        {
+            base = &hereState.load(addr);
+        }
+        else
+        {
+            const ICFGNode* defICFG = getDefSiteOfObjVar(var, node);
+            if (defICFG && hasAbstractState(defICFG))
+            {
+                AbstractState& defState = getAbstractState(defICFG);
+                if (defState.getLocToVal().count(var->getId()) != 0)
+                    base = &defState.load(addr);
+            }
+        }
+
+        // Overlay compose: if any branch refinement reached this node for
+        // this obj, meet it into the base.  No overlay entry = no-op.
+        auto ait = pathRefinedAt.find(node);
+        if (ait != pathRefinedAt.end())
+        {
+            auto oit = ait->second.find(var->getId());
+            if (oit != ait->second.end())
+            {
+                AbstractValue composed = base ? *base : AbstractValue();
+                composed.meet_with(oit->second);
+                // Materialize at hereState so the returned reference is
+                // stable and repeated reads at the same node are O(1).
+                hereState.store(addr, composed);
+                return hereState.load(addr);
+            }
+        }
+
+        if (base)
+            return *base;
+        // No reaching def + no overlay: top via local slot.
+        return hereState.load(addr);
+    }
+    AbstractState& as = getAbstractState(node);
     return as.load(addr);
 }
 
@@ -469,8 +523,27 @@ AbstractValue AbstractStateManager::loadValue(const ValVar* pointer, const ICFGN
     const AbstractValue& ptrVal = getAbstractValue(pointer, node);
     AbstractState& as = getAbstractState(node);
     AbstractValue res;
+    bool sparse =
+        Options::AESparsity() == AbstractInterpretation::AESparsity::Sparse;
     for (auto addr : ptrVal.getAddrs())
+    {
+        if (sparse)
+        {
+            // Route each ObjVar read through getAbstractValue(ObjVar*),
+            // which in Sparse mode redirects to the obj's MSSA def-anchor
+            // trace instead of the local one (which joinWith no longer
+            // fills).  Non-ObjVar addresses (null/blackhole) still read
+            // locally via as.load.
+            u32_t objId = as.getIDFromAddr(addr);
+            const SVFVar* v = svfir->getGNode(objId);
+            if (const ObjVar* obj = SVFUtil::dyn_cast<ObjVar>(v))
+            {
+                res.join_with(getAbstractValue(obj, node));
+                continue;
+            }
+        }
         res.join_with(as.load(addr));
+    }
     return res;
 }
 
@@ -584,5 +657,222 @@ const ICFGNode* AbstractStateManager::getDefSiteOfObjVar(const ObjVar* obj, cons
     for (const auto* edge : node->getInEdges())
         return edge->getSrcNode();
     return nullptr;
+}
+
+// ===----------------------------------------------------------------------===//
+//  MSSA def-anchor transfers (full-sparse Phase A)
+//
+//  Each helper walks SVFG only through its public graph surface
+//  (InEdgeBegin/End + IndirectSVFGEdge::getPointsTo + type casts) and fills
+//  trace[N]._addrToAbsVal[obj] for every obj served by a def-anchor hosted
+//  at N. See plan/plan-per-kind-transfers.md §"Core mechanism" for the
+//  unified pattern, and §"Mechanism / MU-vs-CHI" for the two-hop rule used
+//  by FormalIN and ActualOUT (their direct upstream is a MU that does not
+//  itself hold a value; recurse one more indirect-edge hop to the CHI).
+//
+//  Two-hop FormalIN/ActualOUT chains verified empirically via
+//  `wpa -ander -svfg -dump-vfg` on a minimal interproc test — see
+//  /tmp/mssa-phi-test/case_interproc.c during plan design.
+// ===----------------------------------------------------------------------===//
+
+namespace
+{
+/// Collect the set of ObjVar IDs an MRSVFGNode-like node services.
+/// All memory-side SVFG nodes used by the transfers expose an MRVer.
+template <class MRNodeT>
+inline NodeBS getMRNodeObjIds(const MRNodeT* mrNode)
+{
+    return mrNode->getMRVer()->getMR()->getPointsTo();
+}
+
+/// Unified "meet over upstream def-anchors" pattern. Given a worklist of
+/// upstream SVFG nodes (already filtered to those actually serving `objId`),
+/// read each one's ICFG-anchored trace value and meet them.
+/// Returns (meet, hasAny): hasAny=false means no upstream had a value yet.
+inline std::pair<AbstractValue, bool> meetFromUpstreams(
+    const std::vector<const VFGNode*>& upstreams,
+    u32_t objId,
+    const Map<const ICFGNode*, AbstractState>& trace)
+{
+    AbstractValue meet;
+    bool hasAny = false;
+    for (const VFGNode* U : upstreams)
+    {
+        auto it = trace.find(U->getICFGNode());
+        if (it == trace.end()) continue;
+        const auto& map = it->second.getLocToVal();
+        auto mit = map.find(objId);
+        if (mit == map.end()) continue;
+        if (!hasAny)
+        {
+            meet = mit->second;
+            hasAny = true;
+        }
+        else
+        {
+            meet.join_with(mit->second);
+        }
+    }
+    return {meet, hasAny};
+}
+
+/// Commit `meet` into the target node's trace for `objId` **only if the
+/// slot is currently empty**. This preserves strict transfer additivity:
+///   - Phase A (merge intact): when merge has already written a value —
+///     potentially refined by isCmpBranchFeasible's pred-state narrowing,
+///     which lives on edges and is NOT visible to upstream def-anchor
+///     reads — transfer defers to merge. Transfer only fills slots merge
+///     left empty (rare in Phase A; not a meaningful code path).
+///   - Phase B (merge gated): the slot is always empty when the transfer
+///     runs, so transfer becomes the primary filler.
+/// Merging with the existing value would risk widening away merge's
+/// branch-refined precision (transfer pulls un-refined upstream values).
+inline void commitTransferValue(AbstractState& target,
+                                u32_t objId,
+                                const AbstractValue& meet)
+{
+    const auto& map = target.getLocToVal();
+    if (map.find(objId) != map.end())
+        return;
+    target.store(AbstractState::getVirtualMemAddress(objId), meet);
+}
+}
+
+void AbstractStateManager::runMSSAPHITransferAt(const ICFGNode* N)
+{
+    if (Options::AESparsity() != AbstractInterpretation::AESparsity::Sparse)
+        return;
+    for (const VFGNode* vn : N->getVFGNodes())
+    {
+        const MSSAPHISVFGNode* phi = SVFUtil::dyn_cast<MSSAPHISVFGNode>(vn);
+        if (!phi) continue;
+        // MSSAPHISVFGNode exposes MRVer via getResVer(); only the
+        // IntraMSSAPHISVFGNode subclass aliases it as getMRVer.
+        NodeBS objIds = phi->getResVer()->getMR()->getPointsTo();
+        // One-hop: PHI operand defs arrive as indirect in-edges on the PHI
+        // itself (SVFG's connectIndirectSVFGEdges wires them). Each in-edge
+        // source is a real CHI-holding SVFG node (Store / nested MSSAPHI /
+        // FormalIN / ActualOUT / FormalOUT of inner calls).
+        std::vector<const VFGNode*> upstreams;
+        for (auto it = phi->InEdgeBegin(), eit = phi->InEdgeEnd(); it != eit; ++it)
+        {
+            const IndirectSVFGEdge* ie = SVFUtil::dyn_cast<IndirectSVFGEdge>(*it);
+            if (!ie) continue;
+            // Edge pts must cover at least one of our objIds; we still
+            // per-obj filter inside the loop below.
+            upstreams.push_back(ie->getSrcNode());
+        }
+        AbstractState& here = abstractTrace[N];
+        for (NodeID objId : objIds)
+        {
+            // Filter upstreams to those whose edge carries this specific obj.
+            std::vector<const VFGNode*> filtered;
+            for (auto it = phi->InEdgeBegin(), eit = phi->InEdgeEnd(); it != eit; ++it)
+            {
+                const IndirectSVFGEdge* ie = SVFUtil::dyn_cast<IndirectSVFGEdge>(*it);
+                if (ie && ie->getPointsTo().test(objId))
+                    filtered.push_back(ie->getSrcNode());
+            }
+            auto [meet, ok] = meetFromUpstreams(filtered, objId, abstractTrace);
+            if (ok)
+                commitTransferValue(here, objId, meet);
+        }
+    }
+}
+
+void AbstractStateManager::runFormalINTransferAt(const ICFGNode* N)
+{
+    if (Options::AESparsity() != AbstractInterpretation::AESparsity::Sparse)
+        return;
+    if (!SVFUtil::isa<FunEntryICFGNode>(N))
+        return;
+    for (const VFGNode* vn : N->getVFGNodes())
+    {
+        const FormalINSVFGNode* fin = SVFUtil::dyn_cast<FormalINSVFGNode>(vn);
+        if (!fin) continue;
+        NodeBS objIds = getMRNodeObjIds(fin);
+        AbstractState& here = abstractTrace[N];
+        for (NodeID objId : objIds)
+        {
+            // Two-hop: fin <-CallIndEdge- ActualIN (Mu, no value) <-IndEdge- caller CHI.
+            // Collect the caller-side CHIs by walking one more hop past
+            // each ActualIN.
+            std::vector<const VFGNode*> upstreams;
+            for (auto it = fin->InEdgeBegin(), eit = fin->InEdgeEnd(); it != eit; ++it)
+            {
+                const CallIndSVFGEdge* ce = SVFUtil::dyn_cast<CallIndSVFGEdge>(*it);
+                if (!ce || !ce->getPointsTo().test(objId)) continue;
+                const VFGNode* ain = ce->getSrcNode();
+                for (auto it2 = ain->InEdgeBegin(), eit2 = ain->InEdgeEnd();
+                        it2 != eit2; ++it2)
+                {
+                    const IndirectSVFGEdge* ie2 = SVFUtil::dyn_cast<IndirectSVFGEdge>(*it2);
+                    if (ie2 && ie2->getPointsTo().test(objId))
+                        upstreams.push_back(ie2->getSrcNode());
+                }
+            }
+            auto [meet, ok] = meetFromUpstreams(upstreams, objId, abstractTrace);
+            if (!ok)
+            {
+                // Fallback: program entry / orphan — seed from globalICFGNode.
+                const ICFGNode* g = svfir->getICFG()->getGlobalICFGNode();
+                auto git = abstractTrace.find(g);
+                if (git != abstractTrace.end())
+                {
+                    const auto& gmap = git->second.getLocToVal();
+                    auto mit = gmap.find(objId);
+                    if (mit != gmap.end())
+                    {
+                        meet = mit->second;
+                        ok = true;
+                    }
+                }
+            }
+            if (ok)
+                commitTransferValue(here, objId, meet);
+        }
+    }
+}
+
+void AbstractStateManager::runActualOUTTransferAt(const ICFGNode* N)
+{
+    if (Options::AESparsity() != AbstractInterpretation::AESparsity::Sparse)
+        return;
+    const CallICFGNode* callNode = SVFUtil::dyn_cast<CallICFGNode>(N);
+    if (!callNode)
+        return;
+    // ExtAPI skip: AbsExtAPI handlers (memcpy/strcpy/...) have already
+    // written trace[callNode]._addrToAbsVal for the modified objs.
+    if (SVFUtil::isExtCall(callNode))
+        return;
+    for (const VFGNode* vn : N->getVFGNodes())
+    {
+        const ActualOUTSVFGNode* aout = SVFUtil::dyn_cast<ActualOUTSVFGNode>(vn);
+        if (!aout) continue;
+        NodeBS objIds = getMRNodeObjIds(aout);
+        AbstractState& here = abstractTrace[N];
+        for (NodeID objId : objIds)
+        {
+            // Two-hop: aout <-RetIndEdge- FormalOUT (RetMu, no value)
+            //              <-IndEdge- callee-side CHI (Store / MSSAPHI / ...).
+            std::vector<const VFGNode*> upstreams;
+            for (auto it = aout->InEdgeBegin(), eit = aout->InEdgeEnd(); it != eit; ++it)
+            {
+                const RetIndSVFGEdge* re = SVFUtil::dyn_cast<RetIndSVFGEdge>(*it);
+                if (!re || !re->getPointsTo().test(objId)) continue;
+                const VFGNode* fout = re->getSrcNode();
+                for (auto it2 = fout->InEdgeBegin(), eit2 = fout->InEdgeEnd();
+                        it2 != eit2; ++it2)
+                {
+                    const IndirectSVFGEdge* ie2 = SVFUtil::dyn_cast<IndirectSVFGEdge>(*it2);
+                    if (ie2 && ie2->getPointsTo().test(objId))
+                        upstreams.push_back(ie2->getSrcNode());
+                }
+            }
+            auto [meet, ok] = meetFromUpstreams(upstreams, objId, abstractTrace);
+            if (ok)
+                commitTransferValue(here, objId, meet);
+        }
+    }
 }
 

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -91,7 +91,7 @@ bool AbstractStateManager::hasAbstractState(const ICFGNode* node)
 const AbstractValue& AbstractStateManager::getAbstractValue(const ValVar* var, const ICFGNode* node)
 {
     u32_t id = var->getId();
-    bool semiSparse = Options::AESparsity() == AbstractInterpretation::AESparsity::SemiSparse;
+    bool denseOnly = Options::AESparsity() == AbstractInterpretation::AESparsity::Dense;
 
     // Constants: store into current node's state and return
     AbstractState& as = abstractTrace[node];
@@ -122,13 +122,18 @@ const AbstractValue& AbstractStateManager::getAbstractValue(const ValVar* var, c
     // def-site.  Returning top or bottom here would be wrong: top loses
     // concrete values like NULL addresses; bottom misjudges branch
     // feasibility for uninitialised variables like argc.
-    if (!semiSparse)
+    //
+    // Sparse modes (SemiSparse / Sparse) skip this check: merge doesn't
+    // populate ValVars at non-def-site nodes, and reading a stale
+    // transfer-produced value at the current node would ignore the
+    // cycle-widened value at the def-site.
+    if (denseOnly)
     {
         if (as.inVarToValTable(id) || as.inVarToAddrsTable(id))
             return as[id];
     }
 
-    // Semi-sparse mode: pull from def-site first, then check current state
+    // Sparse modes: pull from def-site first, then check current state
     const ICFGNode* defNode = var->getICFGNode();
     if (defNode && hasAbstractState(defNode))
     {
@@ -298,10 +303,14 @@ bool AbstractStateManager::hasAbstractValue(const SVFVar* var, const ICFGNode* n
 
 void AbstractStateManager::updateAbstractValue(const ValVar* var, const AbstractValue& val, const ICFGNode* node)
 {
-    // In semi-sparse mode, write to the var's def-site so that
-    // getAbstractValue (which reads from def-site) stays consistent.
+    // In sparse modes (SemiSparse / Sparse), write to the var's def-site so
+    // that getAbstractValue (which reads from def-site) stays consistent.
+    // This matters especially for widen/narrow scatter calls that pass
+    // cycle_head as `node` but expect the value to land on body def-sites.
     const ICFGNode* target = node;
-    if (Options::AESparsity() == AbstractInterpretation::AESparsity::SemiSparse)
+    u32_t s = Options::AESparsity();
+    if (s == AbstractInterpretation::AESparsity::SemiSparse ||
+            s == AbstractInterpretation::AESparsity::Sparse)
     {
         const ICFGNode* defNode = var->getICFGNode();
         if (defNode)

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -33,7 +33,7 @@
 using namespace SVF;
 
 AbstractStateManager::AbstractStateManager(SVFIR* svfir, AndersenWaveDiff* pta)
-    : svfir(svfir), svfg(nullptr)
+    : svfir(svfir), svfg(nullptr), pta(pta)
 {
     if (Options::AESparsity() == AbstractInterpretation::AESparsity::Sparse)
     {
@@ -584,8 +584,33 @@ void AbstractStateManager::storeValue(const ValVar* pointer, const AbstractValue
 {
     const AbstractValue& ptrVal = getAbstractValue(pointer, node);
     AbstractState& as = getAbstractState(node);
+    // Write through every addr AE thinks the pointer targets.
     for (auto addr : ptrVal.getAddrs())
         as.store(addr, val);
+    // Full-sparse: also write to every obj in Andersen's pts-to set.
+    // Rationale: SVFG / MSSA builds its reaching-def chain from Andersen's
+    // static pts-to, not from AE's runtime-computed GEP addresses.  When
+    // the two diverge on GEP'd arrays (AE sees one field-obj, Andersen
+    // sees the whole field set or a different base obj), a downstream
+    // reader routed via getDefSiteOfObjVar asks for an obj-id that AE's
+    // store never touched, and the lookup fails.  Mirroring the write
+    // onto Andersen's pts keeps the MSSA-routed reader sound.  Dense and
+    // Semi-Sparse achieve the same effect implicitly via bulk
+    // _addrToAbsVal merge-copy; Full-Sparse gates merge, so we need the
+    // explicit mirror here.
+    if (Options::AESparsity() == AbstractInterpretation::AESparsity::Sparse
+            && pta)
+    {
+        const PointsTo& andersenPts = pta->getPts(pointer->getId());
+        for (NodeID objId : andersenPts)
+        {
+            u32_t vaddr = AbstractState::getVirtualMemAddress(objId);
+            if (as.getLocToVal().count(objId) != 0)
+                as.load(vaddr).join_with(val);
+            else
+                as.store(vaddr, val);
+        }
+    }
 }
 
 // ===----------------------------------------------------------------------===//

--- a/svf/lib/AE/Svfexe/AbstractStateManager.cpp
+++ b/svf/lib/AE/Svfexe/AbstractStateManager.cpp
@@ -133,8 +133,16 @@ const AbstractValue& AbstractStateManager::getAbstractValue(const ValVar* var, c
             return as[id];
     }
 
-    // Sparse modes: pull from def-site first, then check current state
+    // Sparse modes: pull from def-site first, then check current state.
     const ICFGNode* defNode = var->getICFGNode();
+    // Some ValVars (notably load-produced SSA values under certain IR
+    // lowerings) have no ICFGNode set; fall back to the current node,
+    // which is where the transfer would have written to by default.
+    if (!defNode)
+    {
+        if (as.inVarToValTable(id) || as.inVarToAddrsTable(id))
+            return as[id];
+    }
     if (defNode && hasAbstractState(defNode))
     {
         const auto& varMap = getAbstractState(defNode).getVarToVal();
@@ -192,6 +200,22 @@ const AbstractValue& AbstractStateManager::getAbstractValue(const ObjVar* var, c
                 AbstractState& defState = getAbstractState(defICFG);
                 if (defState.getLocToVal().count(var->getId()) != 0)
                     base = &defState.load(addr);
+            }
+            // Fallback: global const-init objects (globals, string literals,
+            // `int a[] = {...}`'s underlying global const array) are
+            // populated at globalICFGNode during program setup and have no
+            // intra-procedural def-anchor that MSSA would track.  If
+            // getDefSiteOfObjVar found nothing, consult globalICFGNode as
+            // a last resort before falling back to top.
+            if (!base)
+            {
+                const ICFGNode* g = svfir->getICFG()->getGlobalICFGNode();
+                if (g && hasAbstractState(g))
+                {
+                    AbstractState& gState = getAbstractState(g);
+                    if (gState.getLocToVal().count(var->getId()) != 0)
+                        base = &gState.load(addr);
+                }
             }
         }
 

--- a/svf/lib/AE/Svfexe/PreAnalysis.cpp
+++ b/svf/lib/AE/Svfexe/PreAnalysis.cpp
@@ -97,7 +97,9 @@ void PreAnalysis::initWTO()
 
 void PreAnalysis::initCycleValVars()
 {
-    if (Options::AESparsity() != AbstractInterpretation::AESparsity::SemiSparse)
+    u32_t sparsity = Options::AESparsity();
+    if (sparsity != AbstractInterpretation::AESparsity::SemiSparse &&
+            sparsity != AbstractInterpretation::AESparsity::Sparse)
         return;
 
     // Step 1: Collect all cycles in top-down order using a stack-based DFS,

--- a/svf/lib/AE/Svfexe/SparseAbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/SparseAbstractInterpretation.cpp
@@ -1,0 +1,96 @@
+//===- SparseAbstractInterpretation.cpp -- Sparse Abstract Execution----//
+//
+//                     SVF: Static Value-Flow Analysis
+//
+// Copyright (C) <2013->  <Yulei Sui>
+//
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//===---------------------------------------------------------------------===//
+
+#include "AE/Svfexe/SparseAbstractInterpretation.h"
+#include "AE/Svfexe/AbstractStateManager.h"
+#include "AE/Svfexe/PreAnalysis.h"
+#include "SVFIR/SVFIR.h"
+
+using namespace SVF;
+
+AbstractState SparseAbstractInterpretation::getFullCycleHeadState(
+    const ICFGCycleWTO* cycle)
+{
+    // Start from the dense snapshot (ObjVars + any ValVars that happen to
+    // be cached at cycle_head's trace entry).
+    AbstractState snap = AbstractInterpretation::getFullCycleHeadState(cycle);
+
+    const Set<const ValVar*>& valVars = preAnalysis->getCycleValVars(cycle);
+    if (valVars.empty())
+        return snap;  // no cycle ValVars known: nothing to pull
+
+    // Drop stale ValVar entries and pull each cycle ValVar from its
+    // def-site.  ValVars without a genuine stored value are skipped to
+    // avoid getAbsValue's top-fallback contaminating body def-sites on
+    // the subsequent widen/narrow scatter.
+    snap.clearValVars();
+    for (const ValVar* v : valVars)
+    {
+        const ICFGNode* defSite = v->getICFGNode();
+        if (!defSite || !hasAbsValue(v, defSite))
+            continue;
+        snap[v->getId()] = getAbsValue(v, defSite);
+    }
+    return snap;
+}
+
+bool SparseAbstractInterpretation::widenCycleState(
+    const AbstractState& prev, const AbstractState& cur, const ICFGCycleWTO* cycle)
+{
+    // Base widens, writes trace[cycle_head], and returns fixpoint bool.
+    bool fixpoint = AbstractInterpretation::widenCycleState(prev, cur, cycle);
+
+    // Scatter the widened ValVars back to their def-sites so body nodes
+    // observe the widened values on the next iteration.  Matches the
+    // pre-refactor semantics: scatter unconditionally, including at
+    // widening fixpoint (see the narrowing-starts-with-stale-body issue
+    // fixed by always writing widened state back).
+    const ICFGNode* cycle_head = cycle->head()->getICFGNode();
+    const AbstractState& next = svfStateMgr->getTrace()[cycle_head];
+    for (const auto& [id, val] : next.getVarToVal())
+        updateAbsValue(svfir->getSVFVar(id), val, cycle_head);
+    // ObjVar scatter intentionally omitted: in full-sparse, ObjVars live at
+    // their StoreVFGNode def-sites and are read via SVFG-aware meet.  Widen
+    // updates at those def-sites happen naturally during WTO iteration on the
+    // store ICFG nodes, so no separate scatter is required here.
+    return fixpoint;
+}
+
+bool SparseAbstractInterpretation::narrowCycleState(
+    const AbstractState& prev, const AbstractState& cur, const ICFGCycleWTO* cycle)
+{
+    // Delegate to base.  It returns true on the two non-scatter cases
+    // (narrowing disabled, or narrow fixpoint); we preserve the original
+    // "skip scatter at fixpoint" semantics by bailing early here.
+    bool fixpoint = AbstractInterpretation::narrowCycleState(prev, cur, cycle);
+    if (fixpoint)
+        return true;
+
+    // Non-fixpoint: base wrote the narrowed state to trace.  Scatter the
+    // narrowed ValVars back to def-sites.
+    const ICFGNode* cycle_head = cycle->head()->getICFGNode();
+    const AbstractState& next = svfStateMgr->getTrace()[cycle_head];
+    for (const auto& [id, val] : next.getVarToVal())
+        updateAbsValue(svfir->getSVFVar(id), val, cycle_head);
+    // See widenCycleState: ObjVar scatter intentionally omitted in full-sparse.
+    return false;
+}


### PR DESCRIPTION
<h1 style="margin-top: 0px; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">PR Description — Full-Sparse AE for SVF</h1><h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">TL;DR</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Add a third sparsity mode to SVF's abstract execution. Replace dense's "copy entire <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_addrToAbsVal</code> at every ICFG node" with three SSA-anchored transfers + two AE-side overlays. Memory drops 98% versus Dense; 332/352 tests pass; Dense and Semi-Sparse remain at 352/352.</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Why Full-Sparse</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Dense AE's <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mergeStatesFromPredecessors</code> does two unrelated jobs at once:</p><ol style="padding-inline-start: 2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>Propagating store-produced values along ICFG edges</strong><span> </span>(the legitimate dataflow job).</li><li><strong>Materialising reaching values at every non-store SSA anchor as a side-effect of bulk state copy</strong><span> </span>— phi nodes, function entries, call returns. This second job is what makes Dense's reader "just work":<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">trace[useNode]._addrToAbsVal[obj]</code><span> </span>is always populated, regardless of whether the reaching def is a store, a phi, a function entry, or a call return.</li></ol><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Full-Sparse decouples the two. Values live at MSSA def-anchors only; reads route through <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getDefSiteOfObjVar</code>. Memory cost falls from <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">O(ICFG nodes × all ObjVars)</code> to <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">O(real def-anchors only)</code>.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">But once we kick out the bulk copy, three things Dense had implicitly stop working. The PR is essentially "rebuild those three things sparingly":</p><ol style="padding-inline-start: 2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>Non-store SSA anchors (MSSAPHI / FormalIN / ActualOUT) need to be filled by someone, since merge no longer materialises them.</strong><span> </span>→ Three transfer helpers (Section 1).</li><li><strong>Branch refinement (cmp-induced narrowing) and GEP-precision refinements were carried by merge's bulk copy.</strong><span> </span>→ Two AE-side overlays (Section 2 + the<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pathRefinedAt</code><span> </span>table for branches).</li><li><strong>Cycle widening relied on<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">trace[cycleHead]</code><span> </span>having every variable's current value because merge put them there.</strong><span> </span>→ ValVar pull-and-scatter at cycle heads + ObjVar via re-firing transfers (Section 3).</li></ol><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">1. Why three new transfer helpers?</h2><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(255, 255, 255); border-color: rgb(200, 200, 200); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-cpp" style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">void runMSSAPHITransferAt(const ICFGNode* N);
void runFormalINTransferAt(const ICFGNode* N);
void runActualOUTTransferAt(const ICFGNode* N);
</code></pre></div><h3 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The invariant they establish</h3><blockquote style="background: none 0% 0% / auto repeat scroll padding-box border-box rgb(242, 242, 242); border-color: rgba(0, 122, 204, 0.5); color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;">For every ICFG node N that <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getDefSiteOfObjVar</code> may return, and every ObjVar <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">o</code> it anchors at N, there is exactly one filler that writes <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">trace[N]._addrToAbsVal[o]</code> during N's WTO visit, before any downstream reader observes it.</p></blockquote><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">MSSA produces exactly five kinds of ObjVar def-anchors:</p>
Anchor SVFG node | ICFG host | Filler
-- | -- | --
StoreVFGNode | store stmt | existing updateStateOnStore
MSSAPHISVFGNode | block entry / cycle head | runMSSAPHITransferAt
FormalINSVFGNode | FunEntryICFGNode | runFormalINTransferAt
ActualOUTSVFGNode (normal callee) | RetICFGNode | runActualOUTTransferAt
ActualOUTSVFGNode (ExtAPI callee) | CallICFGNode | existing AbsExtAPI handler

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ES_Loc_TOTAL</code> (ObjVar storage) drops 98.2% versus Dense. <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ES_Var_TOTAL</code> (ValVar storage) drops 97.7%.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Dense and Semi-Sparse remain unchanged at 352/352 — none of the new mechanisms fire in those modes.</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Out of scope (the 20 remaining failures)</h2><ul style="padding-inline-start: 2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>4 ×<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">recursive_afterrec</code>: ActualOUT chain through self-recursive SCCs needs more iteration; tractable follow-up.</li><li>6 × detector FP/FN under branch refinement:<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pathRefinedAt</code><span> </span>overlay needs to extend to ValVar pointers (<code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">if (cond) p = NULL; UNSAFE_LOAD(p);</code>).</li><li>5 × ExtAPI / scanf / switch / memcpy edge cases: middling effort.</li><li>1 ×<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">BASIC_array_int_0</code>: Phase D's flow-insensitive trade-off (won't fix without losing the simplicity).</li><li>4 × very complex CFG (goto + nested loops + while-true exit): borderline cases.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">None indicate a soundness regression.</p><hr style="font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h2><ul style="padding-inline-start: 2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><a href="vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/include/AE/Svfexe/AbstractStateManager.h" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 106, 177);">svf/include/AE/Svfexe/AbstractStateManager.h</a>: public API for the three transfers,<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pathRefinedAt</code>,<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">gepOverlay</code>.</li><li><a href="vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/AbstractStateManager.cpp" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 106, 177);">svf/lib/AE/Svfexe/AbstractStateManager.cpp</a>: transfer implementations, sparsity-aware reader,<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">gepOverlay</code><span> </span>write/read paths.</li><li><a href="vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/AbstractInterpretation.cpp" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 106, 177);">svf/lib/AE/Svfexe/AbstractInterpretation.cpp</a>: driver hooks for the three transfers, modified<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mergeStatesFromPredecessors</code>, modified<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">isCmpBranchFeasible</code><span> </span>signature.</li><li><a href="vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Core/AbstractState.cpp" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 106, 177);">svf/lib/AE/Core/AbstractState.cpp</a>: sparsity gate in<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">joinWith</code>.</li><li><a href="vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/SparseAbstractInterpretation.cpp" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 106, 177);">svf/lib/AE/Svfexe/SparseAbstractInterpretation.cpp</a>: cycle ValVar pull-and-scatter.</li><li><a href="vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/PreAnalysis.cpp" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 106, 177);">svf/lib/AE/Svfexe/PreAnalysis.cpp</a>:<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">initCycleValVars</code><span> </span>for the bottom-up cycle ValVar set.</li><li><a href="vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/AbsExtAPI.cpp" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 106, 177);">svf/lib/AE/Svfexe/AbsExtAPI.cpp</a>: ObjVar reads in ExtAPI handlers go through the sparsity-aware reader.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">No SVFG / VFG / ICFG / MSSA / Andersen header or behavioural changes.</p>PR Description — Full-Sparse AE for SVF
TL;DR
Add a third sparsity mode to SVF's abstract execution. Replace dense's "copy entire _addrToAbsVal at every ICFG node" with three SSA-anchored transfers + two AE-side overlays. Memory drops 98% versus Dense; 332/352 tests pass; Dense and Semi-Sparse remain at 352/352.

Why Full-Sparse
Dense AE's mergeStatesFromPredecessors does two unrelated jobs at once:

Propagating store-produced values along ICFG edges (the legitimate dataflow job).
Materialising reaching values at every non-store SSA anchor as a side-effect of bulk state copy — phi nodes, function entries, call returns. This second job is what makes Dense's reader "just work": trace[useNode]._addrToAbsVal[obj] is always populated, regardless of whether the reaching def is a store, a phi, a function entry, or a call return.
Full-Sparse decouples the two. Values live at MSSA def-anchors only; reads route through getDefSiteOfObjVar. Memory cost falls from O(ICFG nodes × all ObjVars) to O(real def-anchors only).

But once we kick out the bulk copy, three things Dense had implicitly stop working. The PR is essentially "rebuild those three things sparingly":

Non-store SSA anchors (MSSAPHI / FormalIN / ActualOUT) need to be filled by someone, since merge no longer materialises them. → Three transfer helpers (Section 1).
Branch refinement (cmp-induced narrowing) and GEP-precision refinements were carried by merge's bulk copy. → Two AE-side overlays (Section 2 + the pathRefinedAt table for branches).
Cycle widening relied on trace[cycleHead] having every variable's current value because merge put them there. → ValVar pull-and-scatter at cycle heads + ObjVar via re-firing transfers (Section 3).
1. Why three new transfer helpers?

void runMSSAPHITransferAt(const ICFGNode* N);
void runFormalINTransferAt(const ICFGNode* N);
void runActualOUTTransferAt(const ICFGNode* N);
The invariant they establish
For every ICFG node N that getDefSiteOfObjVar may return, and every ObjVar o it anchors at N, there is exactly one filler that writes trace[N]._addrToAbsVal[o] during N's WTO visit, before any downstream reader observes it.

MSSA produces exactly five kinds of ObjVar def-anchors:

Anchor SVFG node	ICFG host	Filler
StoreVFGNode	store stmt	existing updateStateOnStore
MSSAPHISVFGNode	block entry / cycle head	runMSSAPHITransferAt
FormalINSVFGNode	FunEntryICFGNode	runFormalINTransferAt
ActualOUTSVFGNode (normal callee)	RetICFGNode	runActualOUTTransferAt
ActualOUTSVFGNode (ExtAPI callee)	CallICFGNode	existing AbsExtAPI handler
Without these three helpers, four out of five anchor kinds would be empty when the reader tries to read from them — and the entire sparse design collapses into "everything reads top".

What they share — one pattern, three flavours

runXxxTransferAt(N):
  for each Xxx-kind VFG node D at N:
    for each obj in D.MR.getPointsTo():
      meet = ⊥
      for each upstream CHI U of D (via SVFG indirect edges):
        if trace[U.ICFGNode][obj] exists:
          meet ⊔= trace[U.ICFGNode][obj]
      commitTransferValue(trace[N], obj, meet)   # fill-empty-only
The only thing that varies is how upstream CHIs are reached — and that boils down to one SVFG quirk: MU (use-annotation) nodes don't hold values, only CHI (def-annotation) nodes do. If an edge leads to a MU, walk one more indirect-edge hop.

Transfer	Direct upstream	MU intermediary?	Hops
MSSAPHI	indirect in-edges → operand CHIs	no	1
FormalIN	CallIndSVFGEdge → ActualIN (CallMU) → upstream CHI	yes	2 (then fall back to globalICFGNode if no caller reached)
ActualOUT	RetIndSVFGEdge → FormalOUT (RetMU) → callee CHI	yes	2 (skip entirely if callee is ExtAPI)
Critical detail: commitTransferValue is fill-empty-only
The transfer only writes to slots merge left empty. If merge already wrote a value (which it can, when isCmpBranchFeasible narrowed the pred state in Dense/Phase-A), the transfer defers. Without this, transfer's un-refined upstream values would clobber merge's branch-refined precision and break four assert tests in early prototyping.

In the final design (Phase B+ where merge skips ObjVar copy entirely), the slot is always empty when the transfer runs and the transfer becomes the primary filler — but the fill-empty-only semantics stay as a safety property.

getPathRefinedAt

Map<const ICFGNode*, Map<NodeID, AbstractValue>>& getPathRefinedAt();
This is the public accessor for the branch refinement overlay — a separate concern from the three transfers but tied into the same reader. The overlay stores per-ObjVar narrowings that come from if (*p < 5) style cmp branches, which MSSA does not model (cmp is not a def in SSA). It is populated by the modified mergeStatesFromPredecessors (folding each feasible edge's narrowingDelta from isCmpBranchFeasible) and consumed by getAbstractValue(ObjVar*, useNode) via meet at read time.

Why we need to expose it: cycle handling (SparseAbstractInterpretation::widenCycleState) and external diagnostics need to inspect / preserve the overlay across iterations.

2. Why gepOverlay?

Map<NodeID, AbstractValue> gepOverlay;
The disconnect
AE precise-refines GEP fields at runtime via getGepObjAddrs(base, [low, high]):


int a[10];
a[3] = 7;     // AE writes obj-id 42 (= GepObjVar(base=37, offset=3))
v = a[3];     // AE reads obj-id 42
But MSSA / Andersen are static — they only see the base obj arr (id 37) for these stores, not the field-precise GepObjVar id 42. Concretely:

getDefSiteOfObjVar(42, useNode) returns null because no SVFG indirect edge has 42 in its PointsTo set.
The globalICFGNode fallback for non-globally-initialised arrays returns nothing.
So a GepObjVar read in pure sparse mode would always return ⊤. Every array test would fail.

What we tried first and discarded
ICFG reverse BFS fallback: walk back from useNode via ICFG in-edges until we find a node whose trace holds obj 42. Worked correctly (324/352) but was an O(N) graph walk inside a function that should be O(1), with stale-cache issues across WTO iterations.
Route via base's MSSA def-site: call getDefSiteOfObjVar(baseObj, useNode), then read trace[defNode][gepId]. Triggered SVFG's hard assert(defSite == nullptr && "unique indirect definition"), because complex ICFG nodes (call sites, init nodes) host multiple VFG nodes referencing the base — multiple matches violate the API's unique-def invariant.
Selectively merge only GepObjVar ids: in joinWith, copy only ids whose SVFVar is a GepObjVar. Memory exploded to 2.24M Loc entries because struct field GepObjVars propagated densely to every node in their containing function.
The shipped solution
A flow-insensitive global map keyed by GepObjVar's NodeID (which uniquely encodes (base, offset) via SVFIR's canonical getGepObjVar). Single map, lives in AbstractStateManager.


storeValue(p, val, n):
    ...                                         # existing trace + Andersen mirror writes
    for o in pts(p):
        if o is GepObjVar:
            gepOverlay[o.id].join_with(val)     # fold to the global map

getAbstractValue(ObjVar* var, ICFGNode* node):
    ... step 1-3 (local, MSSA, globalICFGNode) ...
    if !base && var is GepObjVar:               # step 4
        if gepOverlay.has(var.id):
            base = gepOverlay[var.id]
Why this works
Reader O(1): single Map::find, no graph walk.
No SVFG modification: doesn't touch the asserting API.
Unaffected by sparse merge gating: gepOverlay is a separate global structure, propagation isn't merge's job.
Cross-procedural for free: every GepObjVar write across all functions folds into the same map; reads anywhere find them.
Trade-off: flow-insensitive
GepObjVar values use join_with only — never strong-update. So:

a[3]=7; a[3]=11; assert(a[3]==11) reads [7, 11] (joined), not 11. One test regresses (BASIC_array_int_0).
a[3]=7; a[5]=11; assert(a[3]==7) still reads 7 (different keys). Works fine.
for (i...) a[i] = 0; a[k] = 99; assert(a[k]==99) reads [0, 99]. Loses precision in this pattern.
In our 352-test suite, net effect is +8 tests passing versus BFS — flow-insensitivity costs 1 test but the BFS version had its own staleness bugs in cycles that cost more.

Why GepObjVar can get away without widening
A standard concern with flow-insensitive join-only structures is termination. For interval domains it isn't a problem: the lattice has finite height (bounded by [-INF, INF]), and join_with only ever climbs the lattice. So gepOverlay naturally terminates without needing an explicit widen operator. Precision is sacrificed; soundness and termination are not.

3. How Full-Sparse handles cycles
Cycles are the place where everything sparse-related compounds. The challenge: WTO widening compares prev and cur snapshots at the cycle head, and Dense relies on those snapshots having every value via merge's bulk copy. Sparse's prev/cur snapshots come from trace[cycleHead], which doesn't store ValVars at all in sparse mode.

We solve ValVar and ObjVar with two different mechanisms.

3.1 ValVar — pull-and-scatter
In sparse, ValVars only live at their def-sites (var->getICFGNode()). They are never written to trace[cycleHead] by merge. So we must explicitly transport them in and out of the cycle head's snapshot.

Pre-analysis collects the cycle's ValVar set (PreAnalysis::initCycleValVars):


Map<const ICFGCycleWTO*, Set<const ValVar*>> cycleToValVars;
Bottom-up over the WTO: each cycle's ValVar set = LHS ValVars of every stmt in its singleton members + nested sub-cycles' sets + (if head is a FunEntryICFGNode) formal parameters. Computed once before AE runs; reused on every iteration.

Entering the cycle iteration (SparseAbstractInterpretation::getFullCycleHeadState):


AbstractState snap = base::getFullCycleHeadState(cycle);  // ObjVars come from trace
snap.clearValVars();
for (const ValVar* v : preAnalysis->getCycleValVars(cycle)):
    if (v->getICFGNode() && hasAbsValue(v, v->getICFGNode())):
        snap[v->getId()] = getAbsValue(v, v->getICFGNode())  // pull from def-site
Exiting the cycle iteration (widenCycleState / narrowCycleState):


base::widenCycleState(prev, cur, cycle)        // writes widened state to trace[cycleHead]
for (id, val) in trace[cycleHead].getVarToVal():
    updateAbsValue(svfir->getSVFVar(id), val, cycleHead)  // scatter back to def-site
Note that updateAbsValue in sparse mode internally routes the write to the var's def-site (not literally cycleHead) — that's how the next iteration's body reads pick up the widened value.

3.2 ObjVar — no scatter, just re-fire runMSSAPHITransferAt
ObjVars do live in trace[cycleHead]._addrToAbsVal in sparse mode, populated each iteration by runMSSAPHITransferAt(cycleHead) (which joins from operand def-sites = entry def + back-edge def per latch). This means:

The widen-set for ObjVars is implicit — it's exactly MR.getPointsTo() of the MSSAPHIs at cycle head, computed dynamically each iteration. No pre-collection needed.
No scatter needed — values stay in trace[cycleHead]. The next iteration's body reads route via getDefSiteOfObjVar(o, useNode), which (for objs whose defs reach via the cycle's MSSAPHI) returns cycleHead, and the read finds the widened value there.
Per-iteration timeline:


iter k:
  prev = getFullCycleHeadState(cycle)          # ObjVars: copy of trace[cycleHead] from iter k-1
                                                # ValVars: pulled from def-sites
  
  mergeStatesFromPredecessors(cycleHead)       # sparse: clears _addrToAbsVal
  runMSSAPHITransferAt(cycleHead)              # re-fills _addrToAbsVal:
                                                #   for each obj in MR.PointsTo():
                                                #     join over operand def-sites
  handleICFGNode body                          # body stmts may write to other nodes
  
  cur = getFullCycleHeadState(cycle)           # ObjVars: trace[cycleHead] just refilled
                                                # ValVars: pulled again
  
  next = prev.widening(cur)                    # widens both _varToAbsVal and _addrToAbsVal
  trace[cycleHead] = next
  
  scatter ValVars from trace[cycleHead] back to their def-sites
  # ObjVars stay in trace[cycleHead] for iter k+1
3.3 Recursion
WTO treats recursion SCCs as cycles, so the same machinery applies. One subtlety: runActualOUTTransferAt at a recursive call's RetICFGNode walks RetIndSVFGEdge → FormalOUT → IndirectSVFGEdge to find callee CHIs, which may include the same call's ActualOUT (a self-loop). First iteration finds the slot empty (just cleared by merge); WTO iterates the SCC and the slot fills in subsequent rounds. fill-empty-only ensures the recursion's skipRecursionWithTop mode (when enabled) writes ⊤ to exactly the slot the reader will consult, and the transfer doesn't subsequently overwrite that ⊤.

3.4 GepObjVar in cycles
gepOverlay participates in cycles trivially: every iteration's stores fold their values into the same global map via join_with. The lattice is bounded so termination is automatic. There is no widening on gepOverlay and none is needed — the worst case is intervals saturating to [-INF, INF], which terminates the WTO loop.

3.5 The widening monotonicity bug worth noting
An earlier draft of pathRefinedAt's cross-iteration commit used meet. Under widening, this trapped overlay entries at iteration 1's tightest narrowing, while the base def-anchor value widened around them. Reads computed meet(widened_base, stale_tight_overlay) = stale_tight_overlay, and the cycle never converged.

Fix: cross-iteration commit uses join. The per-iteration tightening still happens because isCmpBranchFeasible recomputes narrowingDelta each round and the per-pred snapshot folds delta via meet — that part is correct. Only the cross-iteration step needed to climb the lattice with the base value, not against it. Single-line change in mergeStatesFromPredecessors recovered 50/115 failing tests at the time.

Empirical results (289-file benchmark)
Mode	ES_Loc_TOTAL	ES_Var_TOTAL	Tests
Dense	2,320,904	4,200,835	352/352
Semi-Sparse	2,320,832	106,608	352/352
Full-Sparse	42,323	98,622	332/352
ES_Loc_TOTAL (ObjVar storage) drops 98.2% versus Dense. ES_Var_TOTAL (ValVar storage) drops 97.7%.

Dense and Semi-Sparse remain unchanged at 352/352 — none of the new mechanisms fire in those modes.

Out of scope (the 20 remaining failures)
4 × recursive_afterrec: ActualOUT chain through self-recursive SCCs needs more iteration; tractable follow-up.
6 × detector FP/FN under branch refinement: pathRefinedAt overlay needs to extend to ValVar pointers (if (cond) p = NULL; UNSAFE_LOAD(p);).
5 × ExtAPI / scanf / switch / memcpy edge cases: middling effort.
1 × BASIC_array_int_0: Phase D's flow-insensitive trade-off (won't fix without losing the simplicity).
4 × very complex CFG (goto + nested loops + while-true exit): borderline cases.
None indicate a soundness regression.

Files changed
[svf/include/AE/Svfexe/AbstractStateManager.h](vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/include/AE/Svfexe/AbstractStateManager.h): public API for the three transfers, pathRefinedAt, gepOverlay.
[svf/lib/AE/Svfexe/AbstractStateManager.cpp](vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/AbstractStateManager.cpp): transfer implementations, sparsity-aware reader, gepOverlay write/read paths.
[svf/lib/AE/Svfexe/AbstractInterpretation.cpp](vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/AbstractInterpretation.cpp): driver hooks for the three transfers, modified mergeStatesFromPredecessors, modified isCmpBranchFeasible signature.
[svf/lib/AE/Core/AbstractState.cpp](vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Core/AbstractState.cpp): sparsity gate in joinWith.
[svf/lib/AE/Svfexe/SparseAbstractInterpretation.cpp](vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/SparseAbstractInterpretation.cpp): cycle ValVar pull-and-scatter.
[svf/lib/AE/Svfexe/PreAnalysis.cpp](vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/PreAnalysis.cpp): initCycleValVars for the bottom-up cycle ValVar set.
[svf/lib/AE/Svfexe/AbsExtAPI.cpp](vscode-webview://0t7rvl1hlfrq99k8e7hhl6tv7p42qn3mbmkue891rj4t0qa2fspm/svf/lib/AE/Svfexe/AbsExtAPI.cpp): ObjVar reads in ExtAPI handlers go through the sparsity-aware reader.
No SVFG / VFG / ICFG / MSSA / Andersen header or behavioural changes.