### PR TITLE
Fix MTA wiki link

### DIFF
--- a/svf/lib/MTA/README.md
+++ b/svf/lib/MTA/README.md
@@ -1,6 +1,6 @@
 # MTA and MSli
 
 This directory contains SVF's multithreaded analysis (MTA) and the MSli
-multi-stage slicing implementation. See the [MTA-MSli wiki page](https://github.com/SVF-tools/SVF/wiki/MTA-‐-MSli)
+multi-stage slicing implementation. See the [MTA-MSli wiki page](https://github.com/SVF-tools/SVF/wiki/MTA-MSli)
 for build instructions, command examples, and measured small- and large-program
 results.


### PR DESCRIPTION
Update the MTA README to use the ASCII `MTA-MSli` wiki URL.