### PR TITLE
fix: skip callsite if InlineAsm

### DIFF
--- a/svf-llvm/lib/SVFIRBuilder.cpp
+++ b/svf-llvm/lib/SVFIRBuilder.cpp
@@ -1256,6 +1256,9 @@ void SVFIRBuilder::visitCallSite(CallBase* cs)
     if(isIntrinsicInst(cs))
         return;
 
+    if(cs->isInlineAsm())
+        return;
+
     DBOUT(DPAGBuild,
           outs() << "process callsite " << svfcall->valueOnlyToString() << "\n");
 


### PR DESCRIPTION
Inline assembly is considered an indirect call site in LLVM IR, but not something SVF can process.