### PR TITLE
fix: replace wrnMsg with writeWrnMsg

### DIFF
--- a/svf-llvm/include/SVF-LLVM/SVFIRBuilder.h
+++ b/svf-llvm/include/SVF-LLVM/SVFIRBuilder.h
@@ -336,7 +336,7 @@ protected:
         }
         else
         {
-            SVFUtil::wrnMsg("not support indirect call to add AddrStmt.\n");
+            SVFUtil::writeWrnMsg("not support indirect call to add AddrStmt.\n");
         }
         if (functionName == "malloc")
         {

--- a/svf/lib/MemoryModel/PointerAnalysis.cpp
+++ b/svf/lib/MemoryModel/PointerAnalysis.cpp
@@ -383,7 +383,7 @@ void PointerAnalysis::resolveIndCalls(const CallICFGNode* cs, const PointsTo& ta
 
         if(getNumOfResolvedIndCallEdge() >= Options::IndirectCallLimit())
         {
-            wrnMsg("Resolved Indirect Call Edges are Out-Of-Budget, please increase the limit");
+            writeWrnMsg("Resolved Indirect Call Edges are Out-Of-Budget, please increase the limit");
             return;
         }
 


### PR DESCRIPTION
Replaced two instances of wrnMsg with writeWrnMsg so the warning is actually written to out.