### PR TITLE
Fix missing push() before pop() in SaberCondAllocator::isSatisfiable

### DIFF
--- a/svf/lib/SABER/SaberCondAllocator.cpp
+++ b/svf/lib/SABER/SaberCondAllocator.cpp
@@ -625,6 +625,7 @@ bool SaberCondAllocator::isEquivalentBranchCond(const Condition &lhs,
 /// whether condition is satisfiable
 bool SaberCondAllocator::isSatisfiable(const Condition &condition)
 {
+    Condition::getSolver().push();
     Condition::getSolver().add(condition.getExpr());
     z3::check_result result = Condition::getSolver().check();
     Condition::getSolver().pop();


### PR DESCRIPTION
## Bug Description

`SaberCondAllocator::isSatisfiable()` calls `solver.pop()` without a matching `solver.push()`. This causes a Z3 "index out of bounds" exception when the solver's scope stack is empty. Additionally, the added constraint is never popped, permanently polluting the solver state.

## Fix

Add the missing `push()` before `add()`, consistent with the adjacent `isEquivalentBranchCond()` and the usage pattern in `Z3Expr.cpp`.
