### PR TITLE
fix: prevent abort when Value is ConstantData

### DIFF
--- a/svf-llvm/lib/ObjTypeInference.cpp
+++ b/svf-llvm/lib/ObjTypeInference.cpp
@@ -149,6 +149,7 @@ const Type *ObjTypeInference::inferObjType(const Value *var)
     //  but we can infer the obj type of %0 based on that of %inner_v.
     if (res == defaultType(var))
     {
+        if (!var->hasUseList()) return res;
         for (const auto& use: var->users())
         {
             if (const CallBase* cs = SVFUtil::dyn_cast<CallBase>(use))
@@ -271,6 +272,7 @@ const Type *ObjTypeInference::fwInferObjType(const Value *var)
             if (const auto* gepInst =
                         SVFUtil::dyn_cast<GetElementPtrInst>(curValue))
                 insertInferSite(gepInst);
+            if (!curValue->hasUseList()) continue;
             for (const auto it : curValue->users())
             {
                 if (const auto* loadInst = SVFUtil::dyn_cast<LoadInst>(it))


### PR DESCRIPTION
As per https://github.com/llvm/llvm-project/commit/9383fb23e18bb983d0024fb956a0a724ef9eb03d, LLVM 21 no longer permits the inspection of `users` of `ConstantData`. I encountered two crashes due to this change.

I added checks to guard the two calls that caused the crashes.