### PR TITLE
Correct shapes for DOT graph nodes

### DIFF
--- a/svf/include/Graphs/CDG.h
+++ b/svf/include/Graphs/CDG.h
@@ -420,34 +420,34 @@ struct DOTGraphTraits<SVF::CDG *> : public DOTGraphTraits<SVF::PAG *>
         std::stringstream rawstr(str);
         const SVF::ICFGNode *icfgNode = node->getICFGNode();
 
+        rawstr << "shape=record";
+
         if (SVF::SVFUtil::isa<SVF::IntraICFGNode>(icfgNode))
         {
-            rawstr << "color=black";
+            rawstr << ",color=black";
         }
         else if (SVF::SVFUtil::isa<SVF::FunEntryICFGNode>(icfgNode))
         {
-            rawstr << "color=yellow";
+            rawstr << ",color=yellow";
         }
         else if (SVF::SVFUtil::isa<SVF::FunExitICFGNode>(icfgNode))
         {
-            rawstr << "color=green";
+            rawstr << ",color=green";
         }
         else if (SVF::SVFUtil::isa<SVF::CallICFGNode>(icfgNode))
         {
-            rawstr << "color=red";
+            rawstr << ",color=red";
         }
         else if (SVF::SVFUtil::isa<SVF::RetICFGNode>(icfgNode))
         {
-            rawstr << "color=blue";
+            rawstr << ",color=blue";
         }
         else if (SVF::SVFUtil::isa<SVF::GlobalICFGNode>(icfgNode))
         {
-            rawstr << "color=purple";
+            rawstr << ",color=purple";
         }
         else
             assert(false && "no such kind of node!!");
-
-        rawstr << "";
 
         return rawstr.str();
     }

--- a/svf/include/Graphs/GraphWriter.h
+++ b/svf/include/Graphs/GraphWriter.h
@@ -171,7 +171,7 @@ public:
     {
         std::string NodeAttributes = DTraits.getNodeAttributes(Node, G);
 
-        O << "\tNode" << static_cast<const void*>(Node) << " [shape=record,";
+        O << "\tNode" << static_cast<const void*>(Node) << " [";
         if (!NodeAttributes.empty()) O << NodeAttributes << ",";
         O << "label=\"{";
 

--- a/svf/lib/Graphs/CallGraph.cpp
+++ b/svf/lib/Graphs/CallGraph.cpp
@@ -449,7 +449,7 @@ struct DOTGraphTraits<CallGraph*> : public DefaultDOTGraphTraits
         const FunObjVar* fun = node->getFunction();
         if (!SVFUtil::isExtCall(fun))
         {
-            return "shape=box";
+            return "shape=record";
         }
         else
             return "shape=Mrecord";

--- a/svf/lib/Graphs/ICFG.cpp
+++ b/svf/lib/Graphs/ICFG.cpp
@@ -516,34 +516,34 @@ struct DOTGraphTraits<ICFG*> : public DOTGraphTraits<SVFIR*>
         std::string str;
         std::stringstream rawstr(str);
 
+        rawstr <<  "shape=record";
+
         if(SVFUtil::isa<IntraICFGNode>(node))
         {
-            rawstr <<  "color=black";
+            rawstr <<  ",color=black";
         }
         else if(SVFUtil::isa<FunEntryICFGNode>(node))
         {
-            rawstr <<  "color=yellow";
+            rawstr <<  ",color=yellow";
         }
         else if(SVFUtil::isa<FunExitICFGNode>(node))
         {
-            rawstr <<  "color=green";
+            rawstr <<  ",color=green";
         }
         else if(SVFUtil::isa<CallICFGNode>(node))
         {
-            rawstr <<  "color=red";
+            rawstr <<  ",color=red";
         }
         else if(SVFUtil::isa<RetICFGNode>(node))
         {
-            rawstr <<  "color=blue";
+            rawstr <<  ",color=blue";
         }
         else if(SVFUtil::isa<GlobalICFGNode>(node))
         {
-            rawstr <<  "color=purple";
+            rawstr <<  ",color=purple";
         }
         else
             assert(false && "no such kind of node!!");
-
-        rawstr <<  "";
 
         return rawstr.str();
     }

