### PR TITLE
Build ExtAPI as LLVM bitcode, not LLVM IR.

### DIFF
--- a/svf-llvm/CMakeLists.txt
+++ b/svf-llvm/CMakeLists.txt
@@ -113,7 +113,7 @@ endif()
 # Add a custom command to compile the extapi.bc bitcode file from extapi.c
 add_custom_command(
   OUTPUT ${SVF_BUILD_EXTAPI_BC}
-  COMMAND ${LLVM_CLANG} -w -S -c -fPIC -std=gnu11 -emit-llvm -o ${SVF_BUILD_EXTAPI_BC} ${EXTAPI_SRC}
+  COMMAND ${LLVM_CLANG} -w -c -fPIC -std=gnu11 -emit-llvm -o ${SVF_BUILD_EXTAPI_BC} ${EXTAPI_SRC}
   COMMENT "Generating extapi.bc LLVM bitcode file..."
   MAIN_DEPENDENCY ${EXTAPI_SRC}
   DEPENDS ${EXTAPI_SRC}


### PR DESCRIPTION
Hello!

This fixes compile options to output `extapi.bc` as LLVM bitcode instead of LLVM IR.

Best regards,
Vladimir.