### PR TITLE
AbsExtAPI: make constructor private (friend AbstractInterpretation)

### DIFF
--- a/svf/include/AE/Svfexe/AbsExtAPI.h
+++ b/svf/include/AE/Svfexe/AbsExtAPI.h
@@ -48,12 +48,19 @@ public:
      */
     enum ExtAPIType { UNCLASSIFIED, MEMCPY, MEMSET, STRCPY, STRCAT };
 
+    // Only AbstractInterpretation may construct the single owned AbsExtAPI
+    // instance (reachable through its private getUtils()). Keeping the
+    // constructor private prevents external callers from creating their own
+    // AbsExtAPI and invoking handleExtAPI()/handleMemcpy()/... directly.
+    friend class AbstractInterpretation;
+private:
     /**
      * @brief Constructor for AbsExtAPI.
      * @param ae Reference to the AbstractInterpretation instance.
      */
     AbsExtAPI(AbstractInterpretation* ae);
 
+public:
     /**
      * @brief Initializes the external function map.
      */


### PR DESCRIPTION
Only AbstractInterpretation creates and owns the single AbsExtAPI instance (exposed via its already-private getUtils()). Making the constructor private prevents external code from constructing its own AbsExtAPI to call handleExtAPI()/handleMemcpy()/... directly, which is useful when AbsExtAPI must not be reachable by client code (e.g. an assignment where the external-API summaries are the task). The library itself is unaffected: the in-class new AbsExtAPI(this) in AbstractInterpretation compiles via the friend grant.