--- a/svf/lib/Graphs/IRGraph.cpp
+++ b/svf/lib/Graphs/IRGraph.cpp
@@ -440,71 +440,79 @@ struct DOTGraphTraits<IRGraph*> : public DefaultDOTGraphTraits
     template<class EdgeIter>
     static std::string getEdgeAttributes(SVFVar*, EdgeIter EI, IRGraph*)
     {
+        std::string str;
+        std::stringstream rawstr(str);
+
+        rawstr << "shape=record";
+
         const SVFStmt* edge = *(EI.getCurrent());
         assert(edge && "No edge found!!");
         if (SVFUtil::isa<AddrStmt>(edge))
         {
-            return "color=green";
+            rawstr << ",color=green";
         }
         else if (SVFUtil::isa<CopyStmt>(edge))
         {
-            return "color=black";
+            rawstr << ",color=black";
         }
         else if (SVFUtil::isa<GepStmt>(edge))
         {
-            return "color=purple";
+            rawstr << ",color=purple";
         }
         else if (SVFUtil::isa<StoreStmt>(edge))
         {
-            return "color=blue";
+            rawstr << ",color=blue";
         }
         else if (SVFUtil::isa<LoadStmt>(edge))
         {
-            return "color=red";
+            rawstr << ",color=red";
         }
         else if (SVFUtil::isa<PhiStmt>(edge))
         {
-            return "color=grey";
+            rawstr << ",color=grey";
         }
         else if (SVFUtil::isa<SelectStmt>(edge))
         {
-            return "color=grey";
+            rawstr << ",color=grey";
         }
         else if (SVFUtil::isa<CmpStmt>(edge))
         {
-            return "color=grey";
+            rawstr << ",color=grey";
         }
         else if (SVFUtil::isa<BinaryOPStmt>(edge))
         {
-            return "color=grey";
+            rawstr << ",color=grey";
         }
         else if (SVFUtil::isa<UnaryOPStmt>(edge))
         {
-            return "color=grey";
+            rawstr << ",color=grey";
         }
         else if (SVFUtil::isa<BranchStmt>(edge))
         {
-            return "color=grey";
+            rawstr << ",color=grey";
         }
         else if (SVFUtil::isa<TDForkPE>(edge))
         {
-            return "color=Turquoise";
+            rawstr << ",color=Turquoise";
         }
         else if (SVFUtil::isa<TDJoinPE>(edge))
         {
-            return "color=Turquoise";
+            rawstr << ",color=Turquoise";
         }
         else if (SVFUtil::isa<CallPE>(edge))
         {
-            return "color=black,style=dashed";
+            rawstr << ",color=black,style=dashed";
         }
         else if (SVFUtil::isa<RetPE>(edge))
         {
-            return "color=black,style=dotted";
+            rawstr << ",color=black,style=dotted";
+        }
+        else
+        {
+            assert(false && "No such kind edge!!");
         }
 
-        assert(false && "No such kind edge!!");
-        exit(1);
+        return rawstr.str();
     }
 
     template<class EdgeIter>

--- a/svf/lib/Graphs/SVFG.cpp
+++ b/svf/lib/Graphs/SVFG.cpp
@@ -1010,98 +1010,99 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<SVFIR*>
         std::string str;
         std::stringstream rawstr(str);
 
+        rawstr << "shape=record";
+
         if(StmtSVFGNode* stmtNode = SVFUtil::dyn_cast<StmtSVFGNode>(node))
         {
             const SVFStmt* edge = stmtNode->getSVFStmt();
             if (SVFUtil::isa<AddrStmt>(edge))
             {
-                rawstr <<  "color=green";
+                rawstr <<  ",color=green";
             }
             else if (SVFUtil::isa<CopyStmt>(edge))
             {
-                rawstr <<  "color=black";
+                rawstr <<  ",color=black";
             }
             else if (SVFUtil::isa<RetPE>(edge))
             {
-                rawstr <<  "color=black,style=dotted";
+                rawstr <<  ",color=black,style=dotted";
             }
             else if (SVFUtil::isa<GepStmt>(edge))
             {
-                rawstr <<  "color=purple";
+                rawstr <<  ",color=purple";
             }
             else if (SVFUtil::isa<StoreStmt>(edge))
             {
-                rawstr <<  "color=blue";
+                rawstr <<  ",color=blue";
             }
             else if (SVFUtil::isa<LoadStmt>(edge))
             {
-                rawstr <<  "color=red";
+                rawstr <<  ",color=red";
             }
             else
             {
                 assert(0 && "No such kind edge!!");
             }
-            rawstr <<  "";
         }
         else if(SVFUtil::isa<MSSAPHISVFGNode>(node))
         {
-            rawstr <<  "color=black";
+            rawstr <<  ",color=black";
         }
         else if(SVFUtil::isa<PHISVFGNode>(node))
         {
-            rawstr <<  "color=black";
+            rawstr <<  ",color=black";
         }
         else if(SVFUtil::isa<NullPtrSVFGNode>(node))
         {
-            rawstr <<  "color=grey";
+            rawstr <<  ",color=grey";
         }
         else if(SVFUtil::isa<FormalINSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<FormalOUTSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<FormalParmSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<ActualINSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<ActualOUTSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<ActualParmSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<ActualRetSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<FormalRetSVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<BinaryOPVFGNode>(node))
         {
-            rawstr <<  "color=black,penwidth=2";
+            rawstr <<  ",color=black,penwidth=2";
         }
         else if (SVFUtil::isa<CmpVFGNode>(node))
         {
-            rawstr <<  "color=black,penwidth=2";
+            rawstr <<  ",color=black,penwidth=2";
         }
         else if (SVFUtil::isa<UnaryOPVFGNode>(node))
         {
-            rawstr <<  "color=black,penwidth=2";
+            rawstr <<  ",color=black,penwidth=2";
         }
         else if (SVFUtil::isa<BranchVFGNode>(node))
         {
-            rawstr <<  "color=gold,penwidth=2";
+            rawstr <<  ",color=gold,penwidth=2";
         }
         else
             assert(false && "no such kind of node!!");
