### PR TITLE
Update MSli documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 SVF provides reusable abstractions, graphs, and solvers for analyzing LLVM IR.
 
 ## News
-* <b>[MSli](https://github.com/SVF-tools/SVF/wiki/MTA-MSli), an on-demand program slicing tool for multithreaded programs, is now available in [SVF/MTA](https://github.com/SVF-tools/SVF/tree/master/svf/lib/MTA). </b>
+* <b>[MSli](https://github.com/SVF-tools/SVF/wiki/MTA-MSli), an on-demand program slicing tool for multithreaded programs, is now available in [SVF/MTA](https://github.com/SVF-tools/SVF/tree/master/svf/include/MTA). </b>
 * <b>SVF now supports [LLVM-22](https://github.com/SVF-tools/SVF/pull/1876) (Contributed by [Giorgio](https://github.com/dg1474)). </b>
 * <b>SVF now supports [LLVM-21](https://github.com/SVF-tools/SVF/pull/1815) (Contributed by [cjsrxzdyzds](https://github.com/cjsrxzdyzds)). </b>
 * <b>SVF now supports new [build system](https://github.com/SVF-tools/SVF/pull/1703) (Thank [Johannes](https://github.com/Johanmyst) for his help!). </b>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 SVF provides reusable abstractions, graphs, and solvers for analyzing LLVM IR.
 
 ## News
-* <b>[On-demand program slicing](https://github.com/SVF-tools/SVF/tree/master/svf/include/MTA) published in our [ISSTA paper](https://joelyyoung.github.io/pdf/issta26.pdf) is now available in SVF </b>
+* <b>[MSli](https://github.com/SVF-tools/SVF/wiki/MTA-MSli), an on-demand program slicing tool for multithreaded programs, is now available in [SVF/MTA](https://github.com/SVF-tools/SVF/tree/master/svf/lib/MTA). </b>
 * <b>SVF now supports [LLVM-22](https://github.com/SVF-tools/SVF/pull/1876) (Contributed by [Giorgio](https://github.com/dg1474)). </b>
 * <b>SVF now supports [LLVM-21](https://github.com/SVF-tools/SVF/pull/1815) (Contributed by [cjsrxzdyzds](https://github.com/cjsrxzdyzds)). </b>
 * <b>SVF now supports new [build system](https://github.com/SVF-tools/SVF/pull/1703) (Thank [Johannes](https://github.com/Johanmyst) for his help!). </b>

--- a/svf/include/MTA/README.md
+++ b/svf/include/MTA/README.md
@@ -1,0 +1,6 @@
+# MTA and MSli
+
+This directory contains the public interfaces for SVF's multithreaded analysis
+(MTA) and the MSli multi-stage slicing implementation. See the [MTA-MSli wiki
+page](https://github.com/SVF-tools/SVF/wiki/MTA-MSli) for an overview, benchmark
+inputs, build instructions, and usage examples.

--- a/svf/lib/MTA/README.md
+++ b/svf/lib/MTA/README.md
@@ -1,5 +1,0 @@
-# MTA and MSli
-
-This directory contains SVF's multithreaded analysis (MTA) and the MSli
-multi-stage slicing implementation. See the [MTA-MSli wiki page](https://github.com/SVF-tools/SVF/wiki/MTA-MSli)
-for an overview, benchmark inputs, build instructions, and usage examples.

--- a/svf/lib/MTA/README.md
+++ b/svf/lib/MTA/README.md
@@ -2,5 +2,4 @@
 
 This directory contains SVF's multithreaded analysis (MTA) and the MSli
 multi-stage slicing implementation. See the [MTA-MSli wiki page](https://github.com/SVF-tools/SVF/wiki/MTA-MSli)
-for build instructions, command examples, and measured small- and large-program
-results.
+for an overview, benchmark inputs, build instructions, and usage examples.


### PR DESCRIPTION
- Link the MSli news entry to the wiki and MTA headers.
- Move the MTA README to `svf/include/MTA`.