### PR TITLE
[codex] Pin macOS SVF publish to Z3 4.16.0

### DIFF
--- a/.github/workflows/svf-lib_publish.yml
+++ b/.github/workflows/svf-lib_publish.yml
@@ -14,6 +14,7 @@ env:
   SVF_CTIR: 1
   SVF_Z3: 1
   SVF_DIR: $GITHUB_WORKSPACE
+  MACOS_Z3_VERSION: '4.16.0'
 
 jobs:
   publish:
@@ -21,10 +22,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: npm-publish
     env:
-      XCODE_VERSION: '15.3.0'  # Define Xcode version here to reuse it
+      XCODE_VERSION: '16.0.0'  # Define Xcode version here to reuse it
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14, ubuntu-24.04-arm]
+        os: [ubuntu-24.04, macos-15, ubuntu-24.04-arm]
 
     steps:
       # checkout the repo

--- a/build.sh
+++ b/build.sh
@@ -260,6 +260,14 @@ if [[ ! -d "$Z3_DIR" ]]; then
 		      echo "z3 binary installation failed."
 		      exit 1
 	        fi
+            if [[ -n "$MACOS_Z3_VERSION" ]]; then
+                installedZ3Version=$(brew list --versions z3 | awk '{print $2}' | head -n 1)
+                if [[ "$installedZ3Version" != "$MACOS_Z3_VERSION" ]]; then
+                    echo "Expected Homebrew z3 $MACOS_Z3_VERSION on macOS, but found $installedZ3Version."
+                    exit 1
+                fi
+                echo "Verified Homebrew z3 version $installedZ3Version."
+            fi
             mkdir -p $SVFHOME/$Z3Home
             ln -s $(brew --prefix z3)/* $SVFHOME/$Z3Home
         else


### PR DESCRIPTION
## Summary

- move the SVF npm macOS publish job from `macos-14` to `macos-15`
- update the publish job Xcode selection to `16.0.0`, which is available on the macOS 15 runner
- require Homebrew `z3` to be exactly `4.16.0` during macOS SVF publish builds

## Why

The current macOS SVF npm artifact can be built on `macos-14` with Homebrew Z3 `4.15.4`, which records `/opt/homebrew/opt/z3/lib/libz3.4.15.dylib` in the produced dylibs. Consumers running on `macos-15` currently install/use Z3 `4.16.0`, so those dylibs fail to load because `libz3.4.15.dylib` is not present.

Pinning the macOS publish job to `macos-15` and checking for Z3 `4.16.0` prevents the npm macOS artifacts from silently drifting to a different Z3 dylib version.

## Validation

- `bash -n build.sh`
- `git diff --check`
- local sanity check: `brew list --versions z3` reports `z3 4.16.0`