@@ -1121,8 +1122,6 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<SVFIR*>
         }
         else if(graph->getStat()->inForwardSlice(node))
             rawstr << ",style=filled, fillcolor=gray";
-
-        rawstr <<  "";
 
         return rawstr.str();
     }

--- a/svf/lib/Graphs/VFG.cpp
+++ b/svf/lib/Graphs/VFG.cpp
@@ -1224,32 +1224,34 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<SVFIR*>
         std::string str;
         std::stringstream rawstr(str);
 
+        rawstr << "shape=record";
+
         if(StmtVFGNode* stmtNode = SVFUtil::dyn_cast<StmtVFGNode>(node))
         {
             const SVFStmt* edge = stmtNode->getSVFStmt();
             if (SVFUtil::isa<AddrStmt>(edge))
             {
-                rawstr <<  "color=green";
+                rawstr <<  ",color=green";
             }
             else if (SVFUtil::isa<CopyStmt>(edge))
             {
-                rawstr <<  "color=black";
+                rawstr <<  ",color=black";
             }
             else if (SVFUtil::isa<RetPE>(edge))
             {
-                rawstr <<  "color=black,style=dotted";
+                rawstr <<  ",color=black,style=dotted";
             }
             else if (SVFUtil::isa<GepStmt>(edge))
             {
-                rawstr <<  "color=purple";
+                rawstr <<  ",color=purple";
             }
             else if (SVFUtil::isa<StoreStmt>(edge))
             {
-                rawstr <<  "color=blue";
+                rawstr <<  ",color=blue";
             }
             else if (SVFUtil::isa<LoadStmt>(edge))
             {
-                rawstr << "color=red";
+                rawstr << ",color=red";
             }
             else
             {
@@ -1259,52 +1261,50 @@ struct DOTGraphTraits<VFG*> : public DOTGraphTraits<SVFIR*>
         }
         else if (SVFUtil::isa<CmpVFGNode>(node))
         {
-            rawstr << "color=grey";
+            rawstr << ",color=grey";
         }
         else if (SVFUtil::isa<BinaryOPVFGNode>(node))
         {
-            rawstr << "color=grey";
+            rawstr << ",color=grey";
         }
         else if (SVFUtil::isa<UnaryOPVFGNode>(node))
         {
-            rawstr << "color=grey";
+            rawstr << ",color=grey";
         }
         else if(SVFUtil::isa<PHIVFGNode>(node))
         {
-            rawstr <<  "color=black";
+            rawstr <<  ",color=black";
         }
         else if(SVFUtil::isa<NullPtrVFGNode>(node))
         {
-            rawstr <<  "color=grey";
+            rawstr <<  ",color=grey";
         }
         else if(SVFUtil::isa<FormalParmVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if(SVFUtil::isa<ActualParmVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<ActualRetVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<FormalRetVFGNode>(node))
         {
-            rawstr <<  "color=yellow,penwidth=2";
+            rawstr <<  ",color=yellow,penwidth=2";
         }
         else if (SVFUtil::isa<MRSVFGNode>(node))
         {
-            rawstr <<  "color=orange,penwidth=2";
+            rawstr <<  ",color=orange,penwidth=2";
         }
         else if (SVFUtil::isa<BranchVFGNode>(node))
         {
-            rawstr <<  "color=gold,penwidth=2";
+            rawstr <<  ",color=gold,penwidth=2";
         }
         else
             assert(false && "no such kind of node!!");
-
-        rawstr <<  "";
 
         return rawstr.str();
     }

--- a/svf/lib/MTA/TCT.cpp
+++ b/svf/lib/MTA/TCT.cpp
@@ -612,11 +612,11 @@ struct DOTGraphTraits<TCT*> : public DefaultDOTGraphTraits
         std::string attr;
         if (node->isInloop())
         {
-            attr.append(" style=filled fillcolor=red");
+            attr.append("shape=record,style=filled,fillcolor=red");
         }
         else if (node->isIncycle())
         {
-            attr.append(" style=filled fillcolor=yellow");
+            attr.append("shape=record,style=filled,fillcolor=yellow");
         }
         return attr;
     }


### PR DESCRIPTION
Fixes #307. There is now no longer a shape applied to every graph but every graph must specify what shapes it wants for its nodes. Previously this would have caused a problem of having both the generic shape and the specific shape.