### PR TITLE
Call NodeIDAllocator::unset() when llvmModuleSet released.

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMModule.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMModule.h
@@ -139,6 +139,7 @@ public:
     {
         delete llvmModuleSet;
         llvmModuleSet = nullptr;
+        NodeIDAllocator::unset();
     }
 
     // Build an SVF module from a given LLVM Module instance (for use e.g. in a LLVM pass)


### PR DESCRIPTION
Hello!

Usually, one finishes an analysis calling `releaseLLVMModuleSet()`. After that, **singleton** `NodeIDAllocator` is still alive, so that next time we start with non-empty `NodeIDAllocator` and empty `llvmModuleSet`. So, this PR empties `NodeIDAllocator` too.

Best regards,
Vladimir.