### PR TITLE
Forcefully show variable as used

### DIFF
--- a/svf/lib/DDA/DDAClient.cpp
+++ b/svf/lib/DDA/DDAClient.cpp
@@ -54,7 +54,8 @@ void DDAClient::answerQueries(PointerAnalysis* pta)
 
     collectCandidateQueries(pta->getPAG());
 
-    u32_t count = 0;
+    // We tell the compiler count is used as DBOUT ignores the statement on some builds.
+    u32_t count = 0; (void)count;
     for (OrderedNodeSet::iterator nIter = candidateQueries.begin();
             nIter != candidateQueries.end(); ++nIter,++count)
     {


### PR DESCRIPTION
We were seeing `count` being regarded as unused by the compiler on some systems.