### PR TITLE
Fix AE singleton destructor crash at program exit

### DIFF
--- a/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
+++ b/svf/lib/AE/Svfexe/AbstractInterpretation.cpp
@@ -76,21 +76,33 @@ AbstractInterpretation::AbstractInterpretation()
 /// Must only be called after the option parser has populated AESparsity.
 AbstractInterpretation& AbstractInterpretation::getAEInstance()
 {
-    static std::unique_ptr<AbstractInterpretation> instance = []()
-            -> std::unique_ptr<AbstractInterpretation>
+    // Leak the singleton on purpose.  AbstractInterpretation owns a
+    // Map<std::string, std::function<void(const CallICFGNode*)>> func_map
+    // whose lambda closures back-reference state owned by other globals
+    // (preAnalysis's WTO, the call graph, ...).  Letting the static
+    // unique_ptr's atexit-time destructor run hits a static-destruction-
+    // order issue: the func_map hashtable's destructor calls into
+    // std::function destroyers whose closures touch already-destroyed
+    // state, and ~_Hashtable() segfaults during normal program shutdown.
+    //
+    // Reliably reproducible from any downstream tool that drives a full
+    // AE analysis to completion and then exits normally:
+    //   - SSA's ass3 binary (Software-Security-Analysis/Assignment-3)
+    //   - pysvf via Python interpreter shutdown
+    //
+    // A process-lifetime singleton has no observable lifecycle past
+    // program exit, so leaking is benign and avoids the use-after-destroy.
+    static AbstractInterpretation* instance = []() -> AbstractInterpretation*
     {
         switch (Options::AESparsity())
         {
         case AESparsity::SemiSparse:
-            return std::unique_ptr<AbstractInterpretation>(
-                new SemiSparseAbstractInterpretation());
+            return new SemiSparseAbstractInterpretation();
         case AESparsity::Sparse:
-            return std::unique_ptr<AbstractInterpretation>(
-                new FullSparseAbstractInterpretation());
+            return new FullSparseAbstractInterpretation();
         case AESparsity::Dense:
         default:
-            return std::unique_ptr<AbstractInterpretation>(
-                new AbstractInterpretation());
+            return new AbstractInterpretation();
         }
     }();
     return *instance;


### PR DESCRIPTION
AbstractInterpretation::getAEInstance() stored the singleton in a static unique_ptr, whose atexit-time dtor segfaults when downstream tools exit normally (e.g. pysvf via Python interpreter shutdown, or SSA's ass3 binary).  Leak the instance instead — process-lifetime singletons have no observable lifecycle past program exit.

End-to-end: SSA ctest goes from 17 SEGFAULT cases (all "successfully verified!!" before crashing in atexit) to 0.