### PR TITLE
fix: the entry point should be "svf_main" if using `-svf-main`

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMUtil.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMUtil.h
@@ -33,6 +33,7 @@
 #include "Util/SVFUtil.h"
 #include "SVF-LLVM/BasicTypes.h"
 #include "Util/ThreadAPI.h"
+#include "Util/Options.h"
 
 namespace SVF
 {
@@ -112,7 +113,8 @@ const Function* getProgFunction(const std::string& funName);
 /// Check whether a function is an entry function (i.e., main)
 inline bool isProgEntryFunction(const Function* fun)
 {
-    return fun && fun->getName() == "main";
+    const char* main_name=Options::SVFMain() ? "svf.main" : "main";
+    return fun && fun->getName() == main_name;
 }
 
 /// Check whether this value is a black hole

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -597,7 +597,12 @@ void LLVMModuleSet::addSVFMain()
         }
         // return;
         Builder.CreateRetVoid();
-    } else Options::SVFMain.setValue(false); // use SVF::Options to record whether svf.main is added or not
+    }
+    else
+    {
+        // use SVF::Options to record whether svf.main is added or not
+        Options::SVFMain.setValue(false);
+    }
 }
 
 void LLVMModuleSet::collectExtFunAnnotations(const Module* mod)

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -542,12 +542,12 @@ void LLVMModuleSet::addSVFMain()
             }
         }
     }
-    // Keep it simple, and reduce checks
-    // // Only create svf.main when the original main function is found, and also
-    // // there are global constructor or destructor functions.
-    // if (orgMain && getModuleNum() > 0 &&
-    //         (ctor_funcs.size() > 0 || dtor_funcs.size() > 0))
-    // {
+
+    // Only create svf.main when the original main function is found, and also
+    // there are global constructor or destructor functions.
+    if (orgMain && getModuleNum() > 0 &&
+            (ctor_funcs.size() > 0 || dtor_funcs.size() > 0))
+    {
         assert(mainMod && "Module with main function not found.");
         Module& M = *mainMod;
         // char **
@@ -597,7 +597,7 @@ void LLVMModuleSet::addSVFMain()
         }
         // return;
         Builder.CreateRetVoid();
-    // }
+    } else Options::SVFMain.setValue(false); // use SVF::Options to record whether svf.main is added or not
 }
 
 void LLVMModuleSet::collectExtFunAnnotations(const Module* mod)

--- a/svf-llvm/lib/LLVMModule.cpp
+++ b/svf-llvm/lib/LLVMModule.cpp
@@ -542,12 +542,12 @@ void LLVMModuleSet::addSVFMain()
             }
         }
     }
-
-    // Only create svf.main when the original main function is found, and also
-    // there are global constructor or destructor functions.
-    if (orgMain && getModuleNum() > 0 &&
-            (ctor_funcs.size() > 0 || dtor_funcs.size() > 0))
-    {
+    // Keep it simple, and reduce checks
+    // // Only create svf.main when the original main function is found, and also
+    // // there are global constructor or destructor functions.
+    // if (orgMain && getModuleNum() > 0 &&
+    //         (ctor_funcs.size() > 0 || dtor_funcs.size() > 0))
+    // {
         assert(mainMod && "Module with main function not found.");
         Module& M = *mainMod;
         // char **
@@ -597,7 +597,7 @@ void LLVMModuleSet::addSVFMain()
         }
         // return;
         Builder.CreateRetVoid();
-    }
+    // }
 }
 
 void LLVMModuleSet::collectExtFunAnnotations(const Module* mod)

--- a/svf/include/Util/Options.h
+++ b/svf/include/Util/Options.h
@@ -177,7 +177,7 @@ public:
 
     // LLVMModule.cpp
     static const Option<std::string> Graphtxt;
-    static const Option<bool> SVFMain;
+    static Option<bool> SVFMain;
 
     // SymbolTableInfo.cpp
     static const Option<bool> LocMemModel;

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -113,7 +113,8 @@ std::deque<const FunObjVar*> AbstractInterpretation::collectProgEntryFuns()
         if (cgNode->getInEdges().empty())
         {
             // If main exists, put it first for priority using deque's push_front
-            if (fun->getName() == "main")
+            const char* main_name=Options::SVFMain() ? "svf.main" : "main";
+            if (fun->getName() == main_name)
             {
                 entryFunctions.push_front(fun);
             }

--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -113,8 +113,7 @@ std::deque<const FunObjVar*> AbstractInterpretation::collectProgEntryFuns()
         if (cgNode->getInEdges().empty())
         {
             // If main exists, put it first for priority using deque's push_front
-            const char* main_name=Options::SVFMain() ? "svf.main" : "main";
-            if (fun->getName() == main_name)
+            if (SVFUtil::isProgEntryFunction(fun))
             {
                 entryFunctions.push_front(fun);
             }

--- a/svf/lib/MTA/MHP.cpp
+++ b/svf/lib/MTA/MHP.cpp
@@ -567,7 +567,8 @@ bool MHP::isConnectedfromMain(const FunObjVar* fun)
     while (!worklist.empty())
     {
         const CallGraphNode* node = worklist.pop();
-        if ("main" == node->getFunction()->getName())
+        const char* main_name=Options::SVFMain() ? "svf.main" : "main";
+        if (main_name == node->getFunction()->getName())
             return true;
         for (CallGraphNode::const_iterator nit = node->InEdgeBegin(), neit = node->InEdgeEnd(); nit != neit; nit++)
         {

--- a/svf/lib/MTA/MHP.cpp
+++ b/svf/lib/MTA/MHP.cpp
@@ -567,8 +567,7 @@ bool MHP::isConnectedfromMain(const FunObjVar* fun)
     while (!worklist.empty())
     {
         const CallGraphNode* node = worklist.pop();
-        const char* main_name=Options::SVFMain() ? "svf.main" : "main";
-        if (main_name == node->getFunction()->getName())
+        if (SVFUtil::isProgEntryFunction(node->getFunction()))
             return true;
         for (CallGraphNode::const_iterator nit = node->InEdgeBegin(), neit = node->InEdgeEnd(); nit != neit; nit++)
         {

--- a/svf/lib/Util/Options.cpp
+++ b/svf/lib/Util/Options.cpp
@@ -540,7 +540,7 @@ const Option<std::string> Options::Graphtxt(
     ""
 );
 
-const Option<bool> Options::SVFMain(
+Option<bool> Options::SVFMain(
     "svf-main",
     "add svf.main()",
     false

--- a/svf/lib/Util/SVFUtil.cpp
+++ b/svf/lib/Util/SVFUtil.cpp
@@ -441,5 +441,6 @@ bool SVFUtil::isExtCall(const FunObjVar* fun)
 
 bool SVFUtil::isProgEntryFunction(const FunObjVar* funObjVar)
 {
-    return funObjVar && funObjVar->getName() == "main";
+    const char* main_name=Options::SVFMain() ? "svf.main" : "main";
+    return funObjVar && funObjVar->getName() == main_name;
 }


### PR DESCRIPTION
**Description:**

This PR fixes a case [issue1817](https://github.com/SVF-tools/SVF/issues/1817) where indirect calls through global function pointers fail to resolve the target due to global initializer.

**Cause:**  
We need a "dummy" `main` to put the functions in `llvm::global_ctor` into call graph, however the original `-svf-main` option's implementation has some bugs. Several parts of the SVF project still consider `main` as the entry even with `-svf-main`  option on.

**Fix:**  
Changed the entry point from `main` to `svf.main` when `-svf-main` is specified.

**Testing:**  
- Tested the provided demo in issue
- Tested with my own test suite (26 c/cpp programs), it does not introduce new bugs.