### PR TITLE
Process rep nodes when collapsing an SCC

### DIFF
--- a/svf/lib/WPA/Andersen.cpp
+++ b/svf/lib/WPA/Andersen.cpp
@@ -722,6 +722,10 @@ void Andersen::mergeSccCycle()
         const NodeBS& subNodes = getSCCDetector()->subNodes(repNodeId);
         // merge sub nodes to rep node
         mergeSccNodes(repNodeId, subNodes);
+        if (subNodes.count() > 1) {
+            pushIntoWorklist(repNodeId);
+            reanalyze = true;
+        }
     }
 }
 


### PR DESCRIPTION
When collapsing any cycle, we need to potentially handle stores/loads (postProcessNode) and copies/geps (processNode) if the points-to set has changed or if the rep node gets new edges. I originally thought not so for the latter but SCC detection can happen before all nodes in the SCC get the same points-to set.

Adding to worklist/reanalyzing conditionally upon those two conditions requires a lot of refactoring I believe. I've instead added the rep node unconditionally whenever an SCC is collapsed.