### PR TITLE
Pull some enums out of major classes

### DIFF
--- a/svf-llvm/include/SVF-LLVM/LLVMModule.h
+++ b/svf-llvm/include/SVF-LLVM/LLVMModule.h
@@ -35,6 +35,8 @@
 #include "SVF-LLVM/BasicTypes.h"
 #include "Util/Options.h"
 #include "Graphs/BasicBlockG.h"
+#include "Graphs/ICFGNode.h"
+#include "SVFIR/SVFIR.h"
 
 namespace SVF
 {

--- a/svf/include/CFL/CFLAlias.h
+++ b/svf/include/CFL/CFLAlias.h
@@ -44,7 +44,7 @@ class CFLAlias : public CFLBase
 public:
     typedef OrderedMap<const CallICFGNode*, NodeID> CallSite2DummyValPN;
 
-    CFLAlias(SVFIR* ir) : CFLBase(ir, PointerAnalysis::CFLFICI_WPA)
+    CFLAlias(SVFIR* ir) : CFLBase(ir, PTATY::CFLFICI_WPA)
     {
     }
 

--- a/svf/include/CFL/CFLBase.h
+++ b/svf/include/CFL/CFLBase.h
@@ -36,8 +36,10 @@
 #include "CFL/CFLGraphBuilder.h"
 #include "CFL/CFLGramGraphChecker.h"
 #include "MemoryModel/PointerAnalysis.h"
+#include "MemoryModel/PointerAnalysisImpl.h"
 #include "Graphs/ConsG.h"
 #include "Util/Options.h"
+#include "Util/PTAStat.h"
 #include "SVFIR/SVFType.h"
 
 namespace SVF
@@ -50,7 +52,7 @@ class CFLBase : public BVDataPTAImpl
 {
 
 public:
-    CFLBase(SVFIR* ir, PointerAnalysis::PTATY pty) : BVDataPTAImpl(ir, pty), svfir(ir), graph(nullptr), grammar(nullptr), solver(nullptr)
+    CFLBase(SVFIR* ir, PTATY pty) : BVDataPTAImpl(ir, pty), svfir(ir), graph(nullptr), grammar(nullptr), solver(nullptr)
     {
     }
 

--- a/svf/include/CFL/CFLVF.h
+++ b/svf/include/CFL/CFLVF.h
@@ -42,7 +42,7 @@ class CFLVF : public CFLBase
 {
 
 public:
-    CFLVF(SVFIR* ir) : CFLBase(ir, PointerAnalysis::CFLFSCS_WPA)
+    CFLVF(SVFIR* ir) : CFLBase(ir, PTATY::CFLFSCS_WPA)
     {
     }
 

--- a/svf/include/DDA/FlowDDA.h
+++ b/svf/include/DDA/FlowDDA.h
@@ -58,7 +58,7 @@ public:
     typedef BVDataPTAImpl::CallEdgeMap	CallEdgeMap;
     typedef BVDataPTAImpl::FunctionSet	FunctionSet;
     /// Constructor
-    FlowDDA(SVFIR* _pag, DDAClient* client): BVDataPTAImpl(_pag, PointerAnalysis::FlowS_DDA),
+    FlowDDA(SVFIR* _pag, DDAClient* client): BVDataPTAImpl(_pag, PTATY::FlowS_DDA),
         DDAVFSolver<NodeID,PointsTo,LocDPItem>(),
         _client(client)
     {

--- a/svf/include/Graphs/GraphWriter.h
+++ b/svf/include/Graphs/GraphWriter.h
@@ -24,6 +24,7 @@
 
 #include "Graphs/GraphTraits.h"
 #include "Graphs/DOTGraphTraits.h"
+#include "Util/Options.h"
 #include <algorithm>
 #include <cstddef>
 #include <iterator>

--- a/svf/include/Graphs/SCC.h
+++ b/svf/include/Graphs/SCC.h
@@ -41,6 +41,7 @@
 #define SCC_H_
 
 #include "SVFIR/SVFValue.h"	// for NodeBS
+#include "Util/WorkList.h"	// for NodeBS
 #include <limits.h>
 #include <stack>
 #include <map>

--- a/svf/include/MTA/MTA.h
+++ b/svf/include/MTA/MTA.h
@@ -36,6 +36,7 @@
 
 #include <set>
 #include <vector>
+#include "SVFIR/SVFIR.h"
 #include "SVFIR/SVFValue.h"
 
 namespace SVF

--- a/svf/include/MTA/TCT.h
+++ b/svf/include/MTA/TCT.h
@@ -30,6 +30,7 @@
 #ifndef TCTNodeDetector_H_
 #define TCTNodeDetector_H_
 
+#include "MemoryModel/PointerAnalysis.h"
 #include "Graphs/SCC.h"
 #include "Graphs/ThreadCallGraph.h"
 #include "Util/CxtStmt.h"

--- a/svf/include/MemoryModel/PTATY.h
+++ b/svf/include/MemoryModel/PTATY.h
@@ -1,0 +1,54 @@
+#ifndef PTATY_H
+#define PTATY_H
+
+namespace SVF {
+
+/// Pointer analysis type list
+enum PTATY
+{
+    // Whole program analysis
+    Andersen_BASE,		///< Base Andersen PTA
+    Andersen_WPA,		///< Andersen PTA
+    AndersenSCD_WPA,    ///< Selective cycle detection andersen-style WPA
+    AndersenSFR_WPA,    ///< Stride-based field representation
+    AndersenWaveDiff_WPA,	///< Diff wave propagation andersen-style WPA
+    Steensgaard_WPA,      ///< Steensgaard PTA
+    CSCallString_WPA,	///< Call string based context sensitive WPA
+    CSSummary_WPA,		///< Summary based context sensitive WPA
+    FSDATAFLOW_WPA,	///< Traditional Dataflow-based flow sensitive WPA
+    FSSPARSE_WPA,		///< Sparse flow sensitive WPA
+    VFS_WPA,		///< Versioned sparse flow-sensitive WPA
+    FSCS_WPA,			///< Flow-, context- sensitive WPA
+    CFLFICI_WPA,		///< Flow-, context-, insensitive CFL-reachability-based analysis
+    CFLFSCI_WPA,		///< Flow-insensitive, context-sensitive CFL-reachability-based analysis
+    CFLFSCS_WPA,	///< Flow-, context-, CFL-reachability-based analysis
+    TypeCPP_WPA, ///<  Type-based analysis for C++
+
+    // Demand driven analysis
+    FieldS_DDA,		///< Field sensitive DDA
+    FlowS_DDA,		///< Flow sensitive DDA
+    PathS_DDA,		///< Guarded value-flow DDA
+    Cxt_DDA,		///< context sensitive DDA
+
+
+    Default_PTA		///< default pta without any analysis
+};
+
+/// Implementation type: BVDataPTAImpl or CondPTAImpl.
+enum PTAImplTy
+{
+    BaseImpl,   ///< Represents PointerAnalaysis.
+    BVDataImpl, ///< Represents BVDataPTAImpl.
+    CondImpl,   ///< Represents CondPTAImpl.
+};
+
+/// How the PTData used is implemented.
+enum PTBackingType
+{
+    Mutable,
+    Persistent,
+};
+
+}  // namespace SVF
+
+#endif // PTATY_H

--- a/svf/include/MemoryModel/PointerAnalysis.h
+++ b/svf/include/MemoryModel/PointerAnalysis.h
@@ -41,6 +41,7 @@
 #include "MemoryModel/MutablePointsToDS.h"
 #include "MemoryModel/PersistentPointsToDS.h"
 #include "MemoryModel/PointsTo.h"
+#include "MemoryModel/PTATY.h"
 #include "SVFIR/SVFIR.h"
 
 namespace SVF
@@ -57,45 +58,6 @@ class PointerAnalysis
 {
 
 public:
-    /// Pointer analysis type list
-    enum PTATY
-    {
-        // Whole program analysis
-        Andersen_BASE,		///< Base Andersen PTA
-        Andersen_WPA,		///< Andersen PTA
-        AndersenSCD_WPA,    ///< Selective cycle detection andersen-style WPA
-        AndersenSFR_WPA,    ///< Stride-based field representation
-        AndersenWaveDiff_WPA,	///< Diff wave propagation andersen-style WPA
-        Steensgaard_WPA,      ///< Steensgaard PTA
-        CSCallString_WPA,	///< Call string based context sensitive WPA
-        CSSummary_WPA,		///< Summary based context sensitive WPA
-        FSDATAFLOW_WPA,	///< Traditional Dataflow-based flow sensitive WPA
-        FSSPARSE_WPA,		///< Sparse flow sensitive WPA
-        VFS_WPA,		///< Versioned sparse flow-sensitive WPA
-        FSCS_WPA,			///< Flow-, context- sensitive WPA
-        CFLFICI_WPA,		///< Flow-, context-, insensitive CFL-reachability-based analysis
-        CFLFSCI_WPA,		///< Flow-insensitive, context-sensitive CFL-reachability-based analysis
-        CFLFSCS_WPA,	///< Flow-, context-, CFL-reachability-based analysis
-        TypeCPP_WPA, ///<  Type-based analysis for C++
-
-        // Demand driven analysis
-        FieldS_DDA,		///< Field sensitive DDA
-        FlowS_DDA,		///< Flow sensitive DDA
-        PathS_DDA,		///< Guarded value-flow DDA
-        Cxt_DDA,		///< context sensitive DDA
-
-
-        Default_PTA		///< default pta without any analysis
-    };
-
-    /// Implementation type: BVDataPTAImpl or CondPTAImpl.
-    enum PTAImplTy
-    {
-        BaseImpl,   ///< Represents PointerAnalaysis.
-        BVDataImpl, ///< Represents BVDataPTAImpl.
-        CondImpl,   ///< Represents CondPTAImpl.
-    };
-
     /// Indirect call edges type, map a callsite to a set of callees
     //@{
     typedef Set<const CallICFGNode*> CallSiteSet;
@@ -176,7 +138,7 @@ public:
     }
 
     /// Constructor
-    PointerAnalysis(SVFIR* pag, PTATY ty = Default_PTA, bool alias_check = true);
+    PointerAnalysis(SVFIR* pag, PTATY ty = PTATY::Default_PTA, bool alias_check = true);
 
     /// Type of pointer analysis
     inline PTATY getAnalysisTy() const

--- a/svf/include/MemoryModel/PointerAnalysisImpl.h
+++ b/svf/include/MemoryModel/PointerAnalysisImpl.h
@@ -31,6 +31,7 @@
 #define INCLUDE_MEMORYMODEL_POINTERANALYSISIMPL_H_
 
 #include <Graphs/ConsG.h>
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointerAnalysis.h"
 
 namespace SVF
@@ -60,15 +61,8 @@ public:
     typedef PersistentIncDFPTData<NodeID, NodeSet, NodeID, PointsTo> PersIncDFPTDataTy;
     typedef PersistentVersionedPTData<NodeID, NodeSet, NodeID, PointsTo, VersionedVar, Set<VersionedVar>> PersVersionedPTDataTy;
 
-    /// How the PTData used is implemented.
-    enum PTBackingType
-    {
-        Mutable,
-        Persistent,
-    };
-
     /// Constructor
-    BVDataPTAImpl(SVFIR* pag, PointerAnalysis::PTATY type, bool alias_check = true);
+    BVDataPTAImpl(SVFIR* pag, PTATY type, bool alias_check = true);
 
     /// Destructor
     ~BVDataPTAImpl() override = default;
@@ -80,7 +74,7 @@ public:
 
     static inline bool classof(const PointerAnalysis *pta)
     {
-        return pta->getImplTy() == BVDataImpl;
+        return pta->getImplTy() == PTAImplTy::BVDataImpl;
     }
 
     /// Get points-to and reverse points-to
@@ -257,14 +251,14 @@ public:
     typedef Map<NodeID,CPtSet> PtrToCPtsMap;	 /// map a pointer to its conditional points-to set
 
     /// Constructor
-    CondPTAImpl(SVFIR* pag, PointerAnalysis::PTATY type) : PointerAnalysis(pag, type), normalized(false)
+    CondPTAImpl(SVFIR* pag, PTATY type) : PointerAnalysis(pag, type), normalized(false)
     {
-        if (type == PathS_DDA || type == Cxt_DDA)
+        if (type == PTATY::PathS_DDA || type == PTATY::Cxt_DDA)
             ptD = new MutPTDataTy();
         else
             assert(false && "no points-to data available");
 
-        ptaImplTy = CondImpl;
+        ptaImplTy = PTAImplTy::CondImpl;
     }
 
     /// Destructor
@@ -275,7 +269,7 @@ public:
 
     static inline bool classof(const PointerAnalysis *pta)
     {
-        return pta->getImplTy() == CondImpl;
+        return pta->getImplTy() == PTAImplTy::CondImpl;
     }
 
     /// Release memory
@@ -527,7 +521,7 @@ public:
         expandFIObjs(pts2,cpts2);
         if (containBlackHoleNode(cpts1) || containBlackHoleNode(cpts2))
             return AliasResult::MayAlias;
-        else if(this->getAnalysisTy()==PathS_DDA && contains(cpts1,cpts2) && contains(cpts2,cpts1))
+        else if(this->getAnalysisTy() == PTATY::PathS_DDA && contains(cpts1,cpts2) && contains(cpts2,cpts1))
         {
             return AliasResult::MustAlias;
         }

--- a/svf/include/Util/Options.h
+++ b/svf/include/Util/Options.h
@@ -5,8 +5,8 @@
 
 #include <sstream>
 #include "Util/CommandLine.h"
-#include "Util/PTAStat.h"
-#include "MemoryModel/PointerAnalysisImpl.h"
+#include "Util/SVFStat.h"
+#include "MemoryModel/PTATY.h"
 #include "Util/NodeIDAllocator.h"
 
 namespace SVF
@@ -18,7 +18,7 @@ class Options
 public:
     Options(void) = delete;
 
-    static const OptionMap<enum PTAStat::ClockType> ClockType;
+    static const OptionMap<SVFStat::ClockType> ClockType;
 
     /// If set, only return the clock when getClk is called as getClk(true).
     /// Retrieving the clock is slow but it should be fine for a few calls.
@@ -63,7 +63,7 @@ public:
     static const Option<bool> PredictPtOcc;
 
     /// PTData type.
-    static const OptionMap<BVDataPTAImpl::PTBackingType> ptDataBacking;
+    static const OptionMap<PTBackingType> ptDataBacking;
 
     /// Time limit for the main phase (i.e., the actual solving) of FS analyses.
     static const Option<u32_t> FsTimeLimit;
@@ -87,7 +87,7 @@ public:
     static const Option<bool> PrintCPts;
     static const Option<bool> PrintQueryPts;
     static const Option<bool> WPANum;
-    static OptionMultiple<PointerAnalysis::PTATY> DDASelected;
+    static OptionMultiple<PTATY> DDASelected;
 
     // FlowDDA.cpp
     static const Option<u32_t> FlowBudget;
@@ -215,7 +215,7 @@ public:
     static const Option<bool> AnderSVFG;
     static const Option<bool> SABERFULLSVFG;
     static const Option<bool> PrintAliases;
-    static OptionMultiple<PointerAnalysis::PTATY> PASelected;
+    static OptionMultiple<PTATY> PASelected;
     static OptionMultiple<u32_t> AliasRule;
 
     // DOTGraphTraits
@@ -266,6 +266,9 @@ public:
 
     // float precision for symbolic abstraction
     static const Option<u32_t> AEPrecision;
+
+    // GraphWriter.h
+    static const Option<u32_t> MaxNodeLabelLength;
 };
 }  // namespace SVF
 

--- a/svf/include/Util/SVFStat.h
+++ b/svf/include/Util/SVFStat.h
@@ -30,6 +30,8 @@
 #ifndef SVF_SVFSTAT_H
 #define SVF_SVFSTAT_H
 
+#include "MemoryModel/PointsTo.h"
+
 namespace SVF
 {
 
@@ -45,7 +47,7 @@ public:
 
     typedef OrderedMap<std::string, double> TIMEStatMap;
 
-    enum ClockType
+    enum class ClockType
     {
         Wall,
         CPU,

--- a/svf/include/WPA/Andersen.h
+++ b/svf/include/WPA/Andersen.h
@@ -35,6 +35,7 @@
 #ifndef INCLUDE_WPA_ANDERSEN_H_
 #define INCLUDE_WPA_ANDERSEN_H_
 
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "WPA/WPAStat.h"
 #include "WPA/WPASolver.h"
@@ -61,7 +62,7 @@ public:
 public:
 
     /// Constructor
-    AndersenBase(SVFIR* _pag, PTATY type = Andersen_BASE, bool alias_check = true)
+    AndersenBase(SVFIR* _pag, PTATY type = PTATY::Andersen_BASE, bool alias_check = true)
         :  BVDataPTAImpl(_pag, type, alias_check), consCG(nullptr)
     {
         iterationForPrintStat = OnTheFlyIterBudgetForStat;
@@ -107,13 +108,13 @@ public:
     }
     static inline bool classof(const PointerAnalysis *pta)
     {
-        return ( pta->getAnalysisTy() == Andersen_BASE
-                 || pta->getAnalysisTy() == Andersen_WPA
-                 || pta->getAnalysisTy() == AndersenWaveDiff_WPA
-                 || pta->getAnalysisTy() == AndersenSCD_WPA
-                 || pta->getAnalysisTy() == AndersenSFR_WPA
-                 || pta->getAnalysisTy() == TypeCPP_WPA
-                 || pta->getAnalysisTy() == Steensgaard_WPA);
+        return ( pta->getAnalysisTy() == PTATY::Andersen_BASE
+                 || pta->getAnalysisTy() == PTATY::Andersen_WPA
+                 || pta->getAnalysisTy() == PTATY::AndersenWaveDiff_WPA
+                 || pta->getAnalysisTy() == PTATY::AndersenSCD_WPA
+                 || pta->getAnalysisTy() == PTATY::AndersenSFR_WPA
+                 || pta->getAnalysisTy() == PTATY::TypeCPP_WPA
+                 || pta->getAnalysisTy() == PTATY::Steensgaard_WPA);
     }
     //@}
 
@@ -193,7 +194,7 @@ public:
     typedef SCCDetection<ConstraintGraph*> CGSCC;
 
     /// Constructor
-    Andersen(SVFIR* _pag, PTATY type = Andersen_WPA, bool alias_check = true)
+    Andersen(SVFIR* _pag, PTATY type = PTATY::Andersen_WPA, bool alias_check = true)
         :  AndersenBase(_pag, type, alias_check)
     {
     }
@@ -227,10 +228,10 @@ public:
     }
     static inline bool classof(const PointerAnalysis *pta)
     {
-        return (pta->getAnalysisTy() == Andersen_WPA
-                || pta->getAnalysisTy() == AndersenWaveDiff_WPA
-                || pta->getAnalysisTy() == AndersenSCD_WPA
-                || pta->getAnalysisTy() == AndersenSFR_WPA);
+        return (pta->getAnalysisTy() == PTATY::Andersen_WPA
+                || pta->getAnalysisTy() == PTATY::AndersenWaveDiff_WPA
+                || pta->getAnalysisTy() == PTATY::AndersenSCD_WPA
+                || pta->getAnalysisTy() == PTATY::AndersenSFR_WPA);
     }
     //@}
 
@@ -401,14 +402,14 @@ private:
     static AndersenWaveDiff* diffWave; // static instance
 
 public:
-    AndersenWaveDiff(SVFIR* _pag, PTATY type = AndersenWaveDiff_WPA, bool alias_check = true): Andersen(_pag, type, alias_check) {}
+    AndersenWaveDiff(SVFIR* _pag, PTATY type = PTATY::AndersenWaveDiff_WPA, bool alias_check = true): Andersen(_pag, type, alias_check) {}
 
     /// Create an singleton instance directly instead of invoking llvm pass manager
     static AndersenWaveDiff* createAndersenWaveDiff(SVFIR* _pag)
     {
         if(diffWave==nullptr)
         {
-            diffWave = new AndersenWaveDiff(_pag, AndersenWaveDiff_WPA, false);
+            diffWave = new AndersenWaveDiff(_pag, PTATY::AndersenWaveDiff_WPA, false);
             diffWave->analyze();
             return diffWave;
         }

--- a/svf/include/WPA/AndersenPWC.h
+++ b/svf/include/WPA/AndersenPWC.h
@@ -33,6 +33,7 @@
 
 #include "WPA/Andersen.h"
 #include "WPA/CSC.h"
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointsTo.h"
 
 namespace SVF
@@ -52,7 +53,7 @@ protected:
     NodeToNodeMap pwcReps;
 
 public:
-    AndersenSCD(SVFIR* _pag, PTATY type = AndersenSCD_WPA) :
+    AndersenSCD(SVFIR* _pag, PTATY type = PTATY::AndersenSCD_WPA) :
         Andersen(_pag,type)
     {
     }
@@ -114,7 +115,7 @@ private:
     FieldReps fieldReps;
 
 public:
-    AndersenSFR(SVFIR* _pag, PTATY type = AndersenSFR_WPA) :
+    AndersenSFR(SVFIR* _pag, PTATY type = PTATY::AndersenSFR_WPA) :
         AndersenSCD(_pag, type), csc(nullptr)
     {
     }

--- a/svf/include/WPA/FlowSensitive.h
+++ b/svf/include/WPA/FlowSensitive.h
@@ -57,7 +57,7 @@ public:
     typedef BVDataPTAImpl::MutDFPTDataTy::PtsMap PtsMap;
 
     /// Constructor
-    explicit FlowSensitive(SVFIR* _pag, PTATY type = FSSPARSE_WPA) : WPASVFGFSSolver(), BVDataPTAImpl(_pag, type)
+    explicit FlowSensitive(SVFIR* _pag, PTATY type = PTATY::FSSPARSE_WPA) : WPASVFGFSSolver(), BVDataPTAImpl(_pag, type)
     {
         svfg = nullptr;
         solveTime = sccTime = processTime = propagationTime = updateTime = 0;
@@ -126,7 +126,7 @@ public:
     }
     static inline bool classof(const PointerAnalysis *pta)
     {
-        return pta->getAnalysisTy() == FSSPARSE_WPA;
+        return pta->getAnalysisTy() == PTATY::FSSPARSE_WPA;
     }
     //@}
 

--- a/svf/include/WPA/VersionedFlowSensitive.h
+++ b/svf/include/WPA/VersionedFlowSensitive.h
@@ -18,6 +18,7 @@
 #include "MSSA/SVFGBuilder.h"
 #include "WPA/FlowSensitive.h"
 #include "WPA/WPAFSSolver.h"
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointsTo.h"
 
 namespace SVF
@@ -50,7 +51,7 @@ public:
     static VersionedVar atKey(NodeID, Version);
 
     /// Constructor
-    VersionedFlowSensitive(SVFIR *_pag, PTATY type = VFS_WPA);
+    VersionedFlowSensitive(SVFIR *_pag, PTATY type = PTATY::VFS_WPA);
 
     /// Initialize analysis
     virtual void initialize() override;
@@ -72,7 +73,7 @@ public:
     }
     static inline bool classof(const PointerAnalysis *pta)
     {
-        return pta->getAnalysisTy() == VFS_WPA;
+        return pta->getAnalysisTy() == PTATY::VFS_WPA;
     }
     //@}
 

--- a/svf/lib/AE/Core/AbstractState.cpp
+++ b/svf/lib/AE/Core/AbstractState.cpp
@@ -27,6 +27,7 @@
  *
  */
 
+#include <iomanip>
 #include "AE/Core/AbstractState.h"
 #include "SVFIR/SVFIR.h"
 #include "Util/SVFUtil.h"

--- a/svf/lib/DDA/ContextDDA.cpp
+++ b/svf/lib/DDA/ContextDDA.cpp
@@ -40,7 +40,7 @@ using namespace SVFUtil;
  * Constructor
  */
 ContextDDA::ContextDDA(SVFIR* _pag,  DDAClient* client)
-    : CondPTAImpl<ContextCond>(_pag, PointerAnalysis::Cxt_DDA),DDAVFSolver<CxtVar,CxtPtSet,CxtLocDPItem>(),
+    : CondPTAImpl<ContextCond>(_pag, PTATY::Cxt_DDA),DDAVFSolver<CxtVar,CxtPtSet,CxtLocDPItem>(),
       _client(client)
 {
     flowDDA = new FlowDDA(_pag, client);

--- a/svf/lib/DDA/DDAPass.cpp
+++ b/svf/lib/DDA/DDAPass.cpp
@@ -59,10 +59,9 @@ void DDAPass::runOnModule(SVFIR* pag)
 
     selectClient();
 
-    for (u32_t i = PointerAnalysis::FlowS_DDA;
-            i < PointerAnalysis::Default_PTA; i++)
+    for (u32_t i = PTATY::FlowS_DDA; i < PTATY::Default_PTA; i++)
     {
-        PointerAnalysis::PTATY iPtTy = static_cast<PointerAnalysis::PTATY>(i);
+        PTATY iPtTy = static_cast<PTATY>(i);
         if (Options::DDASelected(iPtTy))
             runPointerAnalysis(pag, i);
     }
@@ -114,12 +113,12 @@ void DDAPass::runPointerAnalysis(SVFIR* pag, u32_t kind)
     /// Initialize pointer analysis.
     switch (kind)
     {
-    case PointerAnalysis::Cxt_DDA:
+    case PTATY::Cxt_DDA:
     {
         _pta = std::make_unique<ContextDDA>(pag, _client);
         break;
     }
-    case PointerAnalysis::FlowS_DDA:
+    case PTATY::FlowS_DDA:
     {
         _pta = std::make_unique<FlowDDA>(pag, _client);
         break;

--- a/svf/lib/Graphs/CallGraph.cpp
+++ b/svf/lib/Graphs/CallGraph.cpp
@@ -28,6 +28,8 @@
  *      Author: Yulei Sui
  */
 
+#include <functional>
+
 #include "Graphs/CallGraph.h"
 #include "SVFIR/SVFIR.h"
 #include "Util/Options.h"

--- a/svf/lib/Graphs/SVFG.cpp
+++ b/svf/lib/Graphs/SVFG.cpp
@@ -852,10 +852,11 @@ struct DOTGraphTraits<SVFG*> : public DOTGraphTraits<SVFIR*>
 
     std::string getNodeLabel(NodeType *node, SVFG *graph)
     {
+        std::string cool = std::string(240, '-');
         if (isSimple())
-            return getSimpleNodeLabel(node, graph);
+            return cool + getSimpleNodeLabel(node, graph);
         else
-            return getCompleteNodeLabel(node, graph);
+            return cool + getCompleteNodeLabel(node, graph);
     }
 
     /// Return label of a VFG node without MemSSA information

--- a/svf/lib/Graphs/VFG.cpp
+++ b/svf/lib/Graphs/VFG.cpp
@@ -27,10 +27,11 @@
  *      Author: Yulei Sui
  */
 
-
+#include "MemoryModel/PointerAnalysis.h"
 #include <Graphs/SVFGNode.h>
-#include "Util/Options.h"
+#include "Graphs/CallGraph.h"
 #include "Graphs/VFG.h"
+#include "Util/Options.h"
 #include "Util/SVFUtil.h"
 
 using namespace SVF;
@@ -928,8 +929,8 @@ void VFG::view()
 void VFG::updateCallGraph(PointerAnalysis* pta)
 {
     VFGEdgeSetTy vfEdgesAtIndCallSite;
-    PointerAnalysis::CallEdgeMap::const_iterator iter = pta->getIndCallMap().begin();
-    PointerAnalysis::CallEdgeMap::const_iterator eiter = pta->getIndCallMap().end();
+    CallGraph::CallEdgeMap::const_iterator iter = pta->getIndCallMap().begin();
+    CallGraph::CallEdgeMap::const_iterator eiter = pta->getIndCallMap().end();
     for (; iter != eiter; iter++)
     {
         const CallICFGNode* newcs = iter->first;

--- a/svf/lib/MSSA/MemRegion.cpp
+++ b/svf/lib/MSSA/MemRegion.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "Util/Options.h"
+#include "MemoryModel/PointerAnalysisImpl.h"
 #include "MSSA/MemRegion.h"
 #include "MSSA/MSSAMuChi.h"
 #include "Graphs/CallGraph.h"

--- a/svf/lib/MSSA/MemSSA.cpp
+++ b/svf/lib/MSSA/MemSSA.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "Util/Options.h"
+#include "MemoryModel/PointerAnalysisImpl.h"
 #include "MSSA/MemPartition.h"
 #include "MSSA/MemSSA.h"
 #include "Graphs/SVFGStat.h"
@@ -48,7 +49,7 @@ double MemSSA::timeOfSSARenaming  = 0;	///< Time for SSA rename
 MemSSA::MemSSA(BVDataPTAImpl* p, bool ptrOnlyMSSA)
 {
     pta = p;
-    assert((pta->getAnalysisTy()!=PointerAnalysis::Default_PTA)
+    assert((pta->getAnalysisTy() != PTATY::Default_PTA)
            && "please specify a pointer analysis");
 
     if (Options::MemPar() == MemPartition::Distinct)

--- a/svf/lib/MemoryModel/AccessPath.cpp
+++ b/svf/lib/MemoryModel/AccessPath.cpp
@@ -29,8 +29,10 @@
  *
  */
 
-#include "Util/Options.h"
 #include "MemoryModel/AccessPath.h"
+#include "SVFIR/SVFIR.h"
+#include "SVFIR/SVFVariables.h"
+#include "Util/Options.h"
 #include "Util/SVFUtil.h"
 
 using namespace SVF;

--- a/svf/lib/MemoryModel/PointerAnalysis.cpp
+++ b/svf/lib/MemoryModel/PointerAnalysis.cpp
@@ -30,6 +30,7 @@
 #include "Util/Options.h"
 #include "Util/SVFUtil.h"
 
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "SVFIR/PAGBuilderFromFile.h"
 #include "Util/PTAStat.h"
@@ -72,7 +73,7 @@ PointerAnalysis::PointerAnalysis(SVFIR *p, PTATY ty, bool alias_check) : ptaTy(t
     pag = p;
     OnTheFlyIterBudgetForStat = Options::StatBudget();
     print_stat = Options::PStat();
-    ptaImplTy = BaseImpl;
+    ptaImplTy = PTAImplTy::BaseImpl;
     alias_validation = (alias_check && Options::EnableAliasCheck());
 }
 

--- a/svf/lib/MemoryModel/PointerAnalysisImpl.cpp
+++ b/svf/lib/MemoryModel/PointerAnalysisImpl.cpp
@@ -29,6 +29,7 @@
  */
 
 
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "Util/Options.h"
 #include <fstream>
@@ -43,12 +44,12 @@ using namespace std;
 /*!
  * Constructor
  */
-BVDataPTAImpl::BVDataPTAImpl(SVFIR* p, PointerAnalysis::PTATY type, bool alias_check) :
+BVDataPTAImpl::BVDataPTAImpl(SVFIR* p, PTATY type, bool alias_check) :
     PointerAnalysis(p, type, alias_check), ptCache()
 {
-    if (type == Andersen_BASE || type == Andersen_WPA || type == AndersenWaveDiff_WPA
-            || type == TypeCPP_WPA || type == FlowS_DDA
-            || type == AndersenSCD_WPA || type == AndersenSFR_WPA || type == CFLFICI_WPA || type == CFLFSCS_WPA)
+    if (type == PTATY::Andersen_BASE || type == PTATY::Andersen_WPA || type == PTATY::AndersenWaveDiff_WPA
+            || type == PTATY::TypeCPP_WPA || type == PTATY::FlowS_DDA
+            || type == PTATY::AndersenSCD_WPA || type == PTATY::AndersenSFR_WPA || type == PTATY::CFLFICI_WPA || type == PTATY::CFLFSCS_WPA)
     {
         // Only maintain reverse points-to when the analysis is field-sensitive, as objects turning
         // field-insensitive is all it is used for.
@@ -57,14 +58,14 @@ BVDataPTAImpl::BVDataPTAImpl(SVFIR* p, PointerAnalysis::PTATY type, bool alias_c
         else if (Options::ptDataBacking() == PTBackingType::Persistent) ptD = std::make_unique<PersDiffPTDataTy>(getPtCache(), maintainRevPts);
         else assert(false && "BVDataPTAImpl::BVDataPTAImpl: unexpected points-to backing type!");
     }
-    else if (type == Steensgaard_WPA)
+    else if (type == PTATY::Steensgaard_WPA)
     {
         // Steensgaard is only field-insensitive (for now?), so no reverse points-to.
         if (Options::ptDataBacking() == PTBackingType::Mutable) ptD = std::make_unique<MutDiffPTDataTy>(false);
         else if (Options::ptDataBacking() == PTBackingType::Persistent) ptD = std::make_unique<PersDiffPTDataTy>(getPtCache(), false);
         else assert(false && "BVDataPTAImpl::BVDataPTAImpl: unexpected points-to backing type!");
     }
-    else if (type == FSSPARSE_WPA)
+    else if (type == PTATY::FSSPARSE_WPA)
     {
         if (Options::INCDFPTData())
         {
@@ -79,7 +80,7 @@ BVDataPTAImpl::BVDataPTAImpl(SVFIR* p, PointerAnalysis::PTATY type, bool alias_c
             else assert(false && "BVDataPTAImpl::BVDataPTAImpl: unexpected points-to backing type!");
         }
     }
-    else if (type == VFS_WPA)
+    else if (type == PTATY::VFS_WPA)
     {
         if (Options::ptDataBacking() == PTBackingType::Mutable) ptD = std::make_unique<MutVersionedPTDataTy>(false);
         else if (Options::ptDataBacking() == PTBackingType::Persistent) ptD = std::make_unique<PersVersionedPTDataTy>(getPtCache(), false);
@@ -87,7 +88,7 @@ BVDataPTAImpl::BVDataPTAImpl(SVFIR* p, PointerAnalysis::PTATY type, bool alias_c
     }
     else assert(false && "no points-to data available");
 
-    ptaImplTy = BVDataImpl;
+    ptaImplTy = PTAImplTy::BVDataImpl;
 }
 
 void BVDataPTAImpl::finalize()
@@ -104,15 +105,15 @@ void BVDataPTAImpl::finalize()
 
         std::string subtitle;
 
-        if(ptaTy >= Andersen_BASE && ptaTy <= Steensgaard_WPA)
+        if(ptaTy >= PTATY::Andersen_BASE && ptaTy <= PTATY::Steensgaard_WPA)
             subtitle = "Andersen's analysis bitvector";
-        else if(ptaTy >=FSDATAFLOW_WPA && ptaTy <=FSCS_WPA)
+        else if(ptaTy >= PTATY::FSDATAFLOW_WPA && ptaTy <= PTATY::FSCS_WPA)
             subtitle = "flow-sensitive analysis bitvector";
-        else if(ptaTy >=CFLFICI_WPA && ptaTy <=CFLFSCS_WPA)
+        else if(ptaTy >= PTATY::CFLFICI_WPA && ptaTy <= PTATY::CFLFSCS_WPA)
             subtitle = "CFL analysis bitvector";
-        else if(ptaTy == TypeCPP_WPA)
+        else if(ptaTy == PTATY::TypeCPP_WPA)
             subtitle = "Type analysis bitvector";
-        else if(ptaTy >=FieldS_DDA && ptaTy <=Cxt_DDA)
+        else if(ptaTy >= PTATY::FieldS_DDA && ptaTy <= PTATY::Cxt_DDA)
             subtitle = "DDA bitvector";
         else
             subtitle = "bitvector";

--- a/svf/lib/SVFIR/SVFIR.cpp
+++ b/svf/lib/SVFIR/SVFIR.cpp
@@ -29,6 +29,7 @@
 
 #include "Util/Options.h"
 #include "SVFIR/SVFIR.h"
+#include "Graphs/CHG.h"
 #include "Graphs/CallGraph.h"
 
 using namespace SVF;

--- a/svf/lib/SVFIR/SVFVariables.cpp
+++ b/svf/lib/SVFIR/SVFVariables.cpp
@@ -29,6 +29,7 @@
  *      Author: Xiao Cheng, Yulei Sui
  */
 
+#include "SVFIR/SVFIR.h"
 #include "SVFIR/SVFVariables.h"
 #include "Util/Options.h"
 #include "Util/SVFUtil.h"

--- a/svf/lib/Util/Options.cpp
+++ b/svf/lib/Util/Options.cpp
@@ -4,19 +4,20 @@
 #include "Util/CommandLine.h"
 #include "FastCluster/fastcluster.h"
 #include "Util/ExtAPI.h"
+#include "MemoryModel/PTATY.h"
 #include "MSSA/MemSSA.h"
 #include "WPA/WPAPass.h"
 #include "AE/Svfexe/AbstractInterpretation.h"
 
 namespace SVF
 {
-const OptionMap<enum PTAStat::ClockType> Options::ClockType(
+const OptionMap<enum SVFStat::ClockType> Options::ClockType(
     "clock-type",
     "how time should be measured",
-    PTAStat::ClockType::CPU,
+    SVFStat::ClockType::CPU,
 {
-    {PTAStat::ClockType::Wall, "wall", "use wall time"},
-    {PTAStat::ClockType::CPU, "cpu", "use CPU time"},
+    {SVFStat::ClockType::Wall, "wall", "use wall time"},
+    {SVFStat::ClockType::CPU, "cpu", "use CPU time"},
 }
 );
 
@@ -44,13 +45,13 @@ const Option<u32_t> Options::MaxFieldLimit(
     512
 );
 
-const OptionMap<BVDataPTAImpl::PTBackingType> Options::ptDataBacking(
+const OptionMap<PTBackingType> Options::ptDataBacking(
     "ptd",
     "Overarching points-to data structure",
-    BVDataPTAImpl::PTBackingType::Persistent,
+    PTBackingType::Persistent,
 {
-    {BVDataPTAImpl::PTBackingType::Mutable, "mutable", "points-to set per pointer"},
-    {BVDataPTAImpl::PTBackingType::Persistent, "persistent", "points-to set ID per pointer, operations hash-consed"},
+    {PTBackingType::Mutable, "mutable", "points-to set per pointer"},
+    {PTBackingType::Persistent, "persistent", "points-to set ID per pointer, operations hash-consed"},
 }
 );
 
@@ -136,11 +137,11 @@ const Option<bool> Options::WPANum(
 
 /// register this into alias analysis group
 //static RegisterAnalysisGroup<AliasAnalysis> AA_GROUP(DDAPA);
-OptionMultiple<PointerAnalysis::PTATY> Options::DDASelected(
+OptionMultiple<PTATY> Options::DDASelected(
     "Select pointer analysis",
 {
-    {PointerAnalysis::FlowS_DDA, "dfs", "Demand-driven flow sensitive analysis"},
-    {PointerAnalysis::Cxt_DDA, "cxt", "Demand-driven context- flow- sensitive analysis"},
+    {PTATY::FlowS_DDA, "dfs", "Demand-driven flow sensitive analysis"},
+    {PTATY::Cxt_DDA, "cxt", "Demand-driven context- flow- sensitive analysis"},
 }
 );
 
@@ -677,18 +678,18 @@ const Option<bool> Options::PrintAliases(
     false
 );
 
-OptionMultiple<PointerAnalysis::PTATY> Options::PASelected(
+OptionMultiple<PTATY> Options::PASelected(
     "Select pointer analysis",
 {
-    {PointerAnalysis::Andersen_WPA, "nander", "Standard inclusion-based analysis"},
-    {PointerAnalysis::AndersenSCD_WPA, "sander", "Selective cycle detection inclusion-based analysis"},
-    {PointerAnalysis::AndersenSFR_WPA, "sfrander", "Stride-based field representation inclusion-based analysis"},
-    {PointerAnalysis::AndersenWaveDiff_WPA, "ander", "Diff wave propagation inclusion-based analysis"},
-    {PointerAnalysis::Steensgaard_WPA, "steens", "Steensgaard's pointer analysis"},
+    {PTATY::Andersen_WPA, "nander", "Standard inclusion-based analysis"},
+    {PTATY::AndersenSCD_WPA, "sander", "Selective cycle detection inclusion-based analysis"},
+    {PTATY::AndersenSFR_WPA, "sfrander", "Stride-based field representation inclusion-based analysis"},
+    {PTATY::AndersenWaveDiff_WPA, "ander", "Diff wave propagation inclusion-based analysis"},
+    {PTATY::Steensgaard_WPA, "steens", "Steensgaard's pointer analysis"},
     // Disabled till further work is done.
-    {PointerAnalysis::FSSPARSE_WPA, "fspta", "Sparse flow sensitive pointer analysis"},
-    {PointerAnalysis::VFS_WPA, "vfspta", "Versioned sparse flow-sensitive points-to analysis"},
-    {PointerAnalysis::TypeCPP_WPA, "type", "Type-based fast analysis for Callgraph, SVFIR and CHA"},
+    {PTATY::FSSPARSE_WPA, "fspta", "Sparse flow sensitive pointer analysis"},
+    {PTATY::VFS_WPA, "vfspta", "Versioned sparse flow-sensitive points-to analysis"},
+    {PTATY::TypeCPP_WPA, "type", "Type-based fast analysis for Callgraph, SVFIR and CHA"},
 }
 );
 
@@ -854,6 +855,12 @@ const Option<u32_t> Options::AEPrecision(
     "precision",
     "symbolic abstraction precision for float",
     0
+);
+
+const Option<u32_t> Options::MaxNodeLabelLength(
+    "max-node-label-length",
+    "maxmimum length of dumped graph node labels",
+    250
 );
 
 } // namespace SVF.

--- a/svf/lib/Util/PTAStat.cpp
+++ b/svf/lib/Util/PTAStat.cpp
@@ -30,6 +30,7 @@
 #include <iomanip>
 #include "Graphs/CallGraph.h"
 #include "Util/PTAStat.h"
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "SVFIR/SVFIR.h"
 
@@ -129,13 +130,13 @@ void PTAStat::callgraphStat()
     PTNumStatMap["TotalEdge"] = totalEdge;
     PTNumStatMap["CalRetPairInCycle"] = edgeInCycle;
 
-    if(pta->getAnalysisTy() >= PointerAnalysis::PTATY::Andersen_BASE && pta->getAnalysisTy() <= PointerAnalysis::PTATY::Steensgaard_WPA)
+    if(pta->getAnalysisTy() >= PTATY::Andersen_BASE && pta->getAnalysisTy() <= PTATY::Steensgaard_WPA)
         SVFStat::printStat("PTACallGraph Stats (Andersen analysis)");
-    else if(pta->getAnalysisTy() >= PointerAnalysis::PTATY::FSDATAFLOW_WPA && pta->getAnalysisTy() <= PointerAnalysis::PTATY::FSCS_WPA)
+    else if(pta->getAnalysisTy() >= PTATY::FSDATAFLOW_WPA && pta->getAnalysisTy() <= PTATY::FSCS_WPA)
         SVFStat::printStat("PTACallGraph Stats (Flow-sensitive analysis)");
-    else if(pta->getAnalysisTy() >= PointerAnalysis::PTATY::CFLFICI_WPA && pta->getAnalysisTy() <= PointerAnalysis::PTATY::CFLFSCS_WPA)
+    else if(pta->getAnalysisTy() >= PTATY::CFLFICI_WPA && pta->getAnalysisTy() <= PTATY::CFLFSCS_WPA)
         SVFStat::printStat("PTACallGraph Stats (CFL-R analysis)");
-    else if(pta->getAnalysisTy() >= PointerAnalysis::PTATY::FieldS_DDA && pta->getAnalysisTy() <= PointerAnalysis::PTATY::Cxt_DDA)
+    else if(pta->getAnalysisTy() >= PTATY::FieldS_DDA && pta->getAnalysisTy() <= PTATY::Cxt_DDA)
         SVFStat::printStat("PTACallGraph Stats (DDA analysis)");
     else
         SVFStat::printStat("PTACallGraph Stats");

--- a/svf/lib/Util/SVFStat.cpp
+++ b/svf/lib/Util/SVFStat.cpp
@@ -27,6 +27,9 @@
  *      Author: Xiao Cheng
  */
 
+#include <iomanip>
+
+#include "SVFIR/SVFIR.h"
 #include "Util/Options.h"
 #include "Util/SVFStat.h"
 #include "Graphs/CallGraph.h"

--- a/svf/lib/Util/SVFUtil.cpp
+++ b/svf/lib/Util/SVFUtil.cpp
@@ -27,10 +27,14 @@
  *      Author: Yulei Sui
  */
 
+#include <unistd.h>
+#include <signal.h>
+
 #include "Util/Options.h"
 #include "Util/SVFUtil.h"
 #include "MemoryModel/PointsTo.h"
 #include "Graphs/CallGraph.h"
+#include "SVFIR/SVFIR.h"
 #include "SVFIR/SVFVariables.h"
 
 #include <sys/resource.h>		/// increase stack size

--- a/svf/lib/WPA/VersionedFlowSensitive.cpp
+++ b/svf/lib/WPA/VersionedFlowSensitive.cpp
@@ -10,6 +10,7 @@
 #include "WPA/Andersen.h"
 #include "WPA/VersionedFlowSensitive.h"
 #include "Util/Options.h"
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointsTo.h"
 #include <iostream>
 #include <queue>

--- a/svf/lib/WPA/WPAPass.cpp
+++ b/svf/lib/WPA/WPAPass.cpp
@@ -34,6 +34,7 @@
 
 
 #include "Util/Options.h"
+#include "MemoryModel/PTATY.h"
 #include "MemoryModel/PointerAnalysisImpl.h"
 #include "WPA/WPAPass.h"
 #include "WPA/Andersen.h"
@@ -67,9 +68,9 @@ WPAPass::~WPAPass()
  */
 void WPAPass::runOnModule(SVFIR* pag)
 {
-    for (u32_t i = 0; i<= PointerAnalysis::Default_PTA; i++)
+    for (u32_t i = 0; i<= PTATY::Default_PTA; i++)
     {
-        PointerAnalysis::PTATY iPtaTy = static_cast<PointerAnalysis::PTATY>(i);
+        PTATY iPtaTy = static_cast<PTATY>(i);
         if (Options::PASelected(iPtaTy))
             runPointerAnalysis(pag, i);
     }
@@ -84,28 +85,28 @@ void WPAPass::runPointerAnalysis(SVFIR* pag, u32_t kind)
     /// Initialize pointer analysis.
     switch (kind)
     {
-    case PointerAnalysis::Andersen_WPA:
+    case PTATY::Andersen_WPA:
         _pta = new Andersen(pag);
         break;
-    case PointerAnalysis::AndersenSCD_WPA:
+    case PTATY::AndersenSCD_WPA:
         _pta = new AndersenSCD(pag);
         break;
-    case PointerAnalysis::AndersenSFR_WPA:
+    case PTATY::AndersenSFR_WPA:
         _pta = new AndersenSFR(pag);
         break;
-    case PointerAnalysis::AndersenWaveDiff_WPA:
+    case PTATY::AndersenWaveDiff_WPA:
         _pta = new AndersenWaveDiff(pag);
         break;
-    case PointerAnalysis::Steensgaard_WPA:
+    case PTATY::Steensgaard_WPA:
         _pta = new Steensgaard(pag);
         break;
-    case PointerAnalysis::FSSPARSE_WPA:
+    case PTATY::FSSPARSE_WPA:
         _pta = new FlowSensitive(pag);
         break;
-    case PointerAnalysis::VFS_WPA:
+    case PTATY::VFS_WPA:
         _pta = new VersionedFlowSensitive(pag);
         break;
-    case PointerAnalysis::TypeCPP_WPA:
+    case PTATY::TypeCPP_WPA:
         _pta = new TypeAnalysis(pag);
         break;
     default:
@@ -121,7 +122,7 @@ void WPAPass::runPointerAnalysis(SVFIR* pag, u32_t kind)
         assert(SVFUtil::isa<AndersenBase>(_pta) && "supports only andersen/steensgaard for pre-computed SVFG");
         SVFG *svfg = memSSA.buildFullSVFG((BVDataPTAImpl*)_pta);
         /// support mod-ref queries only for -ander
-        if (Options::PASelected(PointerAnalysis::AndersenWaveDiff_WPA))
+        if (Options::PASelected(PTATY::AndersenWaveDiff_WPA))
             _svfg = svfg;
     }
 
@@ -165,7 +166,7 @@ const PointsTo& WPAPass::getPts(NodeID var)
  */
 ModRefInfo WPAPass::getModRefInfo(const CallICFGNode* callInst)
 {
-    assert(Options::PASelected(PointerAnalysis::AndersenWaveDiff_WPA) && Options::AnderSVFG() && "mod-ref query is only support with -ander and -svfg turned on");
+    assert(Options::PASelected(PTATY::AndersenWaveDiff_WPA) && Options::AnderSVFG() && "mod-ref query is only support with -ander and -svfg turned on");
     return _svfg->getMSSA()->getMRGenerator()->getModRefInfo(callInst);
 }
 
@@ -175,6 +176,6 @@ ModRefInfo WPAPass::getModRefInfo(const CallICFGNode* callInst)
  */
 ModRefInfo WPAPass::getModRefInfo(const CallICFGNode* callInst1, const CallICFGNode* callInst2)
 {
-    assert(Options::PASelected(PointerAnalysis::AndersenWaveDiff_WPA) && Options::AnderSVFG() && "mod-ref query is only support with -ander and -svfg turned on");
+    assert(Options::PASelected(PTATY::AndersenWaveDiff_WPA) && Options::AnderSVFG() && "mod-ref query is only support with -ander and -svfg turned on");
     return _svfg->getMSSA()->getMRGenerator()->getModRefInfo(callInst1, callInst2);
 }


### PR DESCRIPTION
PTATY out of PointerAnalysis avoids a circular dependency for GraphWriter.h to use Options.h. This, I think, is also better, that places like Options.h have as few dependencies as possible. It also unraveled a lot of dependencies being included transitively (hence the size of this PR). Overall, it would be good to spend some time looking at dependencies etc